### PR TITLE
fix(vxc): auto-populate PortUID from AEndConfiguration.ProductUID whe…

### DIFF
--- a/vxc.go
+++ b/vxc.go
@@ -260,8 +260,15 @@ func (svc *VXCServiceOp) UpdateVXCResourceTags(ctx context.Context, vxcID string
 }
 
 func createVXCOrder(req *BuyVXCRequest) []VXCOrder {
+	// If PortUID is not set but AEndConfiguration.ProductUID is, use it as the PortUID
+	// This improves DX by not requiring the same value in two places
+	portUID := req.PortUID
+	if portUID == "" && req.AEndConfiguration.ProductUID != "" {
+		portUID = req.AEndConfiguration.ProductUID
+	}
+
 	return []VXCOrder{{
-		PortID: req.PortUID,
+		PortID: portUID,
 		AssociatedVXCs: []VXCOrderConfiguration{
 			{
 				Name:         req.VXCName,

--- a/vxc.go
+++ b/vxc.go
@@ -260,8 +260,9 @@ func (svc *VXCServiceOp) UpdateVXCResourceTags(ctx context.Context, vxcID string
 }
 
 func createVXCOrder(req *BuyVXCRequest) []VXCOrder {
-	// If PortUID is not set but AEndConfiguration.ProductUID is, use it as the PortUID
-	// This improves the developer experience by not requiring the same value in two places
+	// If PortUID is not set but AEndConfiguration.ProductUID is, use that fallback
+	// value when populating VXCOrder.PortID. This improves the developer
+	// experience by not requiring the same value in two places.
 	portUID := req.PortUID
 	if portUID == "" && req.AEndConfiguration.ProductUID != "" {
 		portUID = req.AEndConfiguration.ProductUID

--- a/vxc.go
+++ b/vxc.go
@@ -261,7 +261,7 @@ func (svc *VXCServiceOp) UpdateVXCResourceTags(ctx context.Context, vxcID string
 
 func createVXCOrder(req *BuyVXCRequest) []VXCOrder {
 	// If PortUID is not set but AEndConfiguration.ProductUID is, use it as the PortUID
-	// This improves DX by not requiring the same value in two places
+	// This improves the developer experience by not requiring the same value in two places
 	portUID := req.PortUID
 	if portUID == "" && req.AEndConfiguration.ProductUID != "" {
 		portUID = req.AEndConfiguration.ProductUID

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -69,6 +69,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			orders := createVXCOrder(tt.req)
 

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,9 +18,9 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		req            *BuyVXCRequest
-		expectedPortID string
+		name            string
+		req             *BuyVXCRequest
+		expectedPortUID string
 	}{
 		{
 			name: "PortUID is set explicitly - should use PortUID",
@@ -32,7 +31,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "a-end-product-uid",
 				},
 			},
-			expectedPortID: "explicit-port-uid",
+			expectedPortUID: "explicit-port-uid",
 		},
 		{
 			name: "PortUID is empty but AEndConfiguration.ProductUID is set - should use AEndConfiguration.ProductUID",
@@ -43,7 +42,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "a-end-product-uid",
 				},
 			},
-			expectedPortID: "a-end-product-uid",
+			expectedPortUID: "a-end-product-uid",
 		},
 		{
 			name: "Both PortUID and AEndConfiguration.ProductUID are empty - should remain empty",
@@ -54,7 +53,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "",
 				},
 			},
-			expectedPortID: "",
+			expectedPortUID: "",
 		},
 		{
 			name: "PortUID is set and AEndConfiguration.ProductUID is empty - should use PortUID",
@@ -65,7 +64,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "",
 				},
 			},
-			expectedPortID: "explicit-port-uid",
+			expectedPortUID: "explicit-port-uid",
 		},
 	}
 
@@ -73,10 +72,12 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			orders := createVXCOrder(tt.req)
 
-			if !assert.Len(t, orders, 1, "Expected exactly one VXC order") {
-				return
+			if len(orders) != 1 {
+				t.Fatalf("expected exactly one VXC order, got %d", len(orders))
 			}
-			assert.Equal(t, tt.expectedPortID, orders[0].PortID, "PortID mismatch")
+			if orders[0].PortID != tt.expectedPortUID {
+				t.Errorf("PortID mismatch: got %q, want %q", orders[0].PortID, tt.expectedPortUID)
+			}
 		})
 	}
 }

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -18,8 +18,8 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		req             *BuyVXCRequest
+		name           string
+		req            *BuyVXCRequest
 		expectedPortID string
 	}{
 		{

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -20,7 +20,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 	tests := []struct {
 		name            string
 		req             *BuyVXCRequest
-		expectedPortUID string
+		expectedPortID string
 	}{
 		{
 			name: "PortUID is set explicitly - should use PortUID",
@@ -31,7 +31,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "a-end-product-uid",
 				},
 			},
-			expectedPortUID: "explicit-port-uid",
+			expectedPortID: "explicit-port-uid",
 		},
 		{
 			name: "PortUID is empty but AEndConfiguration.ProductUID is set - should use AEndConfiguration.ProductUID",
@@ -42,7 +42,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "a-end-product-uid",
 				},
 			},
-			expectedPortUID: "a-end-product-uid",
+			expectedPortID: "a-end-product-uid",
 		},
 		{
 			name: "Both PortUID and AEndConfiguration.ProductUID are empty - should remain empty",
@@ -53,7 +53,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "",
 				},
 			},
-			expectedPortUID: "",
+			expectedPortID: "",
 		},
 		{
 			name: "PortUID is set and AEndConfiguration.ProductUID is empty - should use PortUID",
@@ -64,7 +64,7 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 					ProductUID: "",
 				},
 			},
-			expectedPortUID: "explicit-port-uid",
+			expectedPortID: "explicit-port-uid",
 		},
 	}
 
@@ -76,8 +76,8 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 			if len(orders) != 1 {
 				t.Fatalf("expected exactly one VXC order, got %d", len(orders))
 			}
-			if orders[0].PortID != tt.expectedPortUID {
-				t.Errorf("PortID mismatch: got %q, want %q", orders[0].PortID, tt.expectedPortUID)
+			if orders[0].PortID != tt.expectedPortID {
+				t.Errorf("PortID mismatch: got %q, want %q", orders[0].PortID, tt.expectedPortID)
 			}
 		})
 	}

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -73,7 +73,9 @@ func TestCreateVXCOrder_PortUIDAutoPopulation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			orders := createVXCOrder(tt.req)
 
-			assert.Len(t, orders, 1, "Expected exactly one VXC order")
+			if !assert.Len(t, orders, 1, "Expected exactly one VXC order") {
+				return
+			}
 			assert.Equal(t, tt.expectedPortID, orders[0].PortID, "PortID mismatch")
 		})
 	}


### PR DESCRIPTION
…n not set

When creating a VXC order, users previously had to specify both `PortUID` and `AEndConfiguration.ProductUID` even though they're typically the same value. This change automatically uses `AEndConfiguration.ProductUID` as the `PortUID` when `PortUID` is not explicitly set. This reduces redundancy and prevents confusing `"Valid A-End is required"` validation errors. The explicit `PortUID` field still takes precedence if set, maintaining backward compatibility.
