### PR TITLE
feat: add NAT Gateway CRUD endpoints

### DIFF
--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -8,12 +8,23 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"time"
 )
 
 // NATGatewayService is an interface for interfacing with the NAT Gateway endpoints of the Megaport API.
 type NATGatewayService interface {
+	// CreateNATGateway creates a new NAT Gateway resource.
+	CreateNATGateway(ctx context.Context, req *CreateNATGatewayRequest) (*NATGateway, error)
+	// ListNATGateways retrieves all NAT Gateways for the authenticated company.
+	ListNATGateways(ctx context.Context) ([]*NATGateway, error)
+	// GetNATGateway retrieves a NAT Gateway by its product UID.
+	GetNATGateway(ctx context.Context, productUID string) (*NATGateway, error)
+	// UpdateNATGateway updates a NAT Gateway by its product UID.
+	UpdateNATGateway(ctx context.Context, req *UpdateNATGatewayRequest) (*NATGateway, error)
+	// DeleteNATGateway deletes a NAT Gateway by its product UID.
+	DeleteNATGateway(ctx context.Context, productUID string) error
 	// ListNATGatewaySessions returns the speed/session-count availability matrix for NAT Gateways.
 	ListNATGatewaySessions(ctx context.Context) ([]*NATGatewaySession, error)
 	// GetNATGatewayTelemetry returns telemetry data for a NAT Gateway product.
@@ -55,6 +66,166 @@ var ErrNATGatewayTelemetryDaysOutOfRange = errors.New("days must be between 1 an
 
 // ErrNATGatewayTelemetryFromToIncomplete is returned when only one of From/To is provided.
 var ErrNATGatewayTelemetryFromToIncomplete = errors.New("both from and to must be provided together")
+
+// ErrNATGatewayProductNameRequired is returned when a ProductName is not provided.
+var ErrNATGatewayProductNameRequired = errors.New("product name is required")
+
+// ErrNATGatewayLocationIDRequired is returned when a LocationID is not provided or is invalid.
+var ErrNATGatewayLocationIDRequired = errors.New("location ID must be greater than 0")
+
+// ErrNATGatewaySpeedRequired is returned when a Speed is not provided or is invalid.
+var ErrNATGatewaySpeedRequired = errors.New("speed must be greater than 0")
+
+// ErrNATGatewayInvalidTerm is returned when a Term is not a valid contract term.
+var ErrNATGatewayInvalidTerm = errors.New("term must be one of: 1, 12, 24, 36, 48, 60")
+
+// validateCreateNATGatewayRequest validates the request parameters for creating a NAT Gateway.
+func validateCreateNATGatewayRequest(req *CreateNATGatewayRequest) error {
+	if req.ProductName == "" {
+		return ErrNATGatewayProductNameRequired
+	}
+	if req.LocationID < 1 {
+		return ErrNATGatewayLocationIDRequired
+	}
+	if req.Speed < 1 {
+		return ErrNATGatewaySpeedRequired
+	}
+	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
+		return ErrNATGatewayInvalidTerm
+	}
+	return nil
+}
+
+// validateUpdateNATGatewayRequest validates the request parameters for updating a NAT Gateway.
+func validateUpdateNATGatewayRequest(req *UpdateNATGatewayRequest) error {
+	if req.ProductUID == "" {
+		return ErrNATGatewayProductUIDRequired
+	}
+	if req.ProductName == "" {
+		return ErrNATGatewayProductNameRequired
+	}
+	if req.LocationID < 1 {
+		return ErrNATGatewayLocationIDRequired
+	}
+	if req.Speed < 1 {
+		return ErrNATGatewaySpeedRequired
+	}
+	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
+		return ErrNATGatewayInvalidTerm
+	}
+	return nil
+}
+
+// CreateNATGateway creates a new NAT Gateway resource.
+func (svc *NATGatewayServiceOp) CreateNATGateway(ctx context.Context, req *CreateNATGatewayRequest) (*NATGateway, error) {
+	if err := validateCreateNATGatewayRequest(req); err != nil {
+		return nil, err
+	}
+
+	path := "/v3/products/nat_gateways"
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPost, path, req)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var natResp NATGatewayResponse
+	if err := json.Unmarshal(buf.Bytes(), &natResp); err != nil {
+		return nil, err
+	}
+	return &natResp.Data, nil
+}
+
+// ListNATGateways retrieves all NAT Gateways for the authenticated company.
+func (svc *NATGatewayServiceOp) ListNATGateways(ctx context.Context) ([]*NATGateway, error) {
+	path := "/v3/products/nat_gateways"
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var listResp NATGatewayListResponse
+	if err := json.Unmarshal(buf.Bytes(), &listResp); err != nil {
+		return nil, err
+	}
+	return listResp.Data, nil
+}
+
+// GetNATGateway retrieves a NAT Gateway by its product UID.
+func (svc *NATGatewayServiceOp) GetNATGateway(ctx context.Context, productUID string) (*NATGateway, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var natResp NATGatewayResponse
+	if err := json.Unmarshal(buf.Bytes(), &natResp); err != nil {
+		return nil, err
+	}
+	return &natResp.Data, nil
+}
+
+// UpdateNATGateway updates a NAT Gateway by its product UID.
+func (svc *NATGatewayServiceOp) UpdateNATGateway(ctx context.Context, req *UpdateNATGatewayRequest) (*NATGateway, error) {
+	if err := validateUpdateNATGatewayRequest(req); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(req.ProductUID))
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPut, path, req)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var natResp NATGatewayResponse
+	if err := json.Unmarshal(buf.Bytes(), &natResp); err != nil {
+		return nil, err
+	}
+	return &natResp.Data, nil
+}
+
+// DeleteNATGateway deletes a NAT Gateway by its product UID.
+func (svc *NATGatewayServiceOp) DeleteNATGateway(ctx context.Context, productUID string) error {
+	if productUID == "" {
+		return ErrNATGatewayProductUIDRequired
+	}
+
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Client.Do(ctx, clientReq, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
 
 // validateGetNATGatewayTelemetryRequest validates the request parameters.
 func validateGetNATGatewayTelemetryRequest(req *GetNATGatewayTelemetryRequest) error {

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -1,0 +1,157 @@
+package megaport
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	TEST_NAT_GATEWAY_LOCATION_MARKET = "AU"
+)
+
+// NATGatewayIntegrationTestSuite is the integration test suite for the NAT Gateway service.
+type NATGatewayIntegrationTestSuite IntegrationTestSuite
+
+func TestNATGatewayIntegrationTestSuite(t *testing.T) {
+	t.Parallel()
+	if *runIntegrationTests {
+		suite.Run(t, new(NATGatewayIntegrationTestSuite))
+	}
+}
+
+func (suite *NATGatewayIntegrationTestSuite) SetupSuite() {
+	accessKey := os.Getenv("MEGAPORT_ACCESS_KEY")
+	secretKey := os.Getenv("MEGAPORT_SECRET_KEY")
+
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: programLevel})
+	programLevel.Set(slog.LevelDebug)
+
+	megaportClient, err := New(nil, WithBaseURL(MEGAPORTURL), WithLogHandler(handler), WithCredentials(accessKey, secretKey))
+	if err != nil {
+		suite.FailNowf("", "could not initialize megaport test client: %s", err.Error())
+	}
+
+	_, err = megaportClient.Authorize(ctx)
+	if err != nil {
+		suite.FailNowf("", "could not authorize megaport test client: %s", err.Error())
+	}
+
+	suite.client = megaportClient
+}
+
+// TestNATGatewayLifecycle tests the full CRUD lifecycle of a NAT Gateway.
+func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	// Step 1: List available sessions to pick a valid speed/session count.
+	logger.DebugContext(ctx, "Listing NAT Gateway sessions.")
+	sessions, err := natSvc.ListNATGatewaySessions(ctx)
+	if err != nil {
+		suite.FailNowf("could not list sessions", "could not list NAT Gateway sessions: %v", err)
+	}
+	suite.NotEmpty(sessions, "expected at least one session configuration")
+
+	testSpeed := sessions[0].SpeedMbps
+	testSessionCount := sessions[0].SessionCount[0]
+	logger.DebugContext(ctx, "Selected session config",
+		slog.Int("speed", testSpeed),
+		slog.Int("session_count", testSessionCount),
+	)
+
+	// Step 2: Pick a location.
+	testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
+	if locErr != nil {
+		suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
+	}
+	suite.NotNil(testLocation)
+	logger.DebugContext(ctx, "Test location determined", slog.String("location", testLocation.Name), slog.Int("location_id", testLocation.ID))
+
+	// Step 3: Create a NAT Gateway (stays in NEW status, not provisioned).
+	logger.DebugContext(ctx, "Creating NAT Gateway.")
+	createReq := &CreateNATGatewayRequest{
+		AutoRenewTerm: true,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: false,
+			DiversityZone:      "red",
+			SessionCount:       testSessionCount,
+		},
+		LocationID:  testLocation.ID,
+		ProductName: "Integration Test NAT Gateway",
+		Speed:       testSpeed,
+		Term:        1,
+	}
+	gw, err := natSvc.CreateNATGateway(ctx, createReq)
+	if err != nil {
+		suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", err)
+	}
+	suite.NotEmpty(gw.ProductUID)
+	suite.Equal("Integration Test NAT Gateway", gw.ProductName)
+	suite.Equal(testSpeed, gw.Speed)
+	suite.Equal(1, gw.Term)
+	logger.DebugContext(ctx, "NAT Gateway created", slog.String("product_uid", gw.ProductUID), slog.String("provisioning_status", gw.ProvisioningStatus))
+
+	productUID := gw.ProductUID
+
+	// Step 4: Get the NAT Gateway by UID.
+	logger.DebugContext(ctx, "Retrieving NAT Gateway by UID.")
+	fetched, err := natSvc.GetNATGateway(ctx, productUID)
+	if err != nil {
+		suite.FailNowf("could not get NAT Gateway", "could not get NAT Gateway: %v", err)
+	}
+	suite.Equal(productUID, fetched.ProductUID)
+	suite.Equal("Integration Test NAT Gateway", fetched.ProductName)
+	suite.Equal(testLocation.ID, fetched.LocationID)
+
+	// Step 5: List NAT Gateways and verify ours appears.
+	logger.DebugContext(ctx, "Listing NAT Gateways.")
+	gateways, err := natSvc.ListNATGateways(ctx)
+	if err != nil {
+		suite.FailNowf("could not list NAT Gateways", "could not list NAT Gateways: %v", err)
+	}
+	found := false
+	for _, g := range gateways {
+		if g.ProductUID == productUID {
+			found = true
+			break
+		}
+	}
+	suite.True(found, "created NAT Gateway not found in list")
+
+	// Step 6: Update the NAT Gateway.
+	logger.DebugContext(ctx, "Updating NAT Gateway.")
+	updated, err := natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductUID:    productUID,
+		AutoRenewTerm: false,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: true,
+			DiversityZone:      "red",
+			SessionCount:       testSessionCount,
+		},
+		LocationID:  testLocation.ID,
+		ProductName: "Integration Test NAT Gateway [Updated]",
+		Speed:       testSpeed,
+		Term:        1,
+	})
+	if err != nil {
+		suite.FailNowf("could not update NAT Gateway", "could not update NAT Gateway: %v", err)
+	}
+	suite.Equal("Integration Test NAT Gateway [Updated]", updated.ProductName)
+	suite.False(updated.AutoRenewTerm)
+	logger.DebugContext(ctx, "NAT Gateway updated", slog.String("product_name", updated.ProductName))
+
+	// Step 7: Delete the NAT Gateway (allowed while provisioningStatus is NEW).
+	logger.DebugContext(ctx, "Deleting NAT Gateway.")
+	err = natSvc.DeleteNATGateway(ctx, productUID)
+	if err != nil {
+		suite.FailNowf("could not delete NAT Gateway", "could not delete NAT Gateway: %v", err)
+	}
+	logger.DebugContext(ctx, "NAT Gateway deleted", slog.String("product_uid", productUID))
+}

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -35,6 +35,329 @@ func (suite *NATGatewayClientTestSuite) TearDownTest() {
 	suite.server.Close()
 }
 
