### PR TITLE
Add ExtractAWSPartnerConfig function and invoke in MarshallPartnerConfig

### DIFF
--- a/service/vxc/aws.go
+++ b/service/vxc/aws.go
@@ -76,3 +76,19 @@ func (v *VXC) ExtractAwsId(vxcDetails types.VXC) string {
 
 	return ""
 }
+
+// Extract AWS CSP details from VXC CspConnection
+func (v *VXC) ExtractAWSPartnerConfig(vxcDetails types.VXC) (*types.AWSVXCOrderBEndPartnerConfig, error) {
+
+	cspConnection := v.GetCspConnection("resource_name", "b_csp_connection", vxcDetails)
+
+	if cspConnection != nil {
+		partnerConfigInterface, err := v.MarshallPartnerConfig("", PARTNER_AWS, cspConnection)
+		if err != nil {
+			return nil, err
+		}
+		partnerConfig := partnerConfigInterface.(types.AWSVXCOrderBEndPartnerConfig)
+		return &partnerConfig, nil
+	}
+	return nil, nil
+}

--- a/service/vxc/partner.go
+++ b/service/vxc/partner.go
@@ -26,6 +26,7 @@ import (
 
 const PARTNER_AZURE string = "AZURE"
 const PARTNER_GOOGLE string = "GOOGLE"
+const PARTNER_AWS string = "AWS"
 const PEERING_AZURE_PRIVATE string = "private"
 const PEERING_AZURE_PUBLIC string = "public"
 const PEERING_AZURE_MICROSOFT string = "microsoft"
@@ -179,6 +180,17 @@ func (v *VXC) MarshallPartnerConfig(
 			ConnectType: partner,
 			PairingKey:  key,
 		}
+	} else if partner == PARTNER_AWS {
+		// Marshal/unmarshal via JSON so we can reuse struct field mappings
+		partnerConfigJson, err := json.Marshal(attributes)
+		if err != nil {
+			return nil, err
+		}
+		newPartnerConfig := types.AWSVXCOrderBEndPartnerConfig{}
+		if err := json.Unmarshal(partnerConfigJson, &newPartnerConfig); err != nil {
+			return nil, err
+		}
+		partnerConfig = newPartnerConfig
 	} else {
 		return "", errors.New(mega_err.ERR_INVALID_PARTNER)
 	}

--- a/types/vxc_order.go
+++ b/types/vxc_order.go
@@ -99,6 +99,7 @@ type AWSVXCOrderBEndPartnerConfig struct {
 	Prefixes          string `json:"prefixes,omitempty"`
 	CustomerIPAddress string `json:"customerIpAddress,omitempty"`
 	AmazonIPAddress   string `json:"amazonIpAddress,omitempty"`
+	ConnectionName    string `json:"name,omitempty"`
 }
 
 // Partner


### PR DESCRIPTION
## Description

Add ExtractAWSPartnerConfig function and invoke in MarshallPartnerConfig
Add ConnectionName attribute to AWSVXCOrderBEndPartnerConfig (supersedes megaport/megaportgo/pull/4)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Contributor Agreement

I have read and accept the CLA