### PR TITLE
fix: change aend partner config to vrouter config as it can be used on both ends, add support for as_path_prepend_count in bgp config

### DIFF
--- a/vxc_integration_test.go
+++ b/vxc_integration_test.go
@@ -496,7 +496,7 @@ func (suite *VXCIntegrationTestSuite) TestAWSHostedConnectionBuy() {
 		Shutdown:  false,
 		AEndConfiguration: VXCOrderEndpointConfiguration{
 			VLAN: GenerateRandomVLAN(),
-			PartnerConfig: VXCOrderAEndPartnerConfig{
+			PartnerConfig: VXCOrderVrouterPartnerConfig{
 				Interfaces: []PartnerConfigInterface{
 					{
 						IpAddresses: []string{"10.0.0.1/30"},

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -251,6 +251,13 @@ type VXCOrderVrouterPartnerConfig struct {
 	Interfaces []PartnerConfigInterface `json:"interfaces,omitempty"`
 }
 
+// DEPRECATED - Use VXCOrderVrouterPartnerConfig instead
+// VXCOrderAEndPartnerConfig represents the configuration of a VXC A-End partner.
+type VXCOrderAEndPartnerConfig struct {
+	VXCPartnerConfiguration
+	Interfaces []PartnerConfigInterface `json:"interfaces,omitempty"`
+}
+
 // VXCOrderConfirmation represents the confirmation of a VXC order from the Megaport Products API.
 type VXCOrderConfirmation struct {
 	TechnicalServiceUID string `json:"vxcJTechnicalServiceUid"`

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -245,8 +245,8 @@ type VXCOrderMVEConfig struct {
 	NetworkInterfaceIndex int `json:"vNicIndex"`
 }
 
-// VXCOrderAEndPartnerConfig represents the configuration of a VXC A-End partner.
-type VXCOrderAEndPartnerConfig struct {
+// VXCOrderVrouterPartnerConfig represents the configuration of a VXC Vrouter Configuration partner.
+type VXCOrderVrouterPartnerConfig struct {
 	VXCPartnerConfiguration
 	Interfaces []PartnerConfigInterface `json:"interfaces,omitempty"`
 }
@@ -283,22 +283,23 @@ type BfdConfig struct {
 
 // BgpConnectionConfig represents the configuration of a BGP connection.
 type BgpConnectionConfig struct {
-	PeerAsn         int      `json:"peerAsn"`
-	LocalIpAddress  string   `json:"localIpAddress"`
-	PeerIpAddress   string   `json:"peerIpAddress"`
-	Password        string   `json:"password,omitempty"`
-	Shutdown        bool     `json:"shutdown"`
-	Description     string   `json:"description,omitempty"`
-	MedIn           int      `json:"medIn,omitempty"`
-	MedOut          int      `json:"medOut,omitempty"`
-	BfdEnabled      bool     `json:"bfdEnabled"`
-	ExportPolicy    string   `json:"exportPolicy,omitempty"`
-	PermitExportTo  []string `json:"permitExportTo,omitempty"`
-	DenyExportTo    []string `json:"denyExportTo,omitempty"`
-	ImportWhitelist int      `json:"importWhitelist,omitempty"`
-	ImportBlacklist int      `json:"importBlacklist,omitempty"`
-	ExportWhitelist int      `json:"exportWhitelist,omitempty"`
-	ExportBlacklist int      `json:"exportBlacklist,omitempty"`
+	PeerAsn            int      `json:"peerAsn"`
+	LocalIpAddress     string   `json:"localIpAddress"`
+	PeerIpAddress      string   `json:"peerIpAddress"`
+	Password           string   `json:"password,omitempty"`
+	Shutdown           bool     `json:"shutdown"`
+	Description        string   `json:"description,omitempty"`
+	MedIn              int      `json:"medIn,omitempty"`
+	MedOut             int      `json:"medOut,omitempty"`
+	BfdEnabled         bool     `json:"bfdEnabled"`
+	ExportPolicy       string   `json:"exportPolicy,omitempty"`
+	PermitExportTo     []string `json:"permitExportTo,omitempty"`
+	DenyExportTo       []string `json:"denyExportTo,omitempty"`
+	ImportWhitelist    int      `json:"importWhitelist,omitempty"`
+	ImportBlacklist    int      `json:"importBlacklist,omitempty"`
+	ExportWhitelist    int      `json:"exportWhitelist,omitempty"`
+	ExportBlacklist    int      `json:"exportBlacklist,omitempty"`
+	AsPathPrependCount int      `json:"asPathPrependCount,omitempty"`
 }
 
 // AWS STUFF


### PR DESCRIPTION
## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
