### PR TITLE
feat: migrate ExecuteOrder to POST /v4/networkdesign/buy

### DIFF
--- a/ix_test.go
+++ b/ix_test.go
@@ -98,7 +98,7 @@ func (suite *IXClientTestSuite) TestBuyIX() {
 	})
 
 	// Mock the buy endpoint
-	buyPath := "/v3/networkdesign/buy"
+	buyPath := "/v4/networkdesign/buy"
 	jblob := fmt.Sprintf(`{
         "message": "IX [%s] created.",
         "terms": "This data is subject to the Acceptable Use Policy https://www.megaport.com/legal/acceptable-use-policy",
@@ -109,17 +109,21 @@ func (suite *IXClientTestSuite) TestBuyIX() {
         ]
     }`, ixProductUid, ixProductUid)
 	suite.mux.HandleFunc(buyPath, func(w http.ResponseWriter, r *http.Request) {
-		v := new([]IXOrder)
-		err := json.NewDecoder(r.Body).Decode(v)
+		var wrapper struct {
+			NetworkDesign []IXOrder `json:"networkDesign"`
+			DiscountCodes []string  `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
 		if err != nil {
 			suite.FailNowf("could not decode json", "could not decode json %v", err)
 		}
-		orders := *v
+		orders := wrapper.NetworkDesign
 		wantOrder := ixOrder
 		gotOrder := orders[0]
 		suite.testMethod(r, http.MethodPost)
 		suite.Equal(wantOrder.ProductUID, gotOrder.ProductUID)
 		suite.Equal(wantOrder.AssociatedIXs[0].ProductName, gotOrder.AssociatedIXs[0].ProductName)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, jblob)
 	})

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -69,13 +69,16 @@ func (suite *MCRClientTestSuite) TestBuyMCR() {
 			},
 		},
 	}
-	suite.mux.HandleFunc("/v3/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
-		v := new([]MCROrder)
-		err := json.NewDecoder(r.Body).Decode(v)
+	suite.mux.HandleFunc("/v4/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
+		var wrapper struct {
+			NetworkDesign []MCROrder `json:"networkDesign"`
+			DiscountCodes []string   `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
 		if err != nil {
 			suite.FailNowf("could not decode json", "could not decode json %v", err)
 		}
-		orders := *v
+		orders := wrapper.NetworkDesign
 		wantOrder := mcrOrder[0]
 		gotOrder := orders[0]
 		suite.testMethod(r, http.MethodPost)
@@ -86,6 +89,7 @@ func (suite *MCRClientTestSuite) TestBuyMCR() {
 		suite.Equal(wantOrder.LocationID, gotOrder.LocationID)
 		suite.Equal(wantOrder.Type, gotOrder.Type)
 		suite.Equal(wantOrder.Config, gotOrder.Config)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	got, err := mcrSvc.BuyMCR(ctx, req)
 	suite.NoError(err)

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -721,6 +721,24 @@ func (suite *MCRClientTestSuite) TestBuyMCRWithIPsecValidation() {
 
 	suite.mux.HandleFunc("/v4/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodPost)
+		var wrapper struct {
+			NetworkDesign json.RawMessage `json:"networkDesign"`
+			DiscountCodes []string        `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
+		if err != nil {
+			suite.FailNowf("could not decode json", "could not decode json %v", err)
+		}
+		suite.NotNil(wrapper.NetworkDesign)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
+
+		var orders []map[string]interface{}
+		suite.NoError(json.Unmarshal(wrapper.NetworkDesign, &orders))
+		suite.Len(orders, 1)
+		suite.Equal("test-mcr", orders[0]["productName"])
+		suite.Equal(float64(1), orders[0]["term"])
+		suite.Equal(float64(1000), orders[0]["portSpeed"])
+		suite.Equal(float64(1), orders[0]["locationId"])
 		fmt.Fprint(w, jblob)
 	})
 

--- a/mve_test.go
+++ b/mve_test.go
@@ -136,14 +136,17 @@ func (suite *MVEClientTestSuite) TestBuyMVE() {
 	}}
 	want := &BuyMVEResponse{TechnicalServiceUID: productUid}
 
-	suite.mux.HandleFunc("/v3/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
-		v := new([]MVEOrderConfig)
-		err := json.NewDecoder(r.Body).Decode(v)
+	suite.mux.HandleFunc("/v4/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
+		var wrapper struct {
+			NetworkDesign []MVEOrderConfig `json:"networkDesign"`
+			DiscountCodes []string         `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
 		if err != nil {
 			suite.FailNowf("could not decode json", "could not decode json %v", err)
 		}
 
-		orders := *v
+		orders := wrapper.NetworkDesign
 		wantOrder := mveOrder[0]
 		gotOrder := orders[0]
 		suite.testMethod(r, http.MethodPost)
@@ -154,6 +157,7 @@ func (suite *MVEClientTestSuite) TestBuyMVE() {
 		suite.Equal(wantOrder.LocationID, gotOrder.LocationID)
 		suite.Equal(wantOrder.NetworkInterfaces, gotOrder.NetworkInterfaces)
 		suite.Equal(wantOrder.Config, gotOrder.Config)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	got, err := mveSvc.BuyMVE(ctx, req)
 	suite.NoError(err)

--- a/port_test.go
+++ b/port_test.go
@@ -75,13 +75,16 @@ func (suite *PortClientTestSuite) TestBuyPort() {
 			MarketplaceVisibility: req.MarketPlaceVisibility,
 		},
 	}
-	suite.mux.HandleFunc("/v3/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
-		v := new([]PortOrder)
-		err := json.NewDecoder(r.Body).Decode(v)
+	suite.mux.HandleFunc("/v4/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
+		var wrapper struct {
+			NetworkDesign []PortOrder `json:"networkDesign"`
+			DiscountCodes []string    `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
 		if err != nil {
 			suite.FailNowf("could not decode json", "could not decode json %v", err)
 		}
-		orders := *v
+		orders := wrapper.NetworkDesign
 		wantOrder := portOrder[0]
 		gotOrder := orders[0]
 		suite.testMethod(r, http.MethodPost)
@@ -92,6 +95,7 @@ func (suite *PortClientTestSuite) TestBuyPort() {
 		suite.Equal(wantOrder.LocationID, gotOrder.LocationID)
 		suite.Equal(wantOrder.Virtual, gotOrder.Virtual)
 		suite.Equal(wantOrder.MarketplaceVisibility, gotOrder.MarketplaceVisibility)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	got, err := portSvc.BuyPort(ctx, req)
 	suite.NoError(err)

--- a/product.go
+++ b/product.go
@@ -135,8 +135,8 @@ type ResourceTag struct {
 	Value string `json:"value"`
 }
 
-// BuyRequest is the v4 request envelope for POST /v4/networkdesign/buy.
-type BuyRequest struct {
+// buyRequestV4 is the internal v4 request envelope for POST /v4/networkdesign/buy.
+type buyRequestV4 struct {
 	NetworkDesign interface{} `json:"networkDesign"`
 	DiscountCodes []string    `json:"discountCodes"`
 }
@@ -145,7 +145,7 @@ type BuyRequest struct {
 func (svc *ProductServiceOp) ExecuteOrder(ctx context.Context, requestBody interface{}) (*[]byte, error) {
 	path := "/v4/networkdesign/buy"
 
-	wrappedBody := BuyRequest{
+	wrappedBody := buyRequestV4{
 		NetworkDesign: requestBody,
 		DiscountCodes: []string{},
 	}

--- a/product.go
+++ b/product.go
@@ -135,13 +135,24 @@ type ResourceTag struct {
 	Value string `json:"value"`
 }
 
+// BuyRequest is the v4 request envelope for POST /v4/networkdesign/buy.
+type BuyRequest struct {
+	NetworkDesign interface{} `json:"networkDesign"`
+	DiscountCodes []string    `json:"discountCodes"`
+}
+
 // ExecuteOrder is responsible for executing an order for a product in the Megaport Products API.
 func (svc *ProductServiceOp) ExecuteOrder(ctx context.Context, requestBody interface{}) (*[]byte, error) {
-	path := "/v3/networkdesign/buy"
+	path := "/v4/networkdesign/buy"
+
+	wrappedBody := BuyRequest{
+		NetworkDesign: requestBody,
+		DiscountCodes: []string{},
+	}
 
 	url := svc.Client.BaseURL.JoinPath(path).String()
 
-	req, err := svc.Client.NewRequest(ctx, http.MethodPost, url, requestBody)
+	req, err := svc.Client.NewRequest(ctx, http.MethodPost, url, wrappedBody)
 	if err != nil {
 		return nil, err
 	}

--- a/product_test.go
+++ b/product_test.go
@@ -60,13 +60,16 @@ func (suite *ProductClientTestSuite) TestExecuteOrder() {
 		},
 	}
 
-	suite.mux.HandleFunc("/v3/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
-		v := new([]PortOrder)
-		err := json.NewDecoder(r.Body).Decode(v)
+	suite.mux.HandleFunc("/v4/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
+		var wrapper struct {
+			NetworkDesign []PortOrder `json:"networkDesign"`
+			DiscountCodes []string    `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
 		if err != nil {
 			suite.FailNowf("could not decode json", "could not decode json %v", err)
 		}
-		orders := *v
+		orders := wrapper.NetworkDesign
 		wantOrder := portOrder[0]
 		gotOrder := orders[0]
 		suite.testMethod(r, http.MethodPost)
@@ -77,6 +80,7 @@ func (suite *ProductClientTestSuite) TestExecuteOrder() {
 		suite.Equal(wantOrder.LocationID, gotOrder.LocationID)
 		suite.Equal(wantOrder.Virtual, gotOrder.Virtual)
 		suite.Equal(wantOrder.MarketplaceVisibility, gotOrder.MarketplaceVisibility)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	wantRes := PtrTo([]byte(jblob))
 	gotRes, err := productSvc.ExecuteOrder(ctx, portOrder)

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -209,20 +209,24 @@ func (suite *VXCClientTestSuite) TestBuyVXC() {
 			}
 		]
 	}`
-	path := "/v3/networkdesign/buy"
+	path := "/v4/networkdesign/buy"
 	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		v := new([]VXCOrder)
-		err := json.NewDecoder(r.Body).Decode(v)
+		var wrapper struct {
+			NetworkDesign []VXCOrder `json:"networkDesign"`
+			DiscountCodes []string   `json:"discountCodes"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&wrapper)
 		if err != nil {
 			suite.FailNowf("could not decode json", "could not decode json %v", err)
 		}
-		orders := *v
+		orders := wrapper.NetworkDesign
 		wantOrder := vxcOrder[0]
 		gotOrder := orders[0]
 		suite.testMethod(r, http.MethodPost)
 		fmt.Fprint(w, jblob)
 		suite.Equal(wantOrder.PortID, gotOrder.PortID)
 		suite.Equal(&wantOrder.AssociatedVXCs, &gotOrder.AssociatedVXCs)
+		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	want := &BuyVXCResponse{
 		TechnicalServiceUID: vxcProductUid,


### PR DESCRIPTION
## Summary

Migrates the SDK's buy endpoint from `/v3/networkdesign/buy` to `/v4/networkdesign/buy`. The v4 endpoint wraps the existing order array in a `NetworkDesignAndDiscountsDto` envelope with a `networkDesign` field and a `discountCodes` list.

- The wrapping is done inside `ExecuteOrder` so all callers (Port, MCR, MVE, VXC, IX) are unaffected
- `discountCodes` defaults to an empty array until the Future of Discounting backend feature is enabled; the existing per-item `promoCode` fields continue to work
- `ValidateProductOrder` remains on `/v3/networkdesign/validate` as no v4 validate endpoint exists

## Test plan

- [x] All unit tests updated to assert v4 request envelope structure
- [x] `go test -v ./...` passes
- [ ] Integration test against staging once FoD backend is deployed