### PR TITLE
feat: add support for /v3/order_approvals API endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,6 +89,8 @@ type Client struct {
 	IXService IXService
 	// BillingMarketService provides methods for interacting with the Billing Market API
 	BillingMarketService BillingMarketService
+	// OrderApprovalService provides methods for interacting with the Order Approvals API
+	OrderApprovalService OrderApprovalService
 
 	accessToken string    // Access Token for client
 	tokenExpiry time.Time // Token Expiration
@@ -186,6 +188,7 @@ func NewClient(httpClient *http.Client, base *url.URL) *Client {
 	c.ManagedAccountService = NewManagedAccountService(c)
 	c.BillingMarketService = NewBillingMarketService(c)
 	c.UserManagementService = NewUserManagementService(c)
+	c.OrderApprovalService = NewOrderApprovalService(c)
 
 	c.headers = make(map[string]string)
 

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -118,7 +118,7 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 	if req == nil {
 		req = &ListOrderApprovalsRequest{}
 	}
-	path := "/v3/order_approvals"
+	path := "v3/order_approvals"
 	params := url.Values{}
 	if req.Status != nil {
 		params.Add("status", string(*req.Status))

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -85,8 +85,8 @@ type OrderApproval struct {
 type ListOrderApprovalsRequest struct {
 	Status     *OrderApprovalStatus // Filter by approval status (optional).
 	ServiceIDs []int                // Filter by service IDs (optional).
-	PageNumber *int                 // Page number for pagination (default 1).
-	PageSize   *int                 // Page size for pagination (1-100, default 10).
+	PageNumber *int                 // Page number for pagination; if nil, the API default is used.
+	PageSize   *int                 // Page size for pagination; if nil, the API default is used.
 	Sort       *string              // Field to sort by (optional).
 	Direction  *string              // Sort direction: ASC or DESC (default DESC).
 }

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -1,0 +1,224 @@
+package megaport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// OrderApprovalStatus represents the status of an order approval.
+type OrderApprovalStatus string
+
+const (
+	OrderApprovalStatusPending   OrderApprovalStatus = "PENDING"
+	OrderApprovalStatusApproved  OrderApprovalStatus = "APPROVED"
+	OrderApprovalStatusRejected  OrderApprovalStatus = "REJECTED"
+	OrderApprovalStatusFailed    OrderApprovalStatus = "FAILED"
+	OrderApprovalStatusWithdrawn OrderApprovalStatus = "WITHDRAWN"
+	OrderApprovalStatusExpired   OrderApprovalStatus = "EXPIRED"
+)
+
+// OrderApprovalType represents the type of an order approval.
+type OrderApprovalType string
+
+const (
+	OrderApprovalTypeNewOrder    OrderApprovalType = "NEW_ORDER"
+	OrderApprovalTypeTermChange  OrderApprovalType = "TERM_CHANGE"
+	OrderApprovalTypeSpeedChange OrderApprovalType = "SPEED_CHANGE"
+)
+
+// OrderApprovalService is an interface for interfacing with the Order Approval endpoints in the Megaport API.
+type OrderApprovalService interface {
+	// ListOrderApprovals lists order approval requests from the Megaport API.
+	ListOrderApprovals(ctx context.Context, req *ListOrderApprovalsRequest) (*ListOrderApprovalsResponse, error)
+	// ApproveOrderApproval approves a pending order approval request.
+	ApproveOrderApproval(ctx context.Context, orderApprovalUID string, req *OrderApprovalActionRequest) error
+	// RejectOrderApproval rejects a pending order approval request.
+	RejectOrderApproval(ctx context.Context, orderApprovalUID string, req *OrderApprovalActionRequest) error
+	// WithdrawOrderApproval withdraws own pending order approval request.
+	WithdrawOrderApproval(ctx context.Context, orderApprovalUID string, req *OrderApprovalActionRequest) error
+}
+
+// NewOrderApprovalService creates a new instance of the Order Approval Service.
+func NewOrderApprovalService(c *Client) *OrderApprovalServiceOp {
+	return &OrderApprovalServiceOp{
+		Client: c,
+	}
+}
+
+var _ OrderApprovalService = &OrderApprovalServiceOp{}
+
+// OrderApprovalServiceOp handles communication with the Order Approval related methods of the Megaport API.
+type OrderApprovalServiceOp struct {
+	Client *Client
+}
+
+// OrderApproval represents an order approval from the Megaport API.
+type OrderApproval struct {
+	UID                string              `json:"uid"`
+	ID                 int                 `json:"id"`
+	ReferenceID        string              `json:"referenceId"`
+	Status             OrderApprovalStatus `json:"status"`
+	Type               OrderApprovalType   `json:"type"`
+	Active             bool                `json:"active"`
+	AcctName           string              `json:"acctName"`
+	AcctRef            string              `json:"acctRef"`
+	ApproverCompanyID  int                 `json:"approverCompanyId"`
+	RequesterCompanyID int                 `json:"requesterCompanyId"`
+	ServiceID          int                 `json:"serviceId"`
+	Comment            string              `json:"comment"`
+	CreateDate         int64               `json:"createDate"`
+	Detail             json.RawMessage     `json:"detail"`
+}
+
+// ListOrderApprovalsRequest represents a request to list order approvals from the Megaport API.
+type ListOrderApprovalsRequest struct {
+	Status     *OrderApprovalStatus // Filter by approval status (optional).
+	ServiceIDs []int                // Filter by service IDs (optional).
+	PageNumber *int                 // Page number for pagination (default 1).
+	PageSize   *int                 // Page size for pagination (1-100, default 10).
+	Sort       *string              // Field to sort by (optional).
+	Direction  *string              // Sort direction: ASC or DESC (default DESC).
+}
+
+// ListOrderApprovalsAPIResponse represents the Megaport API HTTP response from listing order approvals.
+type ListOrderApprovalsAPIResponse struct {
+	Message string           `json:"message"`
+	Terms   string           `json:"terms"`
+	Data    []*OrderApproval `json:"data"`
+}
+
+// ListOrderApprovalsResponse represents the Go SDK response from listing order approvals.
+type ListOrderApprovalsResponse struct {
+	OrderApprovals []*OrderApproval
+	TotalCount     int
+	Page           int
+	Limit          int
+	TotalPages     int
+}
+
+// OrderApprovalActionRequest represents a request to approve, reject, or withdraw an order approval.
+type OrderApprovalActionRequest struct {
+	Comments string `json:"comments,omitempty"`
+}
+
+// OrderApprovalActionAPIResponse represents the Megaport API HTTP response from an order approval action.
+type OrderApprovalActionAPIResponse struct {
+	Message string `json:"message"`
+	Terms   string `json:"terms"`
+	Data    string `json:"data"`
+}
+
+// ListOrderApprovals lists order approval requests from the Megaport API.
+func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *ListOrderApprovalsRequest) (*ListOrderApprovalsResponse, error) {
+	path := "/v3/order_approvals"
+	params := url.Values{}
+	if req.Status != nil {
+		params.Add("status", string(*req.Status))
+	}
+	if len(req.ServiceIDs) > 0 {
+		ids := make([]string, len(req.ServiceIDs))
+		for i, id := range req.ServiceIDs {
+			ids[i] = strconv.Itoa(id)
+		}
+		params.Add("serviceIds", strings.Join(ids, ","))
+	}
+	if req.PageNumber != nil {
+		params.Add("pageNumber", strconv.Itoa(*req.PageNumber))
+	}
+	if req.PageSize != nil {
+		params.Add("pageSize", strconv.Itoa(*req.PageSize))
+	}
+	if req.Sort != nil {
+		params.Add("sort", *req.Sort)
+	}
+	if req.Direction != nil {
+		params.Add("direction", *req.Direction)
+	}
+
+	u := svc.Client.BaseURL.JoinPath(path)
+	if len(params) > 0 {
+		u.RawQuery = params.Encode()
+	}
+	urlString := u.String()
+
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, urlString, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, resErr := svc.Client.Do(ctx, clientReq, nil)
+	if resErr != nil {
+		return nil, resErr
+	}
+	defer response.Body.Close()
+
+	svc.Client.Logger.DebugContext(ctx, "Listing Order Approvals", slog.String("url", urlString), slog.Int("status_code", response.StatusCode))
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	var apiResponse ListOrderApprovalsAPIResponse
+	if err = json.Unmarshal(body, &apiResponse); err != nil {
+		return nil, err
+	}
+
+	toReturn := &ListOrderApprovalsResponse{
+		OrderApprovals: apiResponse.Data,
+	}
+
+	if v := response.Header.Get("Pagination-Total-Count"); v != "" {
+		toReturn.TotalCount, _ = strconv.Atoi(v)
+	}
+	if v := response.Header.Get("Pagination-Page"); v != "" {
+		toReturn.Page, _ = strconv.Atoi(v)
+	}
+	if v := response.Header.Get("Pagination-Limit"); v != "" {
+		toReturn.Limit, _ = strconv.Atoi(v)
+	}
+	if v := response.Header.Get("Pagination-Total-Page"); v != "" {
+		toReturn.TotalPages, _ = strconv.Atoi(v)
+	}
+
+	return toReturn, nil
+}
+
+// ApproveOrderApproval approves a pending order approval request.
+func (svc *OrderApprovalServiceOp) ApproveOrderApproval(ctx context.Context, orderApprovalUID string, req *OrderApprovalActionRequest) error {
+	return svc.doAction(ctx, orderApprovalUID, "approve", req)
+}
+
+// RejectOrderApproval rejects a pending order approval request.
+func (svc *OrderApprovalServiceOp) RejectOrderApproval(ctx context.Context, orderApprovalUID string, req *OrderApprovalActionRequest) error {
+	return svc.doAction(ctx, orderApprovalUID, "reject", req)
+}
+
+// WithdrawOrderApproval withdraws own pending order approval request.
+func (svc *OrderApprovalServiceOp) WithdrawOrderApproval(ctx context.Context, orderApprovalUID string, req *OrderApprovalActionRequest) error {
+	return svc.doAction(ctx, orderApprovalUID, "withdraw", req)
+}
+
+func (svc *OrderApprovalServiceOp) doAction(ctx context.Context, orderApprovalUID string, action string, req *OrderApprovalActionRequest) error {
+	path := fmt.Sprintf("/v3/order_approvals/%s/%s", orderApprovalUID, action)
+	u := svc.Client.BaseURL.JoinPath(path).String()
+
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPost, u, req)
+	if err != nil {
+		return err
+	}
+	response, resErr := svc.Client.Do(ctx, clientReq, nil)
+	if resErr != nil {
+		return resErr
+	}
+	if response != nil {
+		svc.Client.Logger.DebugContext(ctx, fmt.Sprintf("Order Approval %s", action), slog.String("url", u), slog.Int("status_code", response.StatusCode))
+		defer response.Body.Close()
+	}
+	return nil
+}

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -118,7 +118,7 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 	if req == nil {
 		req = &ListOrderApprovalsRequest{}
 	}
-	path := "v3/order_approvals"
+	path := "/v3/order_approvals"
 	params := url.Values{}
 	if req.Status != nil {
 		params.Add("status", string(*req.Status))
@@ -143,13 +143,11 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 		params.Add("direction", *req.Direction)
 	}
 
-	u := svc.Client.BaseURL.JoinPath(path)
 	if len(params) > 0 {
-		u.RawQuery = params.Encode()
+		path = path + "?" + params.Encode()
 	}
-	urlString := u.String()
 
-	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, urlString, nil)
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +158,7 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 	}
 	defer response.Body.Close()
 
