### PR TITLE
Add ConnectionName attribute to AWSVXCOrderBEndPartnerConfig

### DIFF
--- a/types/vxc_order.go
+++ b/types/vxc_order.go
@@ -99,6 +99,7 @@ type AWSVXCOrderBEndPartnerConfig struct {
 	Prefixes          string `json:"prefixes,omitempty"`
 	CustomerIPAddress string `json:"customerIpAddress,omitempty"`
 	AmazonIPAddress   string `json:"amazonIpAddress,omitempty"`
+	ConnectionName    string `json:"name,omitempty"`
 }
 
 // Partner


### PR DESCRIPTION
## Description

Add ConnectionName attribute to AWSVXCOrderBEndPartnerConfig.

Required to support new feature for megaport/terraform-provider-megaport#17

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Contributor Agreement

I have read and accept the CLA