### PR TITLE
Integration test fixups

### DIFF
--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	TEST_LOCATION_A = "Interactive 437 Williamstown"
+	TEST_LOCATION_ID_A = 100 // US West (Oregon) (us-west-2) [DZ-RED]
 	MEGAPORTURL     = "https://api-staging.megaport.com/"
 )
 
@@ -83,7 +83,12 @@ func TestSinglePort(t *testing.T) {
 	port := New(&cfg)
 	loc := location.New(&cfg)
 
-	testLocation, _ := loc.GetLocationByName(TEST_LOCATION_A)
+	testLocation, err := loc.GetLocationByID(TEST_LOCATION_ID_A)
+
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation.ID)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
@@ -104,7 +109,12 @@ func TestLAGPort(t *testing.T) {
 	port := New(&cfg)
 	loc := location.New(&cfg)
 
-	testLocation, _ := loc.GetLocationByName(TEST_LOCATION_A)
+	testLocation, err := loc.GetLocationByID(TEST_LOCATION_ID_A)
+
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation.ID)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
@@ -123,9 +133,9 @@ func testCreatePort(port *Port, portType string, locationId int) (string, error)
 
 	logger.Debug("Buying Port:", portType)
 	if portType == types.LAG_PORT {
-		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, locationId, "AU", 4, true)
+		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, locationId, "US", 4, true)
 	} else {
-		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, locationId, "AU", true)
+		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, locationId, "US", true)
 	}
 
 	logger.Debugf("Port Purchased: %s", portId)

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -89,7 +89,7 @@ func TestSinglePort(t *testing.T) {
 		t.FailNow()
 	}
 
-	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation.ID)
+	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
 		cfg.PurchaseError(portId, portErr)
@@ -115,7 +115,7 @@ func TestLAGPort(t *testing.T) {
 		t.FailNow()
 	}
 
-	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation.ID)
+	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
 		cfg.PurchaseError(portId, portErr)
@@ -127,15 +127,15 @@ func TestLAGPort(t *testing.T) {
 	testCancelPort(port, portId, types.LAG_PORT, t)
 }
 
-func testCreatePort(port *Port, portType string, locationId int) (string, error) {
+func testCreatePort(port *Port, portType string, location types.Location) (string, error) {
 	var portId string
 	var portErr error
 
 	logger.Debug("Buying Port:", portType)
 	if portType == types.LAG_PORT {
-		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, locationId, "US", 4, true)
+		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, location.ID, location.Market, 4, true)
 	} else {
-		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, locationId, "US", true)
+		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, location.ID, location.Market, true)
 	}
 
 	logger.Debugf("Port Purchased: %s", portId)

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -96,7 +96,12 @@ func TestSinglePort(t *testing.T) {
 		t.FailNow()
 	}
 
-	port.WaitForPortProvisioning(portId)
+	portCreated, err := port.WaitForPortProvisioning(portId)
+
+	if !assert.NoError(t, err) || !portCreated {
+		t.FailNow()
+	}
+
 	testModifyPort(port, portId, types.SINGLE_PORT, t)
 	testLockPort(port, portId, t)
 	testCancelPort(port, portId, types.SINGLE_PORT, t)
@@ -122,7 +127,12 @@ func TestLAGPort(t *testing.T) {
 		t.FailNow()
 	}
 
-	port.WaitForPortProvisioning(portId)
+	portCreated, err := port.WaitForPortProvisioning(portId)
+
+	if !assert.NoError(t, err) || !portCreated {
+		t.FailNow()
+	}
+
 	testModifyPort(port, portId, types.LAG_PORT, t)
 	testCancelPort(port, portId, types.LAG_PORT, t)
 }


### PR DESCRIPTION
## Description

Fixups for port integration tests.

These commits rearrange the tests a bit in prep for a follow on commit which adds `GetPorts()` functionality (which I need to support similar functionality in the downstream terraform module).  The tracking issue for GetPorts is #8.

## Type of change

Please delete options that are not relevant.

- [x] Testing improvement

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[x] [I have indeed read and do accept the CLA]