### PR TITLE
refactor!: drop exactMatch param from FilterPartnerMegaportByDiversityZone

### DIFF
--- a/partner.go
+++ b/partner.go
@@ -22,7 +22,7 @@ type PartnerService interface {
 	// FilterPartnerMegaportByLocationId filters a list of partner megaports by location ID in the Megaport API.
 	FilterPartnerMegaportByLocationId(ctx context.Context, partners []*PartnerMegaport, locationId int) ([]*PartnerMegaport, error)
 	// FilterPartnerMegaportByDiversityZone filters a list of partner megaports by diversity zone in the Megaport API.
-	FilterPartnerMegaportByDiversityZone(ctx context.Context, partners []*PartnerMegaport, diversityZone string, exactMatch bool) ([]*PartnerMegaport, error)
+	FilterPartnerMegaportByDiversityZone(ctx context.Context, partners []*PartnerMegaport, diversityZone string) ([]*PartnerMegaport, error)
 }
 
 // NewPartnerService creates a new instance of the PartnerService.
@@ -170,24 +170,10 @@ func (svc *PartnerServiceOp) FilterPartnerMegaportByLocationId(ctx context.Conte
 }
 
 // FilterPartnerMegaportByDiversityZone filters a list of partner megaports by diversity zone in the Megaport API.
-func (svc *PartnerServiceOp) FilterPartnerMegaportByDiversityZone(ctx context.Context, partners []*PartnerMegaport, diversityZone string, exactMatch bool) ([]*PartnerMegaport, error) {
+func (svc *PartnerServiceOp) FilterPartnerMegaportByDiversityZone(ctx context.Context, partners []*PartnerMegaport, diversityZone string) ([]*PartnerMegaport, error) {
 	toReturn := []*PartnerMegaport{}
 	for _, partner := range partners {
-		match := false
-		if diversityZone != "" {
-			if exactMatch { // Exact Match
-				if diversityZone == partner.DiversityZone {
-					match = true
-				}
-			} else {
-				if fuzzy.Match(diversityZone, partner.DiversityZone) {
-					match = true
-				}
-			}
-		} else {
-			match = true
-		}
-
+		match := diversityZone == "" || diversityZone == partner.DiversityZone
 		if match && partner.VXCPermitted {
 			toReturn = append(toReturn, partner)
 		}

--- a/partner_integration_test.go
+++ b/partner_integration_test.go
@@ -144,7 +144,7 @@ func (suite *PartnerIntegrationTestSuite) TestFilterPartnerMegaportByDiversityZo
 	if err != nil {
 		suite.FailNowf("could not list partners", "could not list partners %v", err)
 	}
-	filtered, err := partnerSvc.FilterPartnerMegaportByDiversityZone(ctx, partners, "red", true)
+	filtered, err := partnerSvc.FilterPartnerMegaportByDiversityZone(ctx, partners, "red")
 	if err != nil {
 		suite.FailNowf("could not filter partners", "could not filter partners %v", err)
 	}

--- a/partner_test.go
+++ b/partner_test.go
@@ -325,7 +325,7 @@ func (suite *PartnerClientTestSuite) TestFilterPartnerMegaportByDiversityZone() 
 
 	wantFiltered := []*PartnerMegaport{awsPartner, defaultPartner}
 
-	gotFiltered, err := partnerSvc.FilterPartnerMegaportByDiversityZone(ctx, partners, "red", true)
+	gotFiltered, err := partnerSvc.FilterPartnerMegaportByDiversityZone(ctx, partners, "red")
 	suite.NoError(err)
 	suite.Equal(wantFiltered, gotFiltered)
 }


### PR DESCRIPTION
## Summary

Diversity zones are a bounded enum (`red`/`blue`), so fuzzy matching adds no value and risks false positives. This drops the `exactMatch` parameter from `FilterPartnerMegaportByDiversityZone` and always compares with equality.

Follow-up to a NIT raised on #127.

## Breaking change

`FilterPartnerMegaportByDiversityZone` signature no longer accepts `exactMatch`. Downstream consumers (`megaport-cli`, `terraform-provider-megaport`) will need to drop the trailing argument when bumping the SDK.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run`