### PR TITLE
fix: corrects field types in Peer struct

### DIFF
--- a/vxc_types.go
+++ b/vxc_types.go
@@ -127,12 +127,12 @@ type PartnerLookupItem struct {
 
 // Peer represents a VXC Peer.
 type Peer struct {
-	PeerASN         string `json:"peer_asn"`
+	PeerASN         int    `json:"peer_asn"`
 	Prefixes        string `json:"prefixes"`
 	PrimarySubnet   string `json:"primary_subnet"`
 	SecondarySubnet string `json:"secondary_subnet"`
 	Type            string `json:"type"`
-	VLAN            string `json:"vlan"`
+	VLAN            int    `json:"vlan"`
 	SharedKey       string `json:"shared_key"`
 }
 


### PR DESCRIPTION
## Description

This fixes and issue where some fields in the `Peer` struct had a different type than the API causing a failure to marshal, this is technically a breaking change but because it was broken before, this should be fine.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
