### PR TITLE
Add support for Port Diversity

### DIFF
--- a/mega_err/errors.go
+++ b/mega_err/errors.go
@@ -36,3 +36,4 @@ const ERR_PARSING_ERR_RESPONSE = "status code '%v' received from api and there h
 const ERR_PARTNER_PORT_NO_RESULTS = "sorry there were no results returned based on the given filters"
 const ERR_SESSION_TOKEN_STILL_EXIST = "it looks like the session was not removed and still exists, logout did not work"
 const ERR_MEGAPORT_URL_NOT_SET = "The variable megaport_url has not been set correctly"
+const ERR_ZONE_NOT_VALID = "invalid zone, valid values are red, blue, or any"

--- a/service/port/port.go
+++ b/service/port/port.go
@@ -45,8 +45,8 @@ func New(cfg *config.Config) *Port {
 	}
 }
 
-// BuyPort orders a Port.
-func (p *Port) BuyPort(name string, term int, portSpeed int, locationId int, market string, isLAG bool, lagCount int, isPrivate bool, diversityZone string) (string, error) {
+// buyPort orders a Port.
+func (p *Port) buyPort(name string, term int, portSpeed int, locationId int, market string, isLAG bool, lagCount int, isPrivate bool, diversityZone string) (string, error) {
 	var buyOrder []types.PortOrder
 	var portConfig types.PortOrderConfig
 
@@ -115,24 +115,29 @@ func (p *Port) BuyPort(name string, term int, portSpeed int, locationId int, mar
 	return orderInfo.Data[0].TechnicalServiceUID, nil
 }
 
-// BuySinglePort orders a single Port. Same as BuyPort, with isLag set to false and Diversity Zone set to any.
+// BuyPort orders a Port or LAG with unspecified zone. Used for compatability with older versions of megaportgo.
+func (p *Port) BuyPort(name string, term int, portSpeed int, locationId int, market string, isLAG bool, lagCount int, isPrivate bool) (string, error) {
+	return p.buyPort(name, term, portSpeed, locationId, market, isLAG, lagCount, isPrivate, "any")
+}
+
+// BuySinglePort orders a single Port with unspecified zone.
 func (p *Port) BuySinglePort(name string, term int, portSpeed int, locationId int, market string, isPrivate bool) (string, error) {
-	return p.BuyPort(name, term, portSpeed, locationId, market, false, 0, isPrivate, "any")
+	return p.buyPort(name, term, portSpeed, locationId, market, false, 0, isPrivate, "any")
 }
 
-// BuyZonedSinglePort orders a single Port. Same as BuyPort, with isLag set to false and Diversity Zone required.
+// BuyZonedSinglePort orders a single Port in the requested zone.
 func (p *Port) BuyZonedSinglePort(name string, term int, portSpeed int, locationId int, market string, isPrivate bool, diversityZone string) (string, error) {
-	return p.BuyPort(name, term, portSpeed, locationId, market, false, 0, isPrivate, diversityZone)
+	return p.buyPort(name, term, portSpeed, locationId, market, false, 0, isPrivate, diversityZone)
 }
 
-// BuyLAGPort orders a LAG Port. Same as BuyPort, with isLag set to true and Diversity Zone set to any.
+// BuyLAGPort orders a LAG Port/s with unspecified zone.
 func (p *Port) BuyLAGPort(name string, term int, portSpeed int, locationId int, market string, lagCount int, isPrivate bool) (string, error) {
-	return p.BuyPort(name, term, portSpeed, locationId, market, true, lagCount, isPrivate, "any")
+	return p.buyPort(name, term, portSpeed, locationId, market, true, lagCount, isPrivate, "any")
 }
 
-// BuyZonedLAGPort orders a LAG Port. Same as BuyPort, with isLag set to true and Diversity Zone required.
+// BuyZonedLAGPort orders a LAG Port/s in the requested zone.
 func (p *Port) BuyZonedLAGPort(name string, term int, portSpeed int, locationId int, market string, lagCount int, isPrivate bool, diversityZone string) (string, error) {
-	return p.BuyPort(name, term, portSpeed, locationId, market, true, lagCount, isPrivate, diversityZone)
+	return p.buyPort(name, term, portSpeed, locationId, market, true, lagCount, isPrivate, diversityZone)
 }
 
 func (p *Port) GetPortDetails(id string) (types.Port, error) {

--- a/types/port.go
+++ b/types/port.go
@@ -15,16 +15,21 @@
 package types
 
 type PortOrder struct {
-	Name                  string `json:"productName"`
-	Term                  int    `json:"term"`
-	ProductType           string `json:"productType"`
-	PortSpeed             int    `json:"portSpeed"`
-	LocationID            int    `json:"locationId"`
-	CreateDate            int64  `json:"createDate"`
-	Virtual               bool   `json:"virtual"`
-	Market                string `json:"market"`
-	LagPortCount          int    `json:"lagPortCount,omitempty"`
-	MarketplaceVisibility bool   `json:"marketplaceVisibility"`
+	Name                  string          `json:"productName"`
+	Term                  int             `json:"term"`
+	ProductType           string          `json:"productType"`
+	PortSpeed             int             `json:"portSpeed"`
+	LocationID            int             `json:"locationId"`
+	CreateDate            int64           `json:"createDate"`
+	Virtual               bool            `json:"virtual"`
+	Market                string          `json:"market"`
+	LagPortCount          int             `json:"lagPortCount,omitempty"`
+	MarketplaceVisibility bool            `json:"marketplaceVisibility"`
+	Config                PortOrderConfig `json:"config,omitempty"`
+}
+
+type PortOrderConfig struct {
+	DiversityZone string `json:"diversityZone,omitempty"`
 }
 
 type PortOrderConfirmation struct {
@@ -64,6 +69,7 @@ type Port struct {
 	AdminLocked           bool                   `json:"adminLocked"`
 	Cancelable            bool                   `json:"cancelable"`
 	VXCResources          PortResources          `json:"resources"`
+	DiversityZone         string                 `json:"diversityZone"`
 }
 
 type PortResources struct {


### PR DESCRIPTION
## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Add ability to specify diversity zone when ordering a Port or LAG.
This functionality is provided by methods BuyZonedSinglePort and BuyZonedLAGPort of Port type.
Existing BuyPort, BuySinglePort, and BuyLAGPort methods work as before.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
