### PR TITLE
feat: add new MVE image types

### DIFF
--- a/mve_types.go
+++ b/mve_types.go
@@ -23,6 +23,16 @@ type VendorConfig interface {
 	IsVendorConfig()
 }
 
+// VSRConfig represents the configuration for a 6WIND VSR MVE.
+type SixwindVSRConfig struct {
+	VendorConfig
+	Vendor       string `json:"vendor"`
+	ImageID      int    `json:"imageId"`
+	ProductSize  string `json:"productSize"`
+	MVELabel     string `json:"mveLabel"`
+	SSHPublicKey string `json:"sshPublicKey"`
+}
+
 // ArubaConfig represents the configuration for an Aruba MVE.
 type ArubaConfig struct {
 	VendorConfig
@@ -33,6 +43,16 @@ type ArubaConfig struct {
 	AccountName string `json:"accountName"`
 	AccountKey  string `json:"accountKey"`
 	SystemTag   string `json:"systemTag"`
+}
+
+// AviatrixConfig represents the configuration for an Aviatrix Secure Edge MVE.
+type AviatrixConfig struct {
+	VendorConfig
+	Vendor      string `json:"vendor"`
+	ImageID     int    `json:"imageId"`
+	ProductSize string `json:"productSize"`
+	MVELabel    string `json:"mveLabel"`
+	CloudInit   string `json:"cloudInit"`
 }
 
 // CiscoConfig represents the configuration for a Cisco MVE.
@@ -74,6 +94,17 @@ type PaloAltoConfig struct {
 	SSHPublicKey      string `json:"sshPublicKey,omitempty"`
 	AdminPasswordHash string `json:"adminPasswordHash,omitempty"`
 	LicenseData       string `json:"licenseData,omitempty"`
+}
+
+// PrismaConfig represents the configuration for a Palo Alto Prisma MVE.
+type PrismaConfig struct {
+	VendorConfig
+	Vendor      string `json:"vendor"`
+	ImageID     int    `json:"imageId"`
+	ProductSize string `json:"productSize"`
+	MVELabel    string `json:"mveLabel"`
+	IONKey      string `json:"ionKey"`
+	SecretKey   string `json:"secretKey"`
 }
 
 // VersaConfig represents the configuration for a Versa MVE.


### PR DESCRIPTION
Add config types for 6WIND VSR, Aviatrix and Palo Prisma

## Description

This adds support for new MVE images - Aviatrix Secure Edge, 6WIND VSR and Prisma. Two of which aren't GA yet but will be shortly.

Fixes EIP-3669

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
