### PR TITLE
fix: support aEndInnerVlan field in update VXC calls

### DIFF
--- a/vxc.go
+++ b/vxc.go
@@ -83,6 +83,8 @@ type UpdateVXCRequest struct {
 	Term           *int
 	Shutdown       *bool
 
+	AEndInnerVLAN *int
+
 	WaitForUpdate bool          // Wait until the VXC updates before returning
 	WaitForTime   time.Duration // How long to wait for the VXC to update if WaitForUpdate is true (default is 5 minutes)
 }
@@ -250,6 +252,9 @@ func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVX
 	}
 	if req.CostCentre != nil {
 		update.CostCentre = *req.CostCentre
+	}
+	if req.AEndInnerVLAN != nil {
+		update.AEndInnerVLAN = req.AEndInnerVLAN
 	}
 
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPut, url, update)

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -144,6 +144,8 @@ type VXCUpdate struct {
 	Shutdown       *bool  `json:"shutdown,omitempty"`
 	AEndVLAN       *int   `json:"aEndVlan,omitempty"`
 	BEndVLAN       *int   `json:"bEndVlan,omitempty"`
+	AEndInnerVLAN  *int   `json:"aEndInnerVlan,omitempty"`
+	BEndInnerVLAN  *int   `json:"bEndInnerVlan,omitempty"`
 	AEndProductUID string `json:"aEndProductUid,omitempty"`
 	BEndProductUID string `json:"bEndProductUid,omitempty"`
 	Term           *int   `json:"term,omitempty"`

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -145,7 +145,6 @@ type VXCUpdate struct {
 	AEndVLAN       *int   `json:"aEndVlan,omitempty"`
 	BEndVLAN       *int   `json:"bEndVlan,omitempty"`
 	AEndInnerVLAN  *int   `json:"aEndInnerVlan,omitempty"`
-	BEndInnerVLAN  *int   `json:"bEndInnerVlan,omitempty"`
 	AEndProductUID string `json:"aEndProductUid,omitempty"`
 	BEndProductUID string `json:"bEndProductUid,omitempty"`
 	Term           *int   `json:"term,omitempty"`


### PR DESCRIPTION
## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
