### PR TITLE
Add get ports function

### DIFF
--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -155,6 +155,11 @@ func TestLAGPort(t *testing.T) {
 		t.FailNow()
 	}
 
+	portsListInitial, err := port.GetPorts()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
@@ -165,6 +170,36 @@ func TestLAGPort(t *testing.T) {
 	portCreated, err := port.WaitForPortProvisioning(portId)
 
 	if !assert.NoError(t, err) || !portCreated {
+		t.FailNow()
+	}
+
+	portsListPostCreate, err := port.GetPorts()
+	if err != nil {
+		logger.Debug("Failed to get ports list: ", err.Error())
+		t.FailNow()
+	}
+
+	portIsActuallyNew := true
+	for _, p := range portsListInitial {
+		if p.UID == portId {
+			portIsActuallyNew = false
+		}
+	}
+
+	if !portIsActuallyNew {
+		logger.Debug("Failed to find port we just created in ports list: ", portId)
+		t.FailNow()
+	}
+
+	foundNewPort := false
+	for _, p := range portsListPostCreate {
+		if p.UID == portId {
+			foundNewPort = true
+		}
+	}
+
+	if !foundNewPort {
+		logger.Debug("Failed to find port we just created in ports list: ", portId)
 		t.FailNow()
 	}
 

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -89,6 +89,11 @@ func TestSinglePort(t *testing.T) {
 		t.FailNow()
 	}
 
+	portsListInitial, err := port.GetPorts()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
@@ -99,6 +104,36 @@ func TestSinglePort(t *testing.T) {
 	portCreated, err := port.WaitForPortProvisioning(portId)
 
 	if !assert.NoError(t, err) || !portCreated {
+		t.FailNow()
+	}
+
+	portsListPostCreate, err := port.GetPorts()
+	if err != nil {
+		logger.Debug("Failed to get ports list: ", err.Error())
+		t.FailNow()
+	}
+
+	portIsActuallyNew := true
+	for _, p := range portsListInitial {
+		if p.UID == portId {
+			portIsActuallyNew = false
+		}
+	}
+
+	if !portIsActuallyNew {
+		logger.Debug("Failed to find port we just created in ports list: ", portId)
+		t.FailNow()
+	}
+
+	foundNewPort := false
+	for _, p := range portsListPostCreate {
+		if p.UID == portId {
+			foundNewPort = true
+		}
+	}
+
+	if !foundNewPort {
+		logger.Debug("Failed to find port we just created in ports list: ", portId)
 		t.FailNow()
 	}
 

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	TEST_LOCATION_A = "Interactive 437 Williamstown"
+	TEST_LOCATION_ID_A = 100 // US West (Oregon) (us-west-2) [DZ-RED]
 	MEGAPORTURL     = "https://api-staging.megaport.com/"
 )
 
@@ -83,7 +83,12 @@ func TestSinglePort(t *testing.T) {
 	port := New(&cfg)
 	loc := location.New(&cfg)
 
-	testLocation, _ := loc.GetLocationByName(TEST_LOCATION_A)
+	testLocation, err := loc.GetLocationByID(TEST_LOCATION_ID_A)
+
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation.ID)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
@@ -104,7 +109,12 @@ func TestLAGPort(t *testing.T) {
 	port := New(&cfg)
 	loc := location.New(&cfg)
 
-	testLocation, _ := loc.GetLocationByName(TEST_LOCATION_A)
+	testLocation, err := loc.GetLocationByID(TEST_LOCATION_ID_A)
+
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation.ID)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
@@ -123,9 +133,9 @@ func testCreatePort(port *Port, portType string, locationId int) (string, error)
 
 	logger.Debug("Buying Port:", portType)
 	if portType == types.LAG_PORT {
-		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, locationId, "AU", 4, true)
+		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, locationId, "US", 4, true)
 	} else {
-		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, locationId, "AU", true)
+		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, locationId, "US", true)
 	}
 
 	logger.Debugf("Port Purchased: %s", portId)

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -89,7 +89,7 @@ func TestSinglePort(t *testing.T) {
 		t.FailNow()
 	}
 
-	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation.ID)
+	portId, portErr := testCreatePort(port, types.SINGLE_PORT, testLocation)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
 		cfg.PurchaseError(portId, portErr)
@@ -115,7 +115,7 @@ func TestLAGPort(t *testing.T) {
 		t.FailNow()
 	}
 
-	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation.ID)
+	portId, portErr := testCreatePort(port, types.LAG_PORT, testLocation)
 
 	if !assert.NoError(t, portErr) && !assert.True(t, shared.IsGuid(portId)) {
 		cfg.PurchaseError(portId, portErr)
@@ -127,15 +127,15 @@ func TestLAGPort(t *testing.T) {
 	testCancelPort(port, portId, types.LAG_PORT, t)
 }
 
-func testCreatePort(port *Port, portType string, locationId int) (string, error) {
+func testCreatePort(port *Port, portType string, location types.Location) (string, error) {
 	var portId string
 	var portErr error
 
 	logger.Debug("Buying Port:", portType)
 	if portType == types.LAG_PORT {
-		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, locationId, "US", 4, true)
+		portId, portErr = port.BuyLAGPort("Buy Port (LAG) Test", 1, 10000, location.ID, location.Market, 4, true)
 	} else {
-		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, locationId, "US", true)
+		portId, portErr = port.BuySinglePort("Buy Port (Single) Test", 1, 10000, location.ID, location.Market, true)
 	}
 
 	logger.Debugf("Port Purchased: %s", portId)

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -96,7 +96,12 @@ func TestSinglePort(t *testing.T) {
 		t.FailNow()
 	}
 
-	port.WaitForPortProvisioning(portId)
+	portCreated, err := port.WaitForPortProvisioning(portId)
+
+	if !assert.NoError(t, err) || !portCreated {
+		t.FailNow()
+	}
+
 	testModifyPort(port, portId, types.SINGLE_PORT, t)
 	testLockPort(port, portId, t)
 	testCancelPort(port, portId, types.SINGLE_PORT, t)
@@ -122,7 +127,12 @@ func TestLAGPort(t *testing.T) {
 		t.FailNow()
 	}
 
-	port.WaitForPortProvisioning(portId)
+	portCreated, err := port.WaitForPortProvisioning(portId)
+
+	if !assert.NoError(t, err) || !portCreated {
+		t.FailNow()
+	}
+
 	testModifyPort(port, portId, types.LAG_PORT, t)
 	testCancelPort(port, portId, types.LAG_PORT, t)
 }


### PR DESCRIPTION
## Description

Adds the `GetPorts` function as per #8

I think this is best merged after #9 and for that reason I have left this as draft for now.  Will rebase onto main if / when #9 is merged if you like.

I broke this patch series into two PRs because the commits which are exclusively included in #8 really have nothing to do with getting the ports list.

Fixes #8

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

[x] [I have read and do indeed accept the CLA]
