### PR TITLE
fix: make cost centre omit empty for vxc update

### DIFF
--- a/vxc.go
+++ b/vxc.go
@@ -351,7 +351,7 @@ func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVX
 		update.BEndProductUID = *req.BEndProductUID
 	}
 	if req.CostCentre != nil {
-		update.CostCentre = *req.CostCentre
+		update.CostCentre = req.CostCentre
 	}
 	if req.AEndInnerVLAN != nil {
 		update.AEndInnerVLAN = req.AEndInnerVLAN

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -1047,7 +1047,7 @@ func (suite *VXCClientTestSuite) TestUpdateVXC() {
 		AEndVLAN:   updateReq.AEndVLAN,
 		BEndVLAN:   updateReq.BEndVLAN,
 		Shutdown:   updateReq.Shutdown,
-		CostCentre: *updateReq.CostCentre,
+		CostCentre: updateReq.CostCentre,
 		Term:       updateReq.Term,
 	}
 	path := fmt.Sprintf("/v3/product/%s/%s", PRODUCT_VXC, vxcUid)

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -178,20 +178,20 @@ type Peer struct {
 
 // VXCUpdate represents the fields that can be updated on a VXC.
 type VXCUpdate struct {
-	Name           string `json:"name,omitempty"`
-	RateLimit      *int   `json:"rateLimit,omitempty"`  // A new speed for the connection in MBPS.
-	CostCentre     string `json:"costCentre,omitempty"` // A customer reference number to be included in billing information and invoices. Also known as the Service Level Reference (SLR).
-	Shutdown       *bool  `json:"shutdown,omitempty"`   // Temporarily shut down and re-enable the VXC. Valid values are true (shut down) and false (enabled). If not provided, it defaults to false (enabled).
-	AEndVLAN       *int   `json:"aEndVlan,omitempty"`
-	BEndVLAN       *int   `json:"bEndVlan,omitempty"`
-	AEndInnerVLAN  *int   `json:"aEndInnerVlan,omitempty"`
-	BEndInnerVLAN  *int   `json:"bEndInnerVlan,omitempty"`
-	AEndProductUID string `json:"aEndProductUid,omitempty"` // When moving a VXC, this is the new A-End for the connection.
-	BEndProductUID string `json:"bEndProductUid,omitempty"` // When moving a VXC, this is the new B-End for the connection.
-	Term           *int   `json:"term,omitempty"`
-	IsApproved     *bool  `json:"isApproved,omitempty"` // Define whether the VXC is approved or rejected via the Megaport Marketplace. Set to true (Approved) or false (Rejected).
-	AVnicIndex     *int   `json:"aVnicIndex,omitempty"` // When moving a VXC for an MVE, this is the new A-End vNIC for the connection.
-	BVnicIndex     *int   `json:"bVnicIndex,omitempty"` // When moving a VXC for an MVE, this is the new B-End vNIC for the connection.
+	Name           string  `json:"name,omitempty"`
+	RateLimit      *int    `json:"rateLimit,omitempty"`  // A new speed for the connection in MBPS.
+	CostCentre     *string `json:"costCentre,omitempty"` // A customer reference number to be included in billing information and invoices. Also known as the Service Level Reference (SLR).
+	Shutdown       *bool   `json:"shutdown,omitempty"`   // Temporarily shut down and re-enable the VXC. Valid values are true (shut down) and false (enabled). If not provided, it defaults to false (enabled).
+	AEndVLAN       *int    `json:"aEndVlan,omitempty"`
+	BEndVLAN       *int    `json:"bEndVlan,omitempty"`
+	AEndInnerVLAN  *int    `json:"aEndInnerVlan,omitempty"`
+	BEndInnerVLAN  *int    `json:"bEndInnerVlan,omitempty"`
+	AEndProductUID string  `json:"aEndProductUid,omitempty"` // When moving a VXC, this is the new A-End for the connection.
+	BEndProductUID string  `json:"bEndProductUid,omitempty"` // When moving a VXC, this is the new B-End for the connection.
+	Term           *int    `json:"term,omitempty"`
+	IsApproved     *bool   `json:"isApproved,omitempty"` // Define whether the VXC is approved or rejected via the Megaport Marketplace. Set to true (Approved) or false (Rejected).
+	AVnicIndex     *int    `json:"aVnicIndex,omitempty"` // When moving a VXC for an MVE, this is the new A-End vNIC for the connection.
+	BVnicIndex     *int    `json:"bVnicIndex,omitempty"` // When moving a VXC for an MVE, this is the new B-End vNIC for the connection.
 
 	AEndPartnerConfig VXCPartnerConfiguration `json:"aEndConfig,omitempty"`
 	BEndPartnerConfig VXCPartnerConfiguration `json:"bEndConfig,omitempty"`


### PR DESCRIPTION
Prevents Terraform Error involving null cost centre string

## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