-	svc.Client.Logger.DebugContext(ctx, "Listing Order Approvals", slog.String("url", urlString), slog.Int("status_code", response.StatusCode))
+	svc.Client.Logger.DebugContext(ctx, "Listing Order Approvals", slog.String("url", path), slog.Int("status_code", response.StatusCode))
 
 	var apiResponse ListOrderApprovalsAPIResponse
 	if err = json.Unmarshal(buf.Bytes(), &apiResponse); err != nil {

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -227,7 +228,7 @@ func (svc *OrderApprovalServiceOp) doAction(ctx context.Context, orderApprovalUI
 	if err != nil {
 		return err
 	}
-	response, resErr := svc.Client.Do(ctx, clientReq, nil)
+	response, resErr := svc.Client.Do(ctx, clientReq, io.Discard)
 	if resErr != nil {
 		return resErr
 	}

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -78,7 +78,7 @@ type OrderApproval struct {
 	RequesterCompanyID int                 `json:"requesterCompanyId"`
 	ServiceID          int                 `json:"serviceId"`
 	Comment            string              `json:"comment"`
-	CreateDate         int64               `json:"createDate"`
+	CreateDate         *Time               `json:"createDate"`
 	Detail             json.RawMessage     `json:"detail"`
 }
 

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -1,10 +1,10 @@
 package megaport
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -145,7 +145,8 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 	if err != nil {
 		return nil, err
 	}
-	response, resErr := svc.Client.Do(ctx, clientReq, nil)
+	var buf bytes.Buffer
+	response, resErr := svc.Client.Do(ctx, clientReq, &buf)
 	if resErr != nil {
 		return nil, resErr
 	}
@@ -153,12 +154,8 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 
 	svc.Client.Logger.DebugContext(ctx, "Listing Order Approvals", slog.String("url", urlString), slog.Int("status_code", response.StatusCode))
 
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
 	var apiResponse ListOrderApprovalsAPIResponse
-	if err = json.Unmarshal(body, &apiResponse); err != nil {
+	if err = json.Unmarshal(buf.Bytes(), &apiResponse); err != nil {
 		return nil, err
 	}
 

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -108,13 +108,6 @@ type OrderApprovalActionRequest struct {
 	Comments string `json:"comments,omitempty"`
 }
 
-// OrderApprovalActionAPIResponse represents the Megaport API HTTP response from an order approval action.
-type OrderApprovalActionAPIResponse struct {
-	Message string `json:"message"`
-	Terms   string `json:"terms"`
-	Data    string `json:"data"`
-}
-
 // ListOrderApprovals lists order approval requests from the Megaport API.
 func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *ListOrderApprovalsRequest) (*ListOrderApprovalsResponse, error) {
 	path := "/v3/order_approvals"
@@ -174,16 +167,32 @@ func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *
 	}
 
 	if v := response.Header.Get("Pagination-Total-Count"); v != "" {
-		toReturn.TotalCount, _ = strconv.Atoi(v)
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Pagination-Total-Count header %q: %w", v, err)
+		}
+		toReturn.TotalCount = n
 	}
 	if v := response.Header.Get("Pagination-Page"); v != "" {
-		toReturn.Page, _ = strconv.Atoi(v)
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Pagination-Page header %q: %w", v, err)
+		}
+		toReturn.Page = n
 	}
 	if v := response.Header.Get("Pagination-Limit"); v != "" {
-		toReturn.Limit, _ = strconv.Atoi(v)
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Pagination-Limit header %q: %w", v, err)
+		}
+		toReturn.Limit = n
 	}
 	if v := response.Header.Get("Pagination-Total-Page"); v != "" {
-		toReturn.TotalPages, _ = strconv.Atoi(v)
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Pagination-Total-Page header %q: %w", v, err)
+		}
+		toReturn.TotalPages = n
 	}
 
 	return toReturn, nil