+func (suite *NATGatewayClientTestSuite) TestCreateNATGateway() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	jblob := `{
+		"message": "Data returned successfully",
+		"terms": "This data is subject to the Acceptable Use Policy",
+		"data": {
+			"adminLocked": false,
+			"autoRenewTerm": true,
+			"config": {
+				"asn": 64512,
+				"bgpShutdownDefault": false,
+				"diversityZone": "red",
+				"sessionCount": 100
+			},
+			"contractEndDate": "2024-10-01T14:34:56Z",
+			"createDate": "2023-10-01T14:34:56Z",
+			"createdBy": "user-name",
+			"locationId": 123456,
+			"locked": false,
+			"orderApprovalStatus": "PENDING",
+			"productName": "NAT Gateway",
+			"productUid": "e900d0d5-1030-4e29-b2d8-816ad4263190",
+			"promoCode": "PROMO123",
+			"provisioningStatus": "NEW",
+			"resourceTags": [{"key": "env", "value": "test"}],
+			"serviceLevelReference": "SLR-1",
+			"speed": 1000,
+			"term": 1
+		}
+	}`
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, jblob)
+	})
+
+	gw, err := natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		AutoRenewTerm: true,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: false,
+			DiversityZone:      "red",
+			SessionCount:       100,
+		},
+		LocationID:            123456,
+		ProductName:           "NAT Gateway",
+		PromoCode:             "PROMO123",
+		ResourceTags:          []ResourceTag{{Key: "env", Value: "test"}},
+		ServiceLevelReference: "SLR-1",
+		Speed:                 1000,
+		Term:                  1,
+	})
+	suite.NoError(err)
+	suite.Equal("e900d0d5-1030-4e29-b2d8-816ad4263190", gw.ProductUID)
+	suite.Equal("NAT Gateway", gw.ProductName)
+	suite.Equal(1000, gw.Speed)
+	suite.Equal(1, gw.Term)
+	suite.Equal(123456, gw.LocationID)
+	suite.True(gw.AutoRenewTerm)
+	suite.Equal(64512, gw.Config.ASN)
+	suite.False(gw.Config.BGPShutdownDefault)
+	suite.Equal("red", gw.Config.DiversityZone)
+	suite.Equal(100, gw.Config.SessionCount)
+	suite.Equal("NEW", gw.ProvisioningStatus)
+	suite.Equal("PENDING", gw.OrderApprovalStatus)
+	suite.Len(gw.ResourceTags, 1)
+	suite.Equal("env", gw.ResourceTags[0].Key)
+	suite.Equal("test", gw.ResourceTags[0].Value)
+}
+
+func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	// Missing ProductName
+	_, err := natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		LocationID: 1, Speed: 1000, Term: 1,
+	})
+	suite.ErrorIs(err, ErrNATGatewayProductNameRequired)
+
+	// Invalid LocationID
+	_, err = natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		ProductName: "test", LocationID: 0, Speed: 1000, Term: 1,
+	})
+	suite.ErrorIs(err, ErrNATGatewayLocationIDRequired)
+
+	// Invalid Speed
+	_, err = natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		ProductName: "test", LocationID: 1, Speed: 0, Term: 1,
+	})
+	suite.ErrorIs(err, ErrNATGatewaySpeedRequired)
+
+	// Invalid Term
+	_, err = natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		ProductName: "test", LocationID: 1, Speed: 1000, Term: 5,
+	})
+	suite.ErrorIs(err, ErrNATGatewayInvalidTerm)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGateways() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	jblob := `{
+		"message": "Data returned successfully",
+		"terms": "This data is subject to the Acceptable Use Policy",
+		"data": [
+			{
+				"adminLocked": false,
+				"autoRenewTerm": true,
+				"config": {"asn": 64512, "bgpShutdownDefault": false, "diversityZone": "red", "sessionCount": 100},
+				"locationId": 123456,
+				"productName": "NAT Gateway 1",
+				"productUid": "uid-1",
+				"provisioningStatus": "LIVE",
+				"speed": 1000,
+				"term": 12
+			},
+			{
+				"adminLocked": false,
+				"autoRenewTerm": false,
+				"config": {"asn": 64513, "bgpShutdownDefault": true, "diversityZone": "blue", "sessionCount": 200},
+				"locationId": 789012,
+				"productName": "NAT Gateway 2",
+				"productUid": "uid-2",
+				"provisioningStatus": "NEW",
+				"speed": 2500,
+				"term": 24
+			}
+		]
+	}`
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, jblob)
+	})
+
+	gateways, err := natSvc.ListNATGateways(ctx)
+	suite.NoError(err)
+	suite.Len(gateways, 2)
+
+	suite.Equal("uid-1", gateways[0].ProductUID)
+	suite.Equal("NAT Gateway 1", gateways[0].ProductName)
+	suite.Equal(1000, gateways[0].Speed)
+	suite.Equal("LIVE", gateways[0].ProvisioningStatus)
+
+	suite.Equal("uid-2", gateways[1].ProductUID)
+	suite.Equal("NAT Gateway 2", gateways[1].ProductName)
+	suite.Equal(2500, gateways[1].Speed)
+	suite.True(gateways[1].Config.BGPShutdownDefault)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewaysEmpty() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	jblob := `{
+		"message": "Data returned successfully",
+		"terms": "This data is subject to the Acceptable Use Policy",
+		"data": []
+	}`
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, jblob)
+	})
+
+	gateways, err := natSvc.ListNATGateways(ctx)
+	suite.NoError(err)
+	suite.Empty(gateways)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGateway() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "e900d0d5-1030-4e29-b2d8-816ad4263190"
+
+	jblob := `{
+		"message": "Data returned successfully",
+		"terms": "This data is subject to the Acceptable Use Policy",
+		"data": {
+			"adminLocked": false,
+			"autoRenewTerm": true,
+			"config": {"asn": 64512, "bgpShutdownDefault": false, "diversityZone": "red", "sessionCount": 100},
+			"contractEndDate": "2024-10-01T14:34:56Z",
+			"createDate": "2023-10-01T14:34:56Z",
+			"createdBy": "user-name",
+			"locationId": 123456,
+			"locked": false,
+			"orderApprovalStatus": "APPROVED",
+			"productName": "NAT Gateway",
+			"productUid": "e900d0d5-1030-4e29-b2d8-816ad4263190",
+			"provisioningStatus": "LIVE",
+			"speed": 1000,
+			"term": 12
+		}
+	}`
+
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, jblob)
+	})
+
+	gw, err := natSvc.GetNATGateway(ctx, productUID)
+	suite.NoError(err)
+	suite.Equal(productUID, gw.ProductUID)
+	suite.Equal("NAT Gateway", gw.ProductName)
+	suite.Equal("LIVE", gw.ProvisioningStatus)
+	suite.Equal("APPROVED", gw.OrderApprovalStatus)
+	suite.Equal(12, gw.Term)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	_, err := natSvc.GetNATGateway(ctx, "")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+}
+
+func (suite *NATGatewayClientTestSuite) TestUpdateNATGateway() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "e900d0d5-1030-4e29-b2d8-816ad4263190"
+
+	jblob := `{
+		"message": "Data returned successfully",
+		"terms": "This data is subject to the Acceptable Use Policy",
+		"data": {
+			"adminLocked": false,
+			"autoRenewTerm": false,
+			"config": {"asn": 64512, "bgpShutdownDefault": true, "diversityZone": "blue", "sessionCount": 200},
+			"locationId": 123456,
+			"productName": "Updated NAT Gateway",
+			"productUid": "e900d0d5-1030-4e29-b2d8-816ad4263190",
+			"provisioningStatus": "LIVE",
+			"speed": 1000,
+			"term": 24
+		}
+	}`
+
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPut, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, jblob)
+	})
+
+	gw, err := natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductUID:    productUID,
+		AutoRenewTerm: false,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: true,
+			DiversityZone:      "blue",
+			SessionCount:       200,
+		},
+		LocationID:  123456,
+		ProductName: "Updated NAT Gateway",
+		Speed:       1000,
+		Term:        24,
+	})
+	suite.NoError(err)
+	suite.Equal("Updated NAT Gateway", gw.ProductName)
+	suite.Equal(24, gw.Term)
+	suite.True(gw.Config.BGPShutdownDefault)
+	suite.Equal("blue", gw.Config.DiversityZone)
+	suite.Equal(200, gw.Config.SessionCount)
+}
+
+func (suite *NATGatewayClientTestSuite) TestUpdateNATGatewayValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	// Missing ProductUID
+	_, err := natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductName: "test", LocationID: 1, Speed: 1000, Term: 1,
+	})
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	// Missing ProductName
+	_, err = natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductUID: "uid", LocationID: 1, Speed: 1000, Term: 1,
+	})
+	suite.ErrorIs(err, ErrNATGatewayProductNameRequired)
+
+	// Invalid Term
+	_, err = natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductUID: "uid", ProductName: "test", LocationID: 1, Speed: 1000, Term: 7,
+	})
+	suite.ErrorIs(err, ErrNATGatewayInvalidTerm)
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGateway() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "e900d0d5-1030-4e29-b2d8-816ad4263190"
+
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodDelete, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message": "Nat gateway order item deleted successfully", "terms": ""}`)
+	})
+
+	err := natSvc.DeleteNATGateway(ctx, productUID)
+	suite.NoError(err)
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	err := natSvc.DeleteNATGateway(ctx, "")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+}
+
 func (suite *NATGatewayClientTestSuite) TestListNATGatewaySessions() {
 	ctx := context.Background()
 	natSvc := suite.client.NATGatewayService

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -75,3 +75,79 @@ type TelemetryUnit struct {
 	Name     string `json:"name"`
 	FullName string `json:"fullName"`
 }
+
+// NATGateway represents a NAT Gateway product from the Megaport API.
+type NATGateway struct {
+	AdminLocked           bool                    `json:"adminLocked"`
+	AutoRenewTerm         bool                    `json:"autoRenewTerm"`
+	Config                NATGatewayNetworkConfig `json:"config"`
+	ContractEndDate       string                  `json:"contractEndDate"`
+	CreateDate            string                  `json:"createDate"`
+	CreatedBy             string                  `json:"createdBy"`
+	LocationID            int                     `json:"locationId"`
+	Locked                bool                    `json:"locked"`
+	OrderApprovalStatus   string                  `json:"orderApprovalStatus"`
+	ProductName           string                  `json:"productName"`
+	ProductUID            string                  `json:"productUid"`
+	PromoCode             string                  `json:"promoCode"`
+	ProvisioningStatus    string                  `json:"provisioningStatus"`
+	ResourceTags          []ResourceTag           `json:"resourceTags"`
+	ServiceLevelReference string                  `json:"serviceLevelReference"`
+	Speed                 int                     `json:"speed"`
+	Term                  int                     `json:"term"`
+}
+
+// NATGatewayNetworkConfig represents the network configuration for a NAT Gateway.
+type NATGatewayNetworkConfig struct {
+	ASN                int    `json:"asn"`
+	BGPShutdownDefault bool   `json:"bgpShutdownDefault"`
+	DiversityZone      string `json:"diversityZone"`
+	SessionCount       int    `json:"sessionCount"`
+}
+
+// CreateNATGatewayRequest represents a request to create a NAT Gateway.
+type CreateNATGatewayRequest struct {
+	AutoRenewTerm         bool                    `json:"autoRenewTerm"`
+	Config                NATGatewayNetworkConfig `json:"config"`
+	LocationID            int                     `json:"locationId"`
+	ProductName           string                  `json:"productName"`
+	PromoCode             string                  `json:"promoCode,omitempty"`
+	ResourceTags          []ResourceTag           `json:"resourceTags,omitempty"`
+	ServiceLevelReference string                  `json:"serviceLevelReference,omitempty"`
+	Speed                 int                     `json:"speed"`
+	Term                  int                     `json:"term"`
+}
+
+// UpdateNATGatewayRequest represents a request to update a NAT Gateway.
+type UpdateNATGatewayRequest struct {
+	ProductUID            string                  `json:"-"` // path parameter, not serialized
+	AutoRenewTerm         bool                    `json:"autoRenewTerm"`
+	Config                NATGatewayNetworkConfig `json:"config"`
+	LocationID            int                     `json:"locationId"`
+	ProductName           string                  `json:"productName"`
+	PromoCode             string                  `json:"promoCode,omitempty"`
+	ResourceTags          []ResourceTag           `json:"resourceTags,omitempty"`
+	ServiceLevelReference string                  `json:"serviceLevelReference,omitempty"`
+	Speed                 int                     `json:"speed"`
+	Term                  int                     `json:"term"`
+}
+
+// NATGatewayResponse is the API response for a single NAT Gateway.
+type NATGatewayResponse struct {
+	Message string     `json:"message"`
+	Terms   string     `json:"terms"`
+	Data    NATGateway `json:"data"`
+}
+
+// NATGatewayListResponse is the API response for listing NAT Gateways.
+type NATGatewayListResponse struct {
+	Message string        `json:"message"`
+	Terms   string        `json:"terms"`
+	Data    []*NATGateway `json:"data"`
+}
+
+// DeleteNATGatewayResponse is the API response for deleting a NAT Gateway.
+type DeleteNATGatewayResponse struct {
+	Message string `json:"message"`
+	Terms   string `json:"terms"`
+}


### PR DESCRIPTION
## Summary

Adds full CRUD support for NAT Gateway resources to the Go SDK, targeting the Order Service API v3 endpoints. The existing `NATGatewayService` (which already had sessions and telemetry) is extended with five new methods:

- **CreateNATGateway** — `POST /v3/products/nat_gateways`
- **ListNATGateways** — `GET /v3/products/nat_gateways`
- **GetNATGateway** — `GET /v3/products/nat_gateways/{productUid}`
- **UpdateNATGateway** — `PUT /v3/products/nat_gateways/{productUid}`
- **DeleteNATGateway** — `DELETE /v3/products/nat_gateways/{productUid}`

New types include `NATGateway`, `NATGatewayNetworkConfig`, `CreateNATGatewayRequest`, `UpdateNATGatewayRequest`, and response wrappers. All methods include client-side validation (product name, location ID, speed, contract term).

Unit tests cover happy paths and validation error cases for all five endpoints. An integration test exercises the full lifecycle (create → get → list → update → delete) against the staging API — passing as of 2026-04-09.

## Test plan

- [x] Unit tests pass: `go test -v -run TestNATGatewayClientTestSuite ./...`
- [x] Lint clean: `golangci-lint run`
- [x] Integration test passes against staging: `go test -timeout 20m -integration -run TestNATGatewayIntegrationTestSuite ./...`