### PR TITLE
ESD-910: unexport internal API types used only for JSON unmarshaling

### DIFF
--- a/client.go
+++ b/client.go
@@ -104,8 +104,9 @@ type Client struct {
 	authMux sync.Mutex
 }
 
-// AccessTokenResponse is the response structure for the Login method containing the access token and expiration time.
-type AccessTokenResponse struct {
+// accessTokenResponse is the response structure for the Login method containing the access token and expiration time.
+// Used internally for JSON unmarshalling.
+type accessTokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
@@ -547,7 +548,7 @@ func (c *Client) Authorize(ctx context.Context) (*AuthInfo, error) {
 	}
 
 	// Parse the response JSON to extract the access token and expiration time
-	authResponse := AccessTokenResponse{}
+	authResponse := accessTokenResponse{}
 	if err := json.Unmarshal(body, &authResponse); err != nil {
 		return nil, err
 	}

--- a/ix.go
+++ b/ix.go
@@ -203,7 +203,7 @@ func (svc *IXServiceOp) GetIX(ctx context.Context, id string) (*IX, error) {
 		return nil, fileErr
 	}
 
-	ixResponse := IXResponse{}
+	ixResponse := ixResponse{}
 
 	unmarshalErr := json.Unmarshal(body, &ixResponse)
 	if unmarshalErr != nil {
@@ -280,7 +280,7 @@ func (svc *IXServiceOp) UpdateIX(ctx context.Context, id string, req *UpdateIXRe
 	}
 
 	// Parse the response
-	ixResponse := IXResponse{}
+	ixResponse := ixResponse{}
 	if err = json.Unmarshal(body, &ixResponse); err != nil {
 		return nil, err
 	}

--- a/ix.go
+++ b/ix.go
@@ -203,14 +203,14 @@ func (svc *IXServiceOp) GetIX(ctx context.Context, id string) (*IX, error) {
 		return nil, fileErr
 	}
 
-	ixResponse := ixResponse{}
+	resp := ixResponse{}
 
-	unmarshalErr := json.Unmarshal(body, &ixResponse)
+	unmarshalErr := json.Unmarshal(body, &resp)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr
 	}
 
-	return &ixResponse.Data, nil
+	return &resp.Data, nil
 }
 
 // UpdateIX updates an existing Internet Exchange
@@ -280,8 +280,8 @@ func (svc *IXServiceOp) UpdateIX(ctx context.Context, id string, req *UpdateIXRe
 	}
 
 	// Parse the response
-	ixResponse := ixResponse{}
-	if err = json.Unmarshal(body, &ixResponse); err != nil {
+	resp := ixResponse{}
+	if err = json.Unmarshal(body, &resp); err != nil {
 		return nil, err
 	}
 
@@ -316,7 +316,7 @@ func (svc *IXServiceOp) UpdateIX(ctx context.Context, id string, req *UpdateIXRe
 		}
 	} else {
 		// Return without waiting
-		return &ixResponse.Data, nil
+		return &resp.Data, nil
 	}
 }
 

--- a/ix_types.go
+++ b/ix_types.go
@@ -104,8 +104,9 @@ type AssociatedIXOrder struct {
 	PromoCode          string `json:"promoCode,omitempty"` // Optional promotion code for discounts
 }
 