@@ -205,7 +214,7 @@ func (svc *OrderApprovalServiceOp) WithdrawOrderApproval(ctx context.Context, or
 }
 
 func (svc *OrderApprovalServiceOp) doAction(ctx context.Context, orderApprovalUID string, action string, req *OrderApprovalActionRequest) error {
-	path := fmt.Sprintf("/v3/order_approvals/%s/%s", orderApprovalUID, action)
+	path := fmt.Sprintf("/v3/order_approvals/%s/%s", url.PathEscape(orderApprovalUID), action)
 	u := svc.Client.BaseURL.JoinPath(path).String()
 
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPost, u, req)

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -221,8 +221,7 @@ func (svc *OrderApprovalServiceOp) doAction(ctx context.Context, orderApprovalUI
 	if orderApprovalUID == "" {
 		return ErrOrderApprovalUIDRequired
 	}
-	path := fmt.Sprintf("/v3/order_approvals/%s/%s", url.PathEscape(orderApprovalUID), action)
-	u := svc.Client.BaseURL.JoinPath(path).String()
+	u := svc.Client.BaseURL.JoinPath("v3", "order_approvals", orderApprovalUID, action).String()
 
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPost, u, req)
 	if err != nil {

--- a/order_approvals.go
+++ b/order_approvals.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -59,6 +60,9 @@ type OrderApprovalServiceOp struct {
 	Client *Client
 }
 
+// ErrOrderApprovalUIDRequired is returned when an order approval UID is not provided.
+var ErrOrderApprovalUIDRequired = errors.New("order approval UID is required")
+
 // OrderApproval represents an order approval from the Megaport API.
 type OrderApproval struct {
 	UID                string              `json:"uid"`
@@ -110,6 +114,9 @@ type OrderApprovalActionRequest struct {
 
 // ListOrderApprovals lists order approval requests from the Megaport API.
 func (svc *OrderApprovalServiceOp) ListOrderApprovals(ctx context.Context, req *ListOrderApprovalsRequest) (*ListOrderApprovalsResponse, error) {
+	if req == nil {
+		req = &ListOrderApprovalsRequest{}
+	}
 	path := "/v3/order_approvals"
 	params := url.Values{}
 	if req.Status != nil {
@@ -211,6 +218,9 @@ func (svc *OrderApprovalServiceOp) WithdrawOrderApproval(ctx context.Context, or
 }
 
 func (svc *OrderApprovalServiceOp) doAction(ctx context.Context, orderApprovalUID string, action string, req *OrderApprovalActionRequest) error {
+	if orderApprovalUID == "" {
+		return ErrOrderApprovalUIDRequired
+	}
 	path := fmt.Sprintf("/v3/order_approvals/%s/%s", url.PathEscape(orderApprovalUID), action)
 	u := svc.Client.BaseURL.JoinPath(path).String()
 

--- a/order_approvals_test.go
+++ b/order_approvals_test.go
@@ -85,7 +85,7 @@ func (suite *OrderApprovalClientTestSuite) TestListOrderApprovals() {
 				RequesterCompanyID: 200,
 				ServiceID:          5678,
 				Comment:            "Please approve this order",
-				CreateDate:         1700000000000,
+				CreateDate:         &Time{GetTime(1700000000000)},
 				Detail:             json.RawMessage(`{"type": "NEW_ORDER", "origin": "https://portal.megaport.com", "userName": "user@example.com", "requesterCompanyId": 200, "productRequest": [{"name": "test"}]}`),
 			},
 		},

--- a/order_approvals_test.go
+++ b/order_approvals_test.go
@@ -168,6 +168,7 @@ func (suite *OrderApprovalClientTestSuite) TestListOrderApprovalsInvalidPaginati
 	}`
 
 	suite.mux.HandleFunc("/v3/order_approvals", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
 		w.Header().Set("Pagination-Total-Count", "not-a-number")
 		fmt.Fprint(w, jblob)
 	})

--- a/order_approvals_test.go
+++ b/order_approvals_test.go
@@ -1,0 +1,213 @@
+package megaport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type OrderApprovalClientTestSuite struct {
+	ClientTestSuite
+}
+
+func TestOrderApprovalClientTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(OrderApprovalClientTestSuite))
+}
+
+func (suite *OrderApprovalClientTestSuite) SetupTest() {
+	suite.mux = http.NewServeMux()
+	suite.server = httptest.NewServer(suite.mux)
+
+	suite.client = NewClient(nil, nil)
+	url, _ := url.Parse(suite.server.URL)
+	suite.client.BaseURL = url
+}
+
+func (suite *OrderApprovalClientTestSuite) TearDownTest() {
+	suite.server.Close()
+}
+
+func (suite *OrderApprovalClientTestSuite) TestListOrderApprovals() {
+	ctx := context.Background()
+	status := OrderApprovalStatusPending
+	pageNumber := 1
+	pageSize := 10
+
+	listReq := &ListOrderApprovalsRequest{
+		Status:     &status,
+		PageNumber: &pageNumber,
+		PageSize:   &pageSize,
+	}
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": [
+			{
+				"uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+				"id": 12345,
+				"referenceId": "ORD-54321-45",
+				"status": "PENDING",
+				"type": "NEW_ORDER",
+				"active": true,
+				"acctName": "Test Company",
+				"acctRef": "ACCT-001",
+				"approverCompanyId": 100,
+				"requesterCompanyId": 200,
+				"serviceId": 5678,
+				"comment": "Please approve this order",
+				"createDate": 1700000000000,
+				"detail": {"type": "NEW_ORDER", "origin": "https://portal.megaport.com", "userName": "user@example.com", "requesterCompanyId": 200, "productRequest": [{"name": "test"}]}
+			}
+		]
+	}`
+
+	want := &ListOrderApprovalsResponse{
+		OrderApprovals: []*OrderApproval{
+			{
+				UID:                "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+				ID:                 12345,
+				ReferenceID:        "ORD-54321-45",
+				Status:             OrderApprovalStatusPending,
+				Type:               OrderApprovalTypeNewOrder,
+				Active:             true,
+				AcctName:           "Test Company",
+				AcctRef:            "ACCT-001",
+				ApproverCompanyID:  100,
+				RequesterCompanyID: 200,
+				ServiceID:          5678,
+				Comment:            "Please approve this order",
+				CreateDate:         1700000000000,
+				Detail:             json.RawMessage(`{"type": "NEW_ORDER", "origin": "https://portal.megaport.com", "userName": "user@example.com", "requesterCompanyId": 200, "productRequest": [{"name": "test"}]}`),
+			},
+		},
+		TotalCount: 1,
+		Page:       1,
+		Limit:      10,
+		TotalPages: 1,
+	}
+
+	suite.mux.HandleFunc("/v3/order_approvals", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		suite.Equal("PENDING", r.URL.Query().Get("status"))
+		suite.Equal("1", r.URL.Query().Get("pageNumber"))
+		suite.Equal("10", r.URL.Query().Get("pageSize"))
+		w.Header().Set("Pagination-Total-Count", "1")
+		w.Header().Set("Pagination-Page", "1")
+		w.Header().Set("Pagination-Limit", "10")
+		w.Header().Set("Pagination-Total-Page", "1")
+		fmt.Fprint(w, jblob)
+	})
+
+	listRes, err := suite.client.OrderApprovalService.ListOrderApprovals(ctx, listReq)
+	suite.NoError(err)
+	suite.Equal(want, listRes)
+}
+
+func (suite *OrderApprovalClientTestSuite) TestListOrderApprovalsWithServiceIDs() {
+	ctx := context.Background()
+
+	listReq := &ListOrderApprovalsRequest{
+		ServiceIDs: []int{123, 456},
+	}
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": []
+	}`
+
+	suite.mux.HandleFunc("/v3/order_approvals", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		suite.Equal("123,456", r.URL.Query().Get("serviceIds"))
+		fmt.Fprint(w, jblob)
+	})
+
+	listRes, err := suite.client.OrderApprovalService.ListOrderApprovals(ctx, listReq)
+	suite.NoError(err)
+	suite.NotNil(listRes)
+	suite.Empty(listRes.OrderApprovals)
+}
+
+func (suite *OrderApprovalClientTestSuite) TestApproveOrderApproval() {
+	ctx := context.Background()
+	uid := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": "Order request approved successfully"
+	}`
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/order_approvals/%s/approve", uid), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPost)
+		body, _ := io.ReadAll(r.Body)
+		var req OrderApprovalActionRequest
+		_ = json.Unmarshal(body, &req)
+		suite.Equal("Looks good", req.Comments)
+		fmt.Fprint(w, jblob)
+	})
+
+	err := suite.client.OrderApprovalService.ApproveOrderApproval(ctx, uid, &OrderApprovalActionRequest{
+		Comments: "Looks good",
+	})
+	suite.NoError(err)
+}
+
+func (suite *OrderApprovalClientTestSuite) TestRejectOrderApproval() {
+	ctx := context.Background()
+	uid := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": "Order request rejected successfully"
+	}`
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/order_approvals/%s/reject", uid), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPost)
+		body, _ := io.ReadAll(r.Body)
+		var req OrderApprovalActionRequest
+		_ = json.Unmarshal(body, &req)
+		suite.Equal("Not approved", req.Comments)
+		fmt.Fprint(w, jblob)
+	})
+
+	err := suite.client.OrderApprovalService.RejectOrderApproval(ctx, uid, &OrderApprovalActionRequest{
+		Comments: "Not approved",
+	})
+	suite.NoError(err)
+}
+
+func (suite *OrderApprovalClientTestSuite) TestWithdrawOrderApproval() {
+	ctx := context.Background()
+	uid := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": "Order request withdrawn successfully"
+	}`
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/order_approvals/%s/withdraw", uid), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPost)
+		body, _ := io.ReadAll(r.Body)
+		var req OrderApprovalActionRequest
+		_ = json.Unmarshal(body, &req)
+		suite.Equal("No longer needed", req.Comments)
+		fmt.Fprint(w, jblob)
+	})
+
+	err := suite.client.OrderApprovalService.WithdrawOrderApproval(ctx, uid, &OrderApprovalActionRequest{
+		Comments: "No longer needed",
+	})
+	suite.NoError(err)
+}

