### PR TITLE
feat: add mcr speeds, move valid contract term values and mcr speeds into shared types

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -35,14 +35,10 @@ func (r *ErrorResponse) Error() string {
 var ErrWrongProductModify = errors.New("you can only update Ports, MCR, and MVE using this method")
 
 // ErrInvalidTerm creates an error indicating an invalid contract term,dynamically listing the valid terms.
-var ErrInvalidTerm = func(provided int) error {
-	return fmt.Errorf("invalid term %d, valid terms are %s months", provided, intSliceToString(VALID_CONTRACT_TERMS))
-}
+var ErrInvalidTerm = errors.New(fmt.Sprintf("invalid term, valid terms are %s months", intSliceToString(VALID_CONTRACT_TERMS)))
 
 // ErrMCRInvalidPortSpeed creates an error indicating an invalid MCR port speed, dynamically listing the valid speeds.
-var ErrMCRInvalidPortSpeed = func(provided int) error {
-	return fmt.Errorf("invalid port speed %d, valid speeds are %s", provided, intSliceToString(VALID_MCR_PORT_SPEEDS))
-}
+var ErrMCRInvalidPortSpeed = errors.New(fmt.Sprintf("invalid mcr port speed, valid speeds are %s", intSliceToString(VALID_MCR_PORT_SPEEDS)))
 
 // ErrPortAlreadyLocked is returned when a port is already locked
 var ErrPortAlreadyLocked = errors.New("that port is already locked, cannot lock")

--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 // An ErrorResponse reports the error caused by an API request
@@ -39,6 +41,15 @@ var ErrInvalidTerm = fmt.Errorf("invalid term, valid terms are %s months", intSl
 
 // ErrMCRInvalidPortSpeed creates an error indicating an invalid MCR port speed, dynamically listing the valid speeds.
 var ErrMCRInvalidPortSpeed = fmt.Errorf("invalid mcr port speed, valid speeds are %s", intSliceToString(VALID_MCR_PORT_SPEEDS))
+
+// intSliceToString converts a slice of integers to a comma-separated string.
+func intSliceToString(slice []int) string {
+	strSlice := make([]string, len(slice))
+	for i, v := range slice {
+		strSlice[i] = strconv.Itoa(v)
+	}
+	return strings.Join(strSlice, ", ")
+}
 
 // ErrPortAlreadyLocked is returned when a port is already locked
 var ErrPortAlreadyLocked = errors.New("that port is already locked, cannot lock")

--- a/errors.go
+++ b/errors.go
@@ -35,10 +35,10 @@ func (r *ErrorResponse) Error() string {
 var ErrWrongProductModify = errors.New("you can only update Ports, MCR, and MVE using this method")
 
 // ErrInvalidTerm creates an error indicating an invalid contract term,dynamically listing the valid terms.
-var ErrInvalidTerm = errors.New(fmt.Sprintf("invalid term, valid terms are %s months", intSliceToString(VALID_CONTRACT_TERMS)))
+var ErrInvalidTerm = fmt.Errorf("invalid term, valid terms are %s months", intSliceToString(VALID_CONTRACT_TERMS))
 
 // ErrMCRInvalidPortSpeed creates an error indicating an invalid MCR port speed, dynamically listing the valid speeds.
-var ErrMCRInvalidPortSpeed = errors.New(fmt.Sprintf("invalid mcr port speed, valid speeds are %s", intSliceToString(VALID_MCR_PORT_SPEEDS)))
+var ErrMCRInvalidPortSpeed = fmt.Errorf("invalid mcr port speed, valid speeds are %s", intSliceToString(VALID_MCR_PORT_SPEEDS))
 
 // ErrPortAlreadyLocked is returned when a port is already locked
 var ErrPortAlreadyLocked = errors.New("that port is already locked, cannot lock")

--- a/errors.go
+++ b/errors.go
@@ -34,17 +34,21 @@ func (r *ErrorResponse) Error() string {
 // ErrWrongProductModify is returned when a user attempts to modify a product that can't be modified
 var ErrWrongProductModify = errors.New("you can only update Ports, MCR, and MVE using this method")
 
-// ErrInvalidTerm is returned for an invalid product term
-var ErrInvalidTerm = errors.New("invalid term, valid values are 1, 12, 24, and 36")
+// ErrInvalidTerm creates an error indicating an invalid contract term,dynamically listing the valid terms.
+var ErrInvalidTerm = func(provided int) error {
+	return fmt.Errorf("invalid term %d, valid terms are %s months", provided, intSliceToString(VALID_CONTRACT_TERMS))
+}
+
+// ErrMCRInvalidPortSpeed creates an error indicating an invalid MCR port speed, dynamically listing the valid speeds.
+var ErrMCRInvalidPortSpeed = func(provided int) error {
+	return fmt.Errorf("invalid port speed %d, valid speeds are %s", provided, intSliceToString(VALID_MCR_PORT_SPEEDS))
+}
 
 // ErrPortAlreadyLocked is returned when a port is already locked
 var ErrPortAlreadyLocked = errors.New("that port is already locked, cannot lock")
 
 // ErrPortNotLocked is returned when a port is not locked
 var ErrPortNotLocked = errors.New("that port not locked, cannot unlock")
-
-// ErrMCRInvalidPortSpeed is returned for an invalid MCR port speed
-var ErrMCRInvalidPortSpeed = errors.New("invalid port speed, valid speeds are 1000, 2500, 5000, and 10000")
 
 // ErrLocationNotFound is returned when a location can't be found
 var ErrLocationNotFound = errors.New("unable to find location")

--- a/errors.go
+++ b/errors.go
@@ -34,7 +34,7 @@ func (r *ErrorResponse) Error() string {
 // ErrWrongProductModify is returned when a user attempts to modify a product that can't be modified
 var ErrWrongProductModify = errors.New("you can only update Ports, MCR, and MVE using this method")
 
-// ErrInvalidTerm creates an error indicating an invalid contract term,dynamically listing the valid terms.
+// ErrInvalidTerm creates an error indicating an invalid contract term, dynamically listing the valid terms.
 var ErrInvalidTerm = fmt.Errorf("invalid term, valid terms are %s months", intSliceToString(VALID_CONTRACT_TERMS))
 
 // ErrMCRInvalidPortSpeed creates an error indicating an invalid MCR port speed, dynamically listing the valid speeds.

--- a/mcr.go
+++ b/mcr.go
@@ -205,10 +205,10 @@ func (svc *MCRServiceOp) BuyMCR(ctx context.Context, req *BuyMCRRequest) (*BuyMC
 // validateBuyMCRRequest validates the BuyMCRRequest for a valid term and port speed.
 func validateBuyMCRRequest(order *BuyMCRRequest) error {
 	if !slices.Contains(VALID_CONTRACT_TERMS, order.Term) {
-		return ErrInvalidTerm(order.Term)
+		return ErrInvalidTerm
 	}
 	if !slices.Contains(VALID_MCR_PORT_SPEEDS, order.PortSpeed) {
-		return ErrMCRInvalidPortSpeed(order.PortSpeed)
+		return ErrMCRInvalidPortSpeed
 	}
 	return nil
 }

--- a/mcr.go
+++ b/mcr.go
@@ -205,10 +205,10 @@ func (svc *MCRServiceOp) BuyMCR(ctx context.Context, req *BuyMCRRequest) (*BuyMC
 // validateBuyMCRRequest validates the BuyMCRRequest for a valid term and port speed.
 func validateBuyMCRRequest(order *BuyMCRRequest) error {
 	if !slices.Contains(VALID_CONTRACT_TERMS, order.Term) {
-		return ErrInvalidTerm
+		return ErrInvalidTerm(order.Term)
 	}
 	if !slices.Contains(VALID_MCR_PORT_SPEEDS, order.PortSpeed) {
-		return ErrMCRInvalidPortSpeed
+		return ErrMCRInvalidPortSpeed(order.PortSpeed)
 	}
 	return nil
 }

--- a/mcr.go
+++ b/mcr.go
@@ -204,10 +204,10 @@ func (svc *MCRServiceOp) BuyMCR(ctx context.Context, req *BuyMCRRequest) (*BuyMC
 
 // validateBuyMCRRequest validates the BuyMCRRequest for a valid term and port speed.
 func validateBuyMCRRequest(order *BuyMCRRequest) error {
-	if order.Term != 1 && order.Term != 12 && order.Term != 24 && order.Term != 36 {
+	if !slices.Contains(VALID_CONTRACT_TERMS, order.Term) {
 		return ErrInvalidTerm
 	}
-	if order.PortSpeed != 1000 && order.PortSpeed != 2500 && order.PortSpeed != 5000 && order.PortSpeed != 10000 {
+	if !slices.Contains(VALID_MCR_PORT_SPEEDS, order.PortSpeed) {
 		return ErrMCRInvalidPortSpeed
 	}
 	return nil

--- a/mve.go
+++ b/mve.go
@@ -368,7 +368,7 @@ func (svc *MVEServiceOp) ListAvailableMVESizes(ctx context.Context) ([]*MVESize,
 // validateBuyMVERequest validates a BuyMVERequest for proper term length.
 func validateBuyMVERequest(req *BuyMVERequest) error {
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
-		return ErrInvalidTerm
+		return ErrInvalidTerm(req.Term)
 	}
 	return nil
 }

--- a/mve.go
+++ b/mve.go
@@ -367,7 +367,7 @@ func (svc *MVEServiceOp) ListAvailableMVESizes(ctx context.Context) ([]*MVESize,
 
 // validateBuyMVERequest validates a BuyMVERequest for proper term length.
 func validateBuyMVERequest(req *BuyMVERequest) error {
-	if req.Term != 1 && req.Term != 12 && req.Term != 24 && req.Term != 36 {
+	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		return ErrInvalidTerm
 	}
 	return nil

--- a/mve.go
+++ b/mve.go
@@ -368,7 +368,7 @@ func (svc *MVEServiceOp) ListAvailableMVESizes(ctx context.Context) ([]*MVESize,
 // validateBuyMVERequest validates a BuyMVERequest for proper term length.
 func validateBuyMVERequest(req *BuyMVERequest) error {
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
-		return ErrInvalidTerm(req.Term)
+		return ErrInvalidTerm
 	}
 	return nil
 }

--- a/port.go
+++ b/port.go
@@ -232,7 +232,8 @@ func createPortOrder(req *BuyPortRequest) []PortOrder {
 }
 
 func (svc *PortServiceOp) ValidatePortOrder(ctx context.Context, req *BuyPortRequest) error {
-	if req.Term != 1 && req.Term != 12 && req.Term != 24 && req.Term != 36 {
+	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
+		// Validate that term is one of the allowed values
 		return ErrInvalidTerm
 	}
 

--- a/port.go
+++ b/port.go
@@ -142,7 +142,7 @@ type UnlockPortResponse struct {
 // BuyPort buys a port from the Megaport Port API.
 func (svc *PortServiceOp) BuyPort(ctx context.Context, req *BuyPortRequest) (*BuyPortResponse, error) {
 	if req.Term != 1 && req.Term != 12 && req.Term != 24 && req.Term != 36 {
-		return nil, ErrInvalidTerm(req.Term)
+		return nil, ErrInvalidTerm
 	}
 
 	buyOrder := createPortOrder(req)
@@ -234,7 +234,7 @@ func createPortOrder(req *BuyPortRequest) []PortOrder {
 func (svc *PortServiceOp) ValidatePortOrder(ctx context.Context, req *BuyPortRequest) error {
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		// Validate that term is one of the allowed values
-		return ErrInvalidTerm(req.Term)
+		return ErrInvalidTerm
 	}
 
 	buyOrder := createPortOrder(req)

--- a/port.go
+++ b/port.go
@@ -142,7 +142,7 @@ type UnlockPortResponse struct {
 // BuyPort buys a port from the Megaport Port API.
 func (svc *PortServiceOp) BuyPort(ctx context.Context, req *BuyPortRequest) (*BuyPortResponse, error) {
 	if req.Term != 1 && req.Term != 12 && req.Term != 24 && req.Term != 36 {
-		return nil, ErrInvalidTerm
+		return nil, ErrInvalidTerm(req.Term)
 	}
 
 	buyOrder := createPortOrder(req)
@@ -234,7 +234,7 @@ func createPortOrder(req *BuyPortRequest) []PortOrder {
 func (svc *PortServiceOp) ValidatePortOrder(ctx context.Context, req *BuyPortRequest) error {
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		// Validate that term is one of the allowed values
-		return ErrInvalidTerm
+		return ErrInvalidTerm(req.Term)
 	}
 
 	buyOrder := createPortOrder(req)

--- a/shared_types.go
+++ b/shared_types.go
@@ -30,6 +30,11 @@ const (
 )
 
 var (
+	// VALID_CONTRACT_TERMS lists the valid contract terms in months.
+	VALID_CONTRACT_TERMS = []int{1, 12, 24, 36}
+
+	VALID_MCR_PORT_SPEEDS = []int{1000, 2500, 5000, 10000, 25000, 50000, 100000}
+
 	// SERVICE_STATE_READY is a list of service states that are considered ready for use.
 	SERVICE_STATE_READY = []string{SERVICE_CONFIGURED, SERVICE_LIVE}
 )

--- a/shared_types.go
+++ b/shared_types.go
@@ -2,8 +2,6 @@ package megaport
 
 import (
 	"encoding/json"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -40,15 +38,6 @@ var (
 	// SERVICE_STATE_READY is a list of service states that are considered ready for use.
 	SERVICE_STATE_READY = []string{SERVICE_CONFIGURED, SERVICE_LIVE}
 )
-
-// intSliceToString converts a slice of integers to a comma-separated string.
-func intSliceToString(slice []int) string {
-	strSlice := make([]string, len(slice))
-	for i, v := range slice {
-		strSlice[i] = strconv.Itoa(v)
-	}
-	return strings.Join(strSlice, ", ")
-}
 
 // Time is a custom time type that allows for unmarshalling of Unix timestamps.
 type Time struct {

--- a/shared_types.go
+++ b/shared_types.go
@@ -2,6 +2,8 @@ package megaport
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -38,6 +40,15 @@ var (
 	// SERVICE_STATE_READY is a list of service states that are considered ready for use.
 	SERVICE_STATE_READY = []string{SERVICE_CONFIGURED, SERVICE_LIVE}
 )
+
+// intSliceToString converts a slice of integers to a comma-separated string.
+func intSliceToString(slice []int) string {
+	strSlice := make([]string, len(slice))
+	for i, v := range slice {
+		strSlice[i] = strconv.Itoa(v)
+	}
+	return strings.Join(strSlice, ", ")
+}
 
 // Time is a custom time type that allows for unmarshalling of Unix timestamps.
 type Time struct {

--- a/vxc.go
+++ b/vxc.go
@@ -133,7 +133,7 @@ type ListPartnerPortsResponse struct {
 // BuyVXC buys a VXC from the Megaport VXC API.
 func (svc *VXCServiceOp) BuyVXC(ctx context.Context, req *BuyVXCRequest) (*BuyVXCResponse, error) {
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
-		return nil, ErrInvalidTerm
+		return nil, ErrInvalidTerm(req.Term)
 	}
 
 	buyOrder := createVXCOrder(req)
@@ -276,7 +276,7 @@ func (svc *VXCServiceOp) DeleteVXC(ctx context.Context, id string, req *DeleteVX
 // UpdateVXC updates a VXC in the Megaport VXC API.
 func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVXCRequest) (*VXC, error) {
 	if req.Term != nil && (*req.Term != 1 && *req.Term != 12 && *req.Term != 24 && *req.Term != 36) {
-		return nil, ErrInvalidTerm
+		return nil, ErrInvalidTerm(*req.Term)
 	}
 	if req.CostCentre != nil && len(*req.CostCentre) > 255 {
 		return nil, ErrCostCentreTooLong

--- a/vxc.go
+++ b/vxc.go
@@ -133,7 +133,7 @@ type ListPartnerPortsResponse struct {
 // BuyVXC buys a VXC from the Megaport VXC API.
 func (svc *VXCServiceOp) BuyVXC(ctx context.Context, req *BuyVXCRequest) (*BuyVXCResponse, error) {
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
-		return nil, ErrInvalidTerm(req.Term)
+		return nil, ErrInvalidTerm
 	}
 
 	buyOrder := createVXCOrder(req)
@@ -276,7 +276,7 @@ func (svc *VXCServiceOp) DeleteVXC(ctx context.Context, id string, req *DeleteVX
 // UpdateVXC updates a VXC in the Megaport VXC API.
 func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVXCRequest) (*VXC, error) {
 	if req.Term != nil && (*req.Term != 1 && *req.Term != 12 && *req.Term != 24 && *req.Term != 36) {
-		return nil, ErrInvalidTerm(*req.Term)
+		return nil, ErrInvalidTerm
 	}
 	if req.CostCentre != nil && len(*req.CostCentre) > 255 {
 		return nil, ErrCostCentreTooLong

--- a/vxc.go
+++ b/vxc.go
@@ -132,7 +132,7 @@ type ListPartnerPortsResponse struct {
 
 // BuyVXC buys a VXC from the Megaport VXC API.
 func (svc *VXCServiceOp) BuyVXC(ctx context.Context, req *BuyVXCRequest) (*BuyVXCResponse, error) {
-	if req.Term != 1 && req.Term != 12 && req.Term != 24 && req.Term != 36 {
+	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		return nil, ErrInvalidTerm
 	}
 


### PR DESCRIPTION
Add valid contract terms and MCR speeds as shared slices
This PR refactors validation logic by moving hardcoded values into exported slices in `shared_types.go`:

- Move valid contract terms (1, 12, 24, 36 months) into `VALID_CONTRACT_TERMS` slice for reusability and improved readability.
- Move Valid MCR speeds into `VALID_MCR_PORT_SPEEDS` slice for reusability and improved readability.
- Add support for higher MCR port speeds (25000, 50000, and 100000 Mbps)

## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