-// IXResponse represents a response from the Megaport IX API after querying an IX.
-type IXResponse struct {
+// ixResponse represents a response from the Megaport IX API after querying an IX.
+// Used internally for JSON unmarshalling.
+type ixResponse struct {
 	Message string `json:"message"`
 	Terms   string `json:"terms"`
 	Data    IX     `json:"data"`

--- a/location.go
+++ b/location.go
@@ -145,29 +145,32 @@ type LocationV3CrossConnect struct {
 	Type      *string `json:"type,omitempty"`
 }
 
-// LocationsResponse represents the response from the Megaport Locations API.
-type LocationResponse struct {
+// locationResponse represents the response from the Megaport Locations API.
+// Used internally for JSON unmarshalling.
+type locationResponse struct {
 	Message string      `json:"message"`
 	Terms   string      `json:"terms"`
 	Data    []*Location `json:"data"`
 }
 
-// LocationV3Response represents the response from the Megaport Locations API v3.
-type LocationV3Response struct {
+// locationV3Response represents the response from the Megaport Locations API v3.
+// Used internally for JSON unmarshalling.
+type locationV3Response struct {
 	Message string        `json:"message"`
 	Terms   string        `json:"terms"`
 	Data    []*LocationV3 `json:"data"`
 }
 
-// CountryResponse represents the response from the Megaport Network Regions API.
-type CountryResponse struct {
-	Message string                  `json:"message"`
-	Terms   string                  `json:"terms"`
-	Data    []*CountryInnerResponse `json:"data"`
+// countryResponse represents the response from the Megaport Network Regions API.
+// Used internally for JSON unmarshalling.
+type countryResponse struct {
+	Message string                 `json:"message"`
+	Terms   string                 `json:"terms"`
+	Data    []*countryInnerResponse `json:"data"`
 }
 
-// CountriesInnerResponse represents the inner response from the Megaport Network Regions API.
-type CountryInnerResponse struct {
+// countryInnerResponse represents the inner response from the Megaport Network Regions API.
+type countryInnerResponse struct {
 	Countries     []*Country `json:"countries"`
 	NetworkRegion string     `json:"networkRegion"`
 }
@@ -203,7 +206,7 @@ func (svc *LocationServiceOp) ListLocationsV3(ctx context.Context) ([]*LocationV
 		return nil, fileErr
 	}
 
-	locationResponse := &LocationV3Response{}
+	locationResponse := &locationV3Response{}
 
 	unmarshalErr := json.Unmarshal(body, locationResponse)
 	if unmarshalErr != nil {
@@ -458,7 +461,7 @@ func (svc *LocationServiceOp) ListCountries(ctx context.Context) ([]*Country, er
 		return nil, fileErr
 	}
 
-	countryResponse := CountryResponse{}
+	countryResponse := countryResponse{}
 
 	unmarshalErr := json.Unmarshal(body, &countryResponse)
 

--- a/location.go
+++ b/location.go
@@ -164,8 +164,8 @@ type locationV3Response struct {
 // countryResponse represents the response from the Megaport Network Regions API.
 // Used internally for JSON unmarshalling.
 type countryResponse struct {
-	Message string                 `json:"message"`
-	Terms   string                 `json:"terms"`
+	Message string                  `json:"message"`
+	Terms   string                  `json:"terms"`
 	Data    []*countryInnerResponse `json:"data"`
 }
 

--- a/location.go
+++ b/location.go
@@ -170,6 +170,7 @@ type countryResponse struct {
 }
 
 // countryInnerResponse represents the inner response from the Megaport Network Regions API.
+// Used internally for JSON unmarshalling.
 type countryInnerResponse struct {
 	Countries     []*Country `json:"countries"`
 	NetworkRegion string     `json:"networkRegion"`

--- a/location.go
+++ b/location.go
@@ -207,14 +207,14 @@ func (svc *LocationServiceOp) ListLocationsV3(ctx context.Context) ([]*LocationV
 		return nil, fileErr
 	}
 
-	locationResponse := &locationV3Response{}
+	resp := &locationV3Response{}
 
-	unmarshalErr := json.Unmarshal(body, locationResponse)
+	unmarshalErr := json.Unmarshal(body, resp)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr
 	}
 
-	return locationResponse.Data, nil
+	return resp.Data, nil
 }
 
 // GetLocationByIDV3 returns a location by its ID using the v3 API.

--- a/location.go
+++ b/location.go
@@ -462,9 +462,9 @@ func (svc *LocationServiceOp) ListCountries(ctx context.Context) ([]*Country, er
 		return nil, fileErr
 	}
 
-	countryResponse := countryResponse{}
+	resp := countryResponse{}
 
-	unmarshalErr := json.Unmarshal(body, &countryResponse)
+	unmarshalErr := json.Unmarshal(body, &resp)
 
 	if unmarshalErr != nil {
 		return nil, unmarshalErr
@@ -472,9 +472,9 @@ func (svc *LocationServiceOp) ListCountries(ctx context.Context) ([]*Country, er
 
 	allCountries := make([]*Country, 0)
 
-	for i := 0; i < len(countryResponse.Data); i++ {
-		if countryResponse.Data[i].NetworkRegion == "MP1" {
-			allCountries = countryResponse.Data[i].Countries
+	for i := 0; i < len(resp.Data); i++ {
+		if resp.Data[i].NetworkRegion == "MP1" {
+			allCountries = resp.Data[i].Countries
 		}
 	}
 

--- a/location_legacy.go
+++ b/location_legacy.go
@@ -145,7 +145,7 @@ func (svc *LocationServiceOp) ListLocations(ctx context.Context) ([]*Location, e
 		return nil, fileErr
 	}
 
-	locationResponse := &LocationResponse{}
+	locationResponse := &locationResponse{}
 
 	unmarshalErr := json.Unmarshal(body, locationResponse)
 	if unmarshalErr != nil {

--- a/location_legacy.go
+++ b/location_legacy.go
@@ -145,14 +145,14 @@ func (svc *LocationServiceOp) ListLocations(ctx context.Context) ([]*Location, e
 		return nil, fileErr
 	}
 
-	locationResponse := &locationResponse{}
+	resp := &locationResponse{}
 
-	unmarshalErr := json.Unmarshal(body, locationResponse)
+	unmarshalErr := json.Unmarshal(body, resp)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr
 	}
 
-	return locationResponse.Data, nil
+	return resp.Data, nil
 }
 
 // GetLocationByID returns a location by its ID in the Megaport Locations API.

--- a/managed_account.go
+++ b/managed_account.go
@@ -32,13 +32,17 @@ type ManagedAccountRequest struct {
 	AccountRef  string `json:"accountRef"`  // A required string that specifies a reference ID for the managed account. The accountRef is typically an identifier used in partner systems (for example, CRM or billing). This value is shown on the invoices as the Managed Account Reference. The accountRef also identifies the account in email notifications. (The accountRef value maps to the Managed Account UID in the Portal interface.)
 }
 
-type ManagedAccountAPIResponse struct {
+// managedAccountAPIResponse represents the API response for a single managed account.
+// Used internally for JSON unmarshalling.
+type managedAccountAPIResponse struct {
 	Message string          `json:"message"`
 	Terms   string          `json:"terms"`
 	Data    *ManagedAccount `json:"data"`
 }
 
-type ManagedAccountListAPIResponse struct {
+// managedAccountListAPIResponse represents the API response for a list of managed accounts.
+// Used internally for JSON unmarshalling.
+type managedAccountListAPIResponse struct {
 	Message string            `json:"message"`
 	Terms   string            `json:"terms"`
 	Data    []*ManagedAccount `json:"data"`
@@ -70,7 +74,7 @@ func (svc *ManagedAccountServiceOp) ListManagedAccounts(ctx context.Context) ([]
 		return nil, fileErr
 	}
 
-	var apiResponse *ManagedAccountListAPIResponse
+	var apiResponse *managedAccountListAPIResponse
 
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
 		return nil, err
@@ -94,7 +98,7 @@ func (svc *ManagedAccountServiceOp) CreateManagedAccount(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	var createManagedAccountResponse *ManagedAccountAPIResponse
+	var createManagedAccountResponse *managedAccountAPIResponse
 	if err := json.Unmarshal(body, &createManagedAccountResponse); err != nil {
 		return nil, err
 	}
@@ -116,7 +120,7 @@ func (svc *ManagedAccountServiceOp) UpdateManagedAccount(ctx context.Context, co
 	if err != nil {
 		return nil, err
 	}
-	var updateManagedAccountResponse *ManagedAccountAPIResponse
+	var updateManagedAccountResponse *managedAccountAPIResponse
 	if err := json.Unmarshal(body, &updateManagedAccountResponse); err != nil {
 		return nil, err
 	}

--- a/mcr.go
+++ b/mcr.go
@@ -156,7 +156,7 @@ func (svc *MCRServiceOp) BuyMCR(ctx context.Context, req *BuyMCRRequest) (*BuyMC
 		return nil, resErr
 	}
 
-	orderInfo := MCROrderResponse{}
+	orderInfo := mcrOrderResponse{}
 	unmarshalErr := json.Unmarshal(*body, &orderInfo)
 
 	if unmarshalErr != nil {
@@ -296,7 +296,7 @@ func (svc *MCRServiceOp) GetMCR(ctx context.Context, mcrId string) (*MCR, error)
 		return nil, fileErr
 	}
 
-	mcrRes := &MCRResponse{}
+	mcrRes := &mcrResponse{}
 	unmarshalErr := json.Unmarshal(body, mcrRes)
 
 	if unmarshalErr != nil {
@@ -328,7 +328,7 @@ func (svc *MCRServiceOp) CreatePrefixFilterList(ctx context.Context, req *Create
 		return nil, fileErr
 	}
 
-	createRes := &APIMCRPrefixFilterListResponse{}
+	createRes := &apiMCRPrefixFilterListResponse{}
 	unmarshalErr := json.Unmarshal(body, createRes)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr
@@ -371,7 +371,7 @@ func (svc *MCRServiceOp) ListMCRPrefixFilterLists(ctx context.Context, mcrId str
 		return nil, fileErr
 	}
 
-	prefixFilterList := &ListMCRPrefixFilterListResponse{}
+	prefixFilterList := &listMCRPrefixFilterListResponse{}
 	unmarshalErr := json.Unmarshal(body, prefixFilterList)
 
 	if unmarshalErr != nil {
@@ -402,7 +402,7 @@ func (svc *MCRServiceOp) GetMCRPrefixFilterList(ctx context.Context, mcrID strin
 		return nil, fileErr
 	}
 
-	apiPrefixFilterList := &APIMCRPrefixFilterListResponse{}
+	apiPrefixFilterList := &apiMCRPrefixFilterListResponse{}
 	unmarshalErr := json.Unmarshal(body, apiPrefixFilterList)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -128,15 +128,17 @@ type MCRPrefixListEntry struct {
 	Le     int    `json:"le,omitempty"` // Less than or equal to - (Optional) The maximum ending prefix length to be matched. The prefix length is greater than or equal to the minimum value (ge). Valid values are from 0 to 32 (IPv4), or 0 to 128 (IPv6), but the maximum must be no less than the minimum value (ge).
 }
 
-// MCROrdersResponse represents a response from the Megaport Products API after ordering an MCR.
-type MCROrderResponse struct {
+// mcrOrderResponse represents a response from the Megaport Products API after ordering an MCR.
+// Used internally for JSON unmarshalling.
+type mcrOrderResponse struct {
 	Message string                  `json:"message"`
 	Terms   string                  `json:"terms"`
 	Data    []*MCROrderConfirmation `json:"data"`
 }
 
-// MCRResponse represents a response from the Megaport MCR API after querying an MCR.
-type MCRResponse struct {
+// mcrResponse represents a response from the Megaport MCR API after querying an MCR.
+// Used internally for JSON unmarshalling.
+type mcrResponse struct {
 	Message string `json:"message"`
 	Terms   string `json:"terms"`
 	Data    *MCR   `json:"data"`
@@ -149,21 +151,17 @@ type PrefixFilterList struct {
 	AddressFamily string `json:"addressFamily"`
 }
 
-// CreateMCRPrefixFilterListResponse represents a response from the Megaport MCR API after creating a prefix filter list.
-type CreateMCRPrefixFilterListAPIResponse struct {
-	Message string                  `json:"message"`
-	Terms   string                  `json:"terms"`
-	Data    *APIMCRPrefixFilterList `json:"data"`
-}
-
-// ListMCRPrefixFilterListResponse represents a response from the Megaport MCR API after querying an MCR's prefix filter list.
-type ListMCRPrefixFilterListResponse struct {
+// listMCRPrefixFilterListResponse represents a response from the Megaport MCR API after querying an MCR's prefix filter list.
+// Used internally for JSON unmarshalling.
+type listMCRPrefixFilterListResponse struct {
 	Message string              `json:"message"`
 	Terms   string              `json:"terms"`
 	Data    []*PrefixFilterList `json:"data"`
 }
 
-type APIMCRPrefixFilterListResponse struct {
+// apiMCRPrefixFilterListResponse represents a response from the Megaport MCR API for a single prefix filter list.
+// Used internally for JSON unmarshalling.
+type apiMCRPrefixFilterListResponse struct {
 	Message string                  `json:"message"`
 	Terms   string                  `json:"terms"`
 	Data    *APIMCRPrefixFilterList `json:"data"`

--- a/mve.go
+++ b/mve.go
@@ -116,7 +116,7 @@ func (svc *MVEServiceOp) BuyMVE(ctx context.Context, req *BuyMVERequest) (*BuyMV
 		return nil, err
 	}
 
-	orderInfo := MVEOrderResponse{}
+	orderInfo := mveOrderResponse{}
 
 	if err := json.Unmarshal(*resp, &orderInfo); err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func (svc *MVEServiceOp) GetMVE(ctx context.Context, mveId string) (*MVE, error)
 	if err != nil {
 		return nil, err
 	}
-	mveResp := MVEResponse{}
+	mveResp := mveResponse{}
 	if err := json.Unmarshal(body, &mveResp); err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func (svc *MVEServiceOp) ListAvailableMVESizes(ctx context.Context) ([]*MVESize,
 	if err != nil {
 		return nil, err
 	}
-	sizeResp := MVESizeAPIResponse{}
+	sizeResp := mveSizeAPIResponse{}
 	if err := json.Unmarshal(body, &sizeResp); err != nil {
 		return nil, err
 	}

--- a/mve_types.go
+++ b/mve_types.go
@@ -252,15 +252,17 @@ type MVEVirtualMachineImage struct {
 	Version string `json:"version"`
 }
 
-// MVEOrderResponse represents the response to an MVE order request.
-type MVEOrderResponse struct {
+// mveOrderResponse represents the response to an MVE order request.
+// Used internally for JSON unmarshalling.
+type mveOrderResponse struct {
 	Message string                  `json:"message"`
 	Terms   string                  `json:"terms"`
 	Data    []*MVEOrderConfirmation `json:"data"`
 }
 
-// MVEResponse represents the response to an MVE request.
-type MVEResponse struct {
+// mveResponse represents the response to an MVE request.
+// Used internally for JSON unmarshalling.
+type mveResponse struct {
 	Message string `json:"message"`
 	Terms   string `json:"terms"`
 	Data    *MVE   `json:"data"`
@@ -337,8 +339,9 @@ type MVESize struct {
 	RamGB        int    `json:"ramGB"`
 }
 
-// MVESizeAPIResponse represents the response to an MVE size request, returning a list of currently available MVE sizes and details for each size.
-type MVESizeAPIResponse struct {
+// mveSizeAPIResponse represents the response to an MVE size request, returning a list of currently available MVE sizes and details for each size.
+// Used internally for JSON unmarshalling.
+type mveSizeAPIResponse struct {
 	Message string     `json:"message"`
 	Terms   string     `json:"terms"`
 	Data    []*MVESize `json:"data"`

--- a/partner.go
+++ b/partner.go
@@ -55,7 +55,7 @@ func (svc *PartnerServiceOp) ListPartnerMegaports(ctx context.Context) ([]*Partn
 		return nil, fileErr
 	}
 
-	partnerMegaportResponse := PartnerMegaportResponse{}
+	partnerMegaportResponse := partnerMegaportResponse{}
 	unmarshalErr := json.Unmarshal(body, &partnerMegaportResponse)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr

--- a/partner.go
+++ b/partner.go
@@ -55,13 +55,13 @@ func (svc *PartnerServiceOp) ListPartnerMegaports(ctx context.Context) ([]*Partn
 		return nil, fileErr
 	}
 
-	partnerMegaportResponse := partnerMegaportResponse{}
-	unmarshalErr := json.Unmarshal(body, &partnerMegaportResponse)
+	partnerResp := partnerMegaportResponse{}
+	unmarshalErr := json.Unmarshal(body, &partnerResp)
 	if unmarshalErr != nil {
 		return nil, unmarshalErr
 	}
 
-	return partnerMegaportResponse.Data, nil
+	return partnerResp.Data, nil
 }
 
 // FilterPartnerMegaportByProductName filters a list of partner megaports by product name in the Megaport API.

--- a/partner_types.go
+++ b/partner_types.go
@@ -1,14 +1,16 @@
 package megaport
 
-// PartnerLookupResponse represents a response from the Megaport API after looking up a Partner Megaport.
-type PartnerLookupResponse struct {
+// partnerLookupResponse represents a response from the Megaport API after looking up a Partner Megaport.
+// Used internally for JSON unmarshalling.
+type partnerLookupResponse struct {
 	Message string        `json:"message"`
 	Data    PartnerLookup `json:"data"`
 	Terms   string        `json:"terms"`
 }
 
-// PartnerMegaportResponse represents a response from the Megaport API after querying a Partner Megaport.
-type PartnerMegaportResponse struct {
+// partnerMegaportResponse represents a response from the Megaport API after querying a Partner Megaport.
+// Used internally for JSON unmarshalling.
+type partnerMegaportResponse struct {
 	Message string             `json:"message"`
 	Terms   string             `json:"terms"`
 	Data    []*PartnerMegaport `json:"data"`

--- a/product.go
+++ b/product.go
@@ -197,15 +197,15 @@ func (svc *ProductServiceOp) ListProducts(ctx context.Context) ([]Product, error
 
 	for i, rawProduct := range parsed.Data {
 		// First extract just the type field
-		var pp parsedProduct
+		var productMeta parsedProduct
 
-		if err := json.Unmarshal(rawProduct, &pp); err != nil {
+		if err := json.Unmarshal(rawProduct, &productMeta); err != nil {
 			svc.Client.Logger.WarnContext(ctx, fmt.Sprintf("Item %d: Could not extract product type: %v", i, err))
 			continue
 		}
 
 		// Then unmarshal into the appropriate struct based on type
-		switch strings.ToLower(pp.Type) {
+		switch strings.ToLower(productMeta.Type) {
 		case PRODUCT_MEGAPORT:
 			var port Port
 			if err := json.Unmarshal(rawProduct, &port); err != nil {
@@ -432,16 +432,16 @@ func (svc *ProductServiceOp) GetProductType(ctx context.Context, productUID stri
 	// and then return that type.
 	// The response body is expected to be in JSON format.
 
-	var gpr getProductResponse
-	err = json.NewDecoder(response.Body).Decode(&gpr)
+	var productResp getProductResponse
+	err = json.NewDecoder(response.Body).Decode(&productResp)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode response: %w", err)
 	}
-	pp := gpr.Data
+	productData := productResp.Data
 
-	if pp.Type == "" {
+	if productData.Type == "" {
 		return "", fmt.Errorf("product %s type not found in response", productUID)
 	}
 
-	return pp.Type, nil
+	return productData.Type, nil
 }

--- a/user_management.go
+++ b/user_management.go
@@ -93,13 +93,15 @@ func (req *CreateUserRequest) Validate() error {
 	return nil
 }
 
-// CreateUserAPIResponse represents the API response when creating a new user.
-type CreateUserAPIResponse struct {
+// createUserAPIResponse represents the API response when creating a new user.
+// Used internally for JSON unmarshalling.
+type createUserAPIResponse struct {
 	Message string              `json:"message"`
 	Terms   string              `json:"terms"`
 	Data    *CreateUserResponse `json:"data"`
 }
 
+// CreateUserResponse represents the data returned when creating a new user.
 type CreateUserResponse struct {
 	CompanyID    int `json:"companyId"`
 	EmploymentID int `json:"employmentId"`
@@ -241,7 +243,7 @@ func (svc *UserManagementServiceOp) CreateUser(ctx context.Context, req *CreateU
 		return nil, fmt.Errorf("failed to create user: HTTP %d - %s", response.StatusCode, string(body))
 	}
 
-	var apiResponse *CreateUserAPIResponse
+	var apiResponse *createUserAPIResponse
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
 		return nil, err
 	}

--- a/vxc.go
+++ b/vxc.go
@@ -168,7 +168,7 @@ func (svc *VXCServiceOp) BuyVXC(ctx context.Context, req *BuyVXCRequest) (*BuyVX
 		return nil, responseError
 	}
 
-	orderInfo := VXCOrderResponse{}
+	orderInfo := vxcOrderResponse{}
 	if err := json.Unmarshal(*responseBody, &orderInfo); err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (svc *VXCServiceOp) GetVXC(ctx context.Context, id string) (*VXC, error) {
 		return nil, err
 	}
 
-	vxcDetails := VXCResponse{}
+	vxcDetails := vxcResponse{}
 	if err = json.Unmarshal(body, &vxcDetails); err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVX
 		return nil, err
 	}
 
-	vxcDetails := VXCResponse{}
+	vxcDetails := vxcResponse{}
 	if err = json.Unmarshal(body, &vxcDetails); err != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (svc *VXCServiceOp) LookupPartnerPorts(ctx context.Context, req *LookupPart
 		return nil, fileErr
 	}
 
-	lookupResponse := PartnerLookupResponse{}
+	lookupResponse := partnerLookupResponse{}
 	parseErr := json.Unmarshal(body, &lookupResponse)
 
 	if parseErr != nil {
@@ -483,7 +483,7 @@ func (svc *VXCServiceOp) ListPartnerPorts(ctx context.Context, req *ListPartnerP
 		return nil, fileErr
 	}
 
-	lookupResponse := PartnerLookupResponse{}
+	lookupResponse := partnerLookupResponse{}
 	parseErr := json.Unmarshal(body, &lookupResponse)
 
 	if parseErr != nil {

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -197,15 +197,17 @@ type VXCUpdate struct {
 	BEndPartnerConfig VXCPartnerConfiguration `json:"bEndConfig,omitempty"`
 }
 
-// VXCOrderResponse represents the response from the VXC Order API.
-type VXCOrderResponse struct {
+// vxcOrderResponse represents the response from the VXC Order API.
+// Used internally for JSON unmarshalling.
+type vxcOrderResponse struct {
 	Message string                 `json:"message"`
 	Terms   string                 `json:"terms"`
 	Data    []VXCOrderConfirmation `json:"data"`
 }
 
-// VXCResponse represents the response from the VXC API.
-type VXCResponse struct {
+// vxcResponse represents the response from the VXC API.
+// Used internally for JSON unmarshalling.
+type vxcResponse struct {
 	Message string `json:"message"`
 	Terms   string `json:"terms"`
 	Data    VXC    `json:"data"`


### PR DESCRIPTION
## Summary

Unexports response types that are only used internally for JSON unmarshaling. These were never meant for external use — consumers work with the actual data types (`Location`, `LocationV3`, `Country`, …) returned from public methods, not the raw API response wrappers.

### Unexported

| File | Types |
| --- | --- |
| location.go | `locationResponse`, `locationV3Response`, `countryResponse`, `countryInnerResponse` |
| client.go | `accessTokenResponse` |
| partner_types.go | `partnerLookupResponse`, `partnerMegaportResponse` |
| ix_types.go | `ixResponse` |
| managed_account.go | `managedAccountAPIResponse`, `managedAccountListAPIResponse` |
| mve_types.go | `mveOrderResponse`, `mveResponse`, `mveSizeAPIResponse` |
| mcr_types.go | `mcrOrderResponse`, `mcrResponse`, `listMCRPrefixFilterListResponse`, `apiMCRPrefixFilterListResponse` |
| vxc_types.go | `vxcOrderResponse`, `vxcResponse` |
| user_management.go | `createUserAPIResponse` |
| product.go | `parsedProductsResponse`, `getProductResponse`, `parsedProduct`, `resourceTagsResponse`, `resourceTagsResponseData` |

Also removed `CreateMCRPrefixFilterListAPIResponse` — dead code, completely unused.

### Still exported

Types returned from public methods or used by consumers stay exported: `CreateUserResponse`, `ErrorResponse` (used by terraform-provider-megaport), and all `Buy*` / `Modify*` / `Delete*` / `Restore*Response` types.

### Breaking change

Technically breaking if an external consumer imported these directly, but they had no practical external use, so it's extremely unlikely — and any such usage fails at compile time with an obvious fix (the data is still reachable via the public methods). Confirmed no usage in `megaport-cli` or `terraform-provider-megaport`.