--- a/order_approvals_test.go
+++ b/order_approvals_test.go
@@ -158,6 +158,25 @@ func (suite *OrderApprovalClientTestSuite) TestListOrderApprovalsNilRequest() {
 	suite.Empty(listRes.OrderApprovals)
 }
 
+func (suite *OrderApprovalClientTestSuite) TestListOrderApprovalsInvalidPaginationHeader() {
+	ctx := context.Background()
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": []
+	}`
+
+	suite.mux.HandleFunc("/v3/order_approvals", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Pagination-Total-Count", "not-a-number")
+		fmt.Fprint(w, jblob)
+	})
+
+	_, err := suite.client.OrderApprovalService.ListOrderApprovals(ctx, &ListOrderApprovalsRequest{})
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid Pagination-Total-Count header")
+}
+
 func (suite *OrderApprovalClientTestSuite) TestActionEmptyUID() {
 	ctx := context.Background()
 	err := suite.client.OrderApprovalService.ApproveOrderApproval(ctx, "", &OrderApprovalActionRequest{})

--- a/order_approvals_test.go
+++ b/order_approvals_test.go
@@ -149,9 +149,10 @@ func (suite *OrderApprovalClientTestSuite) TestApproveOrderApproval() {
 
 	suite.mux.HandleFunc(fmt.Sprintf("/v3/order_approvals/%s/approve", uid), func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodPost)
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		suite.Require().NoError(err)
 		var req OrderApprovalActionRequest
-		_ = json.Unmarshal(body, &req)
+		suite.Require().NoError(json.Unmarshal(body, &req))
 		suite.Equal("Looks good", req.Comments)
 		fmt.Fprint(w, jblob)
 	})
@@ -174,9 +175,10 @@ func (suite *OrderApprovalClientTestSuite) TestRejectOrderApproval() {
 
 	suite.mux.HandleFunc(fmt.Sprintf("/v3/order_approvals/%s/reject", uid), func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodPost)
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		suite.Require().NoError(err)
 		var req OrderApprovalActionRequest
-		_ = json.Unmarshal(body, &req)
+		suite.Require().NoError(json.Unmarshal(body, &req))
 		suite.Equal("Not approved", req.Comments)
 		fmt.Fprint(w, jblob)
 	})
@@ -199,9 +201,10 @@ func (suite *OrderApprovalClientTestSuite) TestWithdrawOrderApproval() {
 
 	suite.mux.HandleFunc(fmt.Sprintf("/v3/order_approvals/%s/withdraw", uid), func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodPost)
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		suite.Require().NoError(err)
 		var req OrderApprovalActionRequest
-		_ = json.Unmarshal(body, &req)
+		suite.Require().NoError(json.Unmarshal(body, &req))
 		suite.Equal("No longer needed", req.Comments)
 		fmt.Fprint(w, jblob)
 	})

--- a/order_approvals_test.go
+++ b/order_approvals_test.go
@@ -137,6 +137,39 @@ func (suite *OrderApprovalClientTestSuite) TestListOrderApprovalsWithServiceIDs(
 	suite.Empty(listRes.OrderApprovals)
 }
 
+func (suite *OrderApprovalClientTestSuite) TestListOrderApprovalsNilRequest() {
+	ctx := context.Background()
+
+	jblob := `{
+		"message": "Success",
+		"terms": "https://www.megaport.com/legal/acceptable-use-policy",
+		"data": []
+	}`
+
+	suite.mux.HandleFunc("/v3/order_approvals", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		suite.Empty(r.URL.Query())
+		fmt.Fprint(w, jblob)
+	})
+
+	listRes, err := suite.client.OrderApprovalService.ListOrderApprovals(ctx, nil)
+	suite.NoError(err)
+	suite.NotNil(listRes)
+	suite.Empty(listRes.OrderApprovals)
+}
+
+func (suite *OrderApprovalClientTestSuite) TestActionEmptyUID() {
+	ctx := context.Background()
+	err := suite.client.OrderApprovalService.ApproveOrderApproval(ctx, "", &OrderApprovalActionRequest{})
+	suite.ErrorIs(err, ErrOrderApprovalUIDRequired)
+
+	err = suite.client.OrderApprovalService.RejectOrderApproval(ctx, "", &OrderApprovalActionRequest{})
+	suite.ErrorIs(err, ErrOrderApprovalUIDRequired)
+
+	err = suite.client.OrderApprovalService.WithdrawOrderApproval(ctx, "", &OrderApprovalActionRequest{})
+	suite.ErrorIs(err, ErrOrderApprovalUIDRequired)
+}
+
 func (suite *OrderApprovalClientTestSuite) TestApproveOrderApproval() {
 	ctx := context.Background()
 	uid := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"


### PR DESCRIPTION
Adds `OrderApprovalService` to the SDK, implementing the `/v3/order_approvals` API endpoints for managing order approval workflows. This enables SDK consumers to list, approve, reject, and withdraw order approval requests.

The implementation includes four endpoints:
- `ListOrderApprovals` — paginated listing with filters (status, serviceIDs) and pagination metadata parsed from response headers
- `ApproveOrderApproval` — approve a pending order by UID with optional comments
- `RejectOrderApproval` — reject a pending order by UID with optional comments
- `WithdrawOrderApproval` — withdraw own pending order by UID with optional comments

The polymorphic `detail` field on `OrderApproval` is typed as `json.RawMessage` to support the discriminated union (NEW_ORDER, TERM_CHANGE, SPEED_CHANGE) without over-modelling.

## Testing

Unit tests cover all four operations using the httptest/mux mock pattern, including query parameter validation and pagination header parsing.