### PR TITLE
feat: add OrderService for purchasing design-state products

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,6 +93,10 @@ type Client struct {
 	BillingMarketService BillingMarketService
 	// NATGatewayService provides methods for interacting with the NAT Gateway API
 	NATGatewayService NATGatewayService
+	// OrderService provides methods for interacting with the Orders API,
+	// which is used to purchase (provision) products that are created in a
+	// non-purchased design state (currently: NAT Gateways).
+	OrderService OrderService
 
 	accessToken string    // Access Token for client
 	tokenExpiry time.Time // Token Expiration
@@ -191,6 +195,7 @@ func NewClient(httpClient *http.Client, base *url.URL) *Client {
 	c.EventsService = NewEventsService(c)
 	c.BillingMarketService = NewBillingMarketService(c)
 	c.NATGatewayService = NewNATGatewayService(c)
+	c.OrderService = NewOrderService(c)
 	c.UserManagementService = NewUserManagementService(c)
 
 	c.headers = make(map[string]string)

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -154,4 +156,172 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
 		suite.FailNowf("could not delete NAT Gateway", "could not delete NAT Gateway: %v", err)
 	}
 	logger.DebugContext(ctx, "NAT Gateway deleted", slog.String("product_uid", productUID))
+}
+
+// TestNATGatewayFullLifecycle exercises the end-to-end flow: create the
+// design record, submit an order referencing the gateway, buy the order,
+// wait for the gateway to reach CONFIGURED/LIVE, update a field that
+// remains mutable post-deployment, and finally cancel the gateway via
+// ProductService (the DESIGN-only DELETE endpoint no longer applies once
+// the order has been bought).
+func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+	orderSvc := suite.client.OrderService
+
+	// Step 1: List sessions to pick a valid speed/session count.
+	sessions, err := natSvc.ListNATGatewaySessions(ctx)
+	if err != nil {
+		suite.FailNowf("could not list sessions", "could not list NAT Gateway sessions: %v", err)
+	}
+	suite.NotEmpty(sessions, "expected at least one session configuration")
+	testSpeed := sessions[0].SpeedMbps
+	testSessionCount := sessions[0].SessionCount[0]
+
+	// Step 2: Pick a location.
+	testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
+	if locErr != nil {
+		suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
+	}
+	suite.NotNil(testLocation)
+
+	// Step 3: Create the NAT Gateway (returns in DESIGN).
+	createReq := &CreateNATGatewayRequest{
+		AutoRenewTerm: true,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: false,
+			DiversityZone:      "red",
+			SessionCount:       testSessionCount,
+		},
+		LocationID:  testLocation.ID,
+		ProductName: "Integration Test NAT Gateway (Full Lifecycle)",
+		Speed:       testSpeed,
+		Term:        1,
+	}
+	gw, err := natSvc.CreateNATGateway(ctx, createReq)
+	if err != nil {
+		suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", err)
+	}
+	productUID := gw.ProductUID
+	suite.NotEmpty(productUID)
+	logger.InfoContext(ctx, "NAT Gateway design created",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", gw.ProvisioningStatus),
+	)
+
+	// Teardown: cancel the product immediately. Works regardless of state
+	// (DESIGN or post-buy) and runs even if a later step fails.
+	defer func() {
+		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
+		_, delErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+			ProductID: productUID,
+			DeleteNow: true,
+		})
+		if delErr != nil {
+			logger.WarnContext(ctx, "teardown failed", slog.String("error", delErr.Error()))
+		}
+	}()
+
+	// Step 4: Create an Order referencing the gateway.
+	order, err := orderSvc.CreateOrder(ctx, &CreateOrderRequest{
+		Items:     []string{productUID},
+		Reference: "integration-test-" + productUID[:8],
+	})
+	if err != nil {
+		suite.FailNowf("could not create order", "could not create order: %v", err)
+	}
+	orderUID := order.UID
+	suite.NotEmpty(orderUID)
+	logger.InfoContext(ctx, "Order created",
+		slog.String("order_uid", orderUID),
+		slog.String("state", order.State),
+	)
+
+	// Step 5: Validate the order before buying.
+	validated, err := orderSvc.ValidateOrder(ctx, orderUID)
+	if err != nil {
+		suite.FailNowf("could not validate order", "could not validate order: %v", err)
+	}
+	logger.InfoContext(ctx, "Order validated", slog.String("state", validated.State))
+
+	// Step 6: Buy the order — this kicks off provisioning.
+	bought, err := orderSvc.BuyOrder(ctx, orderUID)
+	if err != nil {
+		suite.FailNowf("could not buy order", "could not buy order: %v", err)
+	}
+	logger.InfoContext(ctx, "Order purchased", slog.String("state", bought.State))
+
+	// Step 7: Poll until the gateway reaches CONFIGURED/LIVE, or fail fast
+	// on a terminal error state.
+	const (
+		pollInterval = 10 * time.Second
+		pollTimeout  = 15 * time.Minute
+	)
+	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
+	defer cancel()
+
+	var provisioned *NATGateway
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+PollLoop:
+	for {
+		fetched, getErr := natSvc.GetNATGateway(pollCtx, productUID)
+		if getErr != nil {
+			suite.FailNowf("could not poll NAT Gateway", "error while polling NAT Gateway %s: %v", productUID, getErr)
+		}
+		logger.DebugContext(pollCtx, "poll",
+			slog.String("product_uid", productUID),
+			slog.String("provisioning_status", fetched.ProvisioningStatus),
+		)
+		switch {
+		case slices.Contains(SERVICE_STATE_READY, fetched.ProvisioningStatus):
+			provisioned = fetched
+			break PollLoop
+		case fetched.ProvisioningStatus == STATUS_DECOMMISSIONED ||
+			fetched.ProvisioningStatus == STATUS_CANCELLED:
+			suite.FailNowf("NAT Gateway reached terminal state", "gateway %s reached %s", productUID, fetched.ProvisioningStatus)
+		}
+
+		select {
+		case <-pollCtx.Done():
+			suite.FailNowf("timed out waiting for provisioning", "gateway %s did not reach CONFIGURED/LIVE within %s (last status %q)", productUID, pollTimeout, fetched.ProvisioningStatus)
+		case <-ticker.C:
+		}
+	}
+
+	suite.NotNil(provisioned)
+	suite.Contains(SERVICE_STATE_READY, provisioned.ProvisioningStatus)
+	logger.InfoContext(ctx, "NAT Gateway provisioned",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", provisioned.ProvisioningStatus),
+	)
+
+	// Step 8: Update a field that remains mutable after deployment
+	// (productName). Speed/location/promoCode are immutable post-deploy per
+	// the API docs.
+	const updatedName = "Integration Test NAT Gateway (Updated)"
+	updated, err := natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductUID:    productUID,
+		AutoRenewTerm: false,
+		Config: NATGatewayNetworkConfig{
+			ASN:                provisioned.Config.ASN,
+			BGPShutdownDefault: provisioned.Config.BGPShutdownDefault,
+			DiversityZone:      provisioned.Config.DiversityZone,
+			SessionCount:       provisioned.Config.SessionCount,
+		},
+		LocationID:  provisioned.LocationID,
+		ProductName: updatedName,
+		Speed:       provisioned.Speed,
+		Term:        provisioned.Term,
+	})
+	if err != nil {
+		suite.FailNowf("could not update NAT Gateway", "could not update provisioned NAT Gateway: %v", err)
+	}
+	suite.Equal(updatedName, updated.ProductName)
+	logger.InfoContext(ctx, "NAT Gateway updated", slog.String("product_name", updated.ProductName))
+
+	// Step 9: Teardown runs via the deferred call above.
 }

--- a/orders.go
+++ b/orders.go
@@ -1,0 +1,195 @@
+package megaport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// OrderService is an interface for interacting with the Megaport Orders API.
+//
+// The Orders API is the mechanism for purchasing (provisioning) products
+// that are created in a non-purchased design state. For example, NAT
+// Gateways created via POST /v3/products/nat_gateways are returned in a
+// DESIGN state and must be added to an Order and bought via the endpoints
+// exposed by this service before they enter the normal provisioning
+// lifecycle (DEPLOYABLE -> CONFIGURED -> LIVE).
+//
+// Typical usage:
+//
+//	gw, _ := client.NATGatewayService.CreateNATGateway(ctx, createReq)
+//	order, _ := client.OrderService.CreateOrder(ctx, &CreateOrderRequest{
+//	    Items:     []string{gw.ProductUID},
+//	    Reference: "tf-" + gw.ProductUID,
+//	})
+//	if _, err := client.OrderService.BuyOrder(ctx, order.UID); err != nil {
+//	    // handle
+//	}
+type OrderService interface {
+	// CreateOrder creates a new Order referencing one or more product UIDs.
+	CreateOrder(ctx context.Context, req *CreateOrderRequest) (*Order, error)
+	// GetOrder retrieves an Order by its UID.
+	GetOrder(ctx context.Context, orderUID string) (*Order, error)
+	// UpdateOrder updates an existing Order's items and/or reference.
+	UpdateOrder(ctx context.Context, orderUID string, req *UpdateOrderRequest) (*Order, error)
+	// DeleteOrder deletes an Order. The API only allows deletion while the
+	// Order state is NEW.
+	DeleteOrder(ctx context.Context, orderUID string) error
+	// ValidateOrder validates an Order without purchasing it.
+	ValidateOrder(ctx context.Context, orderUID string) (*Order, error)
+	// BuyOrder purchases (provisions) an Order, causing all items in the
+	// Order to begin provisioning.
+	BuyOrder(ctx context.Context, orderUID string) (*Order, error)
+}
+
+// OrderServiceOp handles communication with Order methods of the Megaport API.
+type OrderServiceOp struct {
+	Client *Client
+}
+
+// NewOrderService creates a new instance of the Order Service.
+func NewOrderService(c *Client) *OrderServiceOp {
+	return &OrderServiceOp{Client: c}
+}
+
+// CreateOrderRequest is the payload for POST /v3/orders.
+type CreateOrderRequest struct {
+	// Items is a list of product UIDs to include in the order.
+	Items []string `json:"items"`
+	// Reference is an optional human-readable reference, e.g. "ORD-123456".
+	Reference string `json:"reference,omitempty"`
+}
+
+// UpdateOrderRequest is the payload for PUT /v3/orders/{orderUid}.
+type UpdateOrderRequest struct {
+	// Items is a list of product UIDs to include in the order.
+	Items []string `json:"items"`
+	// Reference is an optional human-readable reference, e.g. "ORD-123456".
+	Reference string `json:"reference,omitempty"`
+}
+
+// Order represents an Order resource returned by the Megaport API.
+type Order struct {
+	UID        string   `json:"uid"`
+	CompanyUID string   `json:"companyUid"`
+	CreatedBy  string   `json:"createdBy"`
+	Items      []string `json:"items"`
+	Reference  string   `json:"reference"`
+	State      string   `json:"state"`
+}
+
+// orderResponse is the API response envelope for a single Order.
+type orderResponse struct {
+	Message string `json:"message"`
+	Terms   string `json:"terms"`
+	Data    Order  `json:"data"`
+}
+
+// ErrOrderUIDRequired is returned when an Order UID is not provided.
+var ErrOrderUIDRequired = errors.New("order UID is required")
+
+// ErrOrderItemsRequired is returned when no items are provided on create/update.
+var ErrOrderItemsRequired = errors.New("at least one order item is required")
+
+func validateCreateOrderRequest(req *CreateOrderRequest) error {
+	if req == nil || len(req.Items) == 0 {
+		return ErrOrderItemsRequired
+	}
+	return nil
+}
+
+func validateUpdateOrderRequest(orderUID string, req *UpdateOrderRequest) error {
+	if orderUID == "" {
+		return ErrOrderUIDRequired
+	}
+	if req == nil || len(req.Items) == 0 {
+		return ErrOrderItemsRequired
+	}
+	return nil
+}
+
+// CreateOrder creates a new Order.
+func (svc *OrderServiceOp) CreateOrder(ctx context.Context, req *CreateOrderRequest) (*Order, error) {
+	if err := validateCreateOrderRequest(req); err != nil {
+		return nil, err
+	}
+	return svc.doOrderRequest(ctx, http.MethodPost, "/v3/orders", req)
+}
+
+// GetOrder retrieves an Order by UID.
+func (svc *OrderServiceOp) GetOrder(ctx context.Context, orderUID string) (*Order, error) {
+	if orderUID == "" {
+		return nil, ErrOrderUIDRequired
+	}
+	path := fmt.Sprintf("/v3/orders/%s", url.PathEscape(orderUID))
+	return svc.doOrderRequest(ctx, http.MethodGet, path, nil)
+}
+
+// UpdateOrder updates an existing Order.
+func (svc *OrderServiceOp) UpdateOrder(ctx context.Context, orderUID string, req *UpdateOrderRequest) (*Order, error) {
+	if err := validateUpdateOrderRequest(orderUID, req); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v3/orders/%s", url.PathEscape(orderUID))
+	return svc.doOrderRequest(ctx, http.MethodPut, path, req)
+}
+
+// DeleteOrder deletes an Order. The API only allows deletion while the
+// Order state is NEW.
+func (svc *OrderServiceOp) DeleteOrder(ctx context.Context, orderUID string) error {
+	if orderUID == "" {
+		return ErrOrderUIDRequired
+	}
+	path := fmt.Sprintf("/v3/orders/%s", url.PathEscape(orderUID))
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Client.Do(ctx, clientReq, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// ValidateOrder validates an Order without purchasing it.
+func (svc *OrderServiceOp) ValidateOrder(ctx context.Context, orderUID string) (*Order, error) {
+	if orderUID == "" {
+		return nil, ErrOrderUIDRequired
+	}
+	path := fmt.Sprintf("/v3/orders/%s/validate", url.PathEscape(orderUID))
+	return svc.doOrderRequest(ctx, http.MethodPost, path, nil)
+}
+
+// BuyOrder purchases (provisions) an Order.
+func (svc *OrderServiceOp) BuyOrder(ctx context.Context, orderUID string) (*Order, error) {
+	if orderUID == "" {
+		return nil, ErrOrderUIDRequired
+	}
+	path := fmt.Sprintf("/v3/orders/%s/buy", url.PathEscape(orderUID))
+	return svc.doOrderRequest(ctx, http.MethodPost, path, nil)
+}
+
+func (svc *OrderServiceOp) doOrderRequest(ctx context.Context, method, path string, body interface{}) (*Order, error) {
+	clientReq, err := svc.Client.NewRequest(ctx, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var envelope orderResponse
+	if err := json.Unmarshal(buf.Bytes(), &envelope); err != nil {
+		return nil, err
+	}
+	return &envelope.Data, nil
+}

--- a/orders_test.go
+++ b/orders_test.go
@@ -1,0 +1,184 @@
+package megaport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// OrderServiceTestSuite tests the Order service.
+type OrderServiceTestSuite struct {
+	ClientTestSuite
+}
+
+func TestOrderServiceTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(OrderServiceTestSuite))
+}
+
+func (suite *OrderServiceTestSuite) SetupTest() {
+	suite.mux = http.NewServeMux()
+	suite.server = httptest.NewServer(suite.mux)
+
+	suite.client = NewClient(nil, nil)
+	u, _ := url.Parse(suite.server.URL)
+	suite.client.BaseURL = u
+}
+
+func (suite *OrderServiceTestSuite) TearDownTest() {
+	suite.server.Close()
+}
+
+const orderResponseJSON = `{
+	"message": "Data returned successfully",
+	"terms": "This data is subject to the Acceptable Use Policy",
+	"data": {
+		"companyUid": "e900d0d5-1030-4e29-b2d8-816ad4263190",
+		"createdBy": "user-name",
+		"items": ["e900d0d5-1030-4e29-b2d8-816ad4263190"],
+		"reference": "ORD-123456",
+		"state": "DESIGN",
+		"uid": "11111111-2222-3333-4444-555555555555"
+	}
+}`
+
+func (suite *OrderServiceTestSuite) TestCreateOrder() {
+	ctx := context.Background()
+
+	suite.mux.HandleFunc("/v3/orders", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		suite.NoError(err)
+		var payload CreateOrderRequest
+		suite.NoError(json.Unmarshal(body, &payload))
+		suite.Equal([]string{"nat-gw-uid"}, payload.Items)
+		suite.Equal("ORD-TEST", payload.Reference)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, orderResponseJSON)
+	})
+
+	order, err := suite.client.OrderService.CreateOrder(ctx, &CreateOrderRequest{
+		Items:     []string{"nat-gw-uid"},
+		Reference: "ORD-TEST",
+	})
+	suite.NoError(err)
+	suite.Equal("11111111-2222-3333-4444-555555555555", order.UID)
+	suite.Equal("DESIGN", order.State)
+}
+
+func (suite *OrderServiceTestSuite) TestCreateOrder_MissingItems() {
+	_, err := suite.client.OrderService.CreateOrder(context.Background(), &CreateOrderRequest{})
+	suite.ErrorIs(err, ErrOrderItemsRequired)
+}
+
+func (suite *OrderServiceTestSuite) TestGetOrder() {
+	ctx := context.Background()
+	uid := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/orders/"+uid, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, orderResponseJSON)
+	})
+
+	order, err := suite.client.OrderService.GetOrder(ctx, uid)
+	suite.NoError(err)
+	suite.Equal(uid, order.UID)
+	suite.Equal("DESIGN", order.State)
+}
+
+func (suite *OrderServiceTestSuite) TestGetOrder_MissingUID() {
+	_, err := suite.client.OrderService.GetOrder(context.Background(), "")
+	suite.ErrorIs(err, ErrOrderUIDRequired)
+}
+
+func (suite *OrderServiceTestSuite) TestUpdateOrder() {
+	ctx := context.Background()
+	uid := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/orders/"+uid, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPut, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		suite.NoError(err)
+		var payload UpdateOrderRequest
+		suite.NoError(json.Unmarshal(body, &payload))
+		suite.Equal("ORD-UPDATED", payload.Reference)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, orderResponseJSON)
+	})
+
+	order, err := suite.client.OrderService.UpdateOrder(ctx, uid, &UpdateOrderRequest{
+		Items:     []string{"nat-gw-uid"},
+		Reference: "ORD-UPDATED",
+	})
+	suite.NoError(err)
+	suite.Equal(uid, order.UID)
+}
+
+func (suite *OrderServiceTestSuite) TestDeleteOrder() {
+	ctx := context.Background()
+	uid := "11111111-2222-3333-4444-555555555555"
+
+	called := false
+	suite.mux.HandleFunc("/v3/orders/"+uid, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		suite.Equal(http.MethodDelete, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"Order deleted successfully","terms":""}`)
+	})
+
+	err := suite.client.OrderService.DeleteOrder(ctx, uid)
+	suite.NoError(err)
+	suite.True(called)
+}
+
+func (suite *OrderServiceTestSuite) TestDeleteOrder_MissingUID() {
+	err := suite.client.OrderService.DeleteOrder(context.Background(), "")
+	suite.ErrorIs(err, ErrOrderUIDRequired)
+}
+
+func (suite *OrderServiceTestSuite) TestValidateOrder() {
+	ctx := context.Background()
+	uid := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/orders/"+uid+"/validate", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, orderResponseJSON)
+	})
+
+	order, err := suite.client.OrderService.ValidateOrder(ctx, uid)
+	suite.NoError(err)
+	suite.Equal(uid, order.UID)
+}
+
+func (suite *OrderServiceTestSuite) TestBuyOrder() {
+	ctx := context.Background()
+	uid := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/orders/"+uid+"/buy", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, orderResponseJSON)
+	})
+
+	order, err := suite.client.OrderService.BuyOrder(ctx, uid)
+	suite.NoError(err)
+	suite.Equal(uid, order.UID)
+}
+
+func (suite *OrderServiceTestSuite) TestBuyOrder_MissingUID() {
+	_, err := suite.client.OrderService.BuyOrder(context.Background(), "")
+	suite.ErrorIs(err, ErrOrderUIDRequired)
+}


### PR DESCRIPTION
## Summary

Adds a new `OrderService` that wraps the Megaport Orders API
(`/v3/orders/*`). Currently the SDK has no way to submit an order for
provisioning, which means products that ship in a non-purchased
DESIGN state cannot be fully provisioned via the SDK.

## Why this is needed

The NAT Gateway API docs state explicitly:

> **NOTE:** This does not purchase the NAT Gateway. To purchase network
> products, use the `POST /v3/orders` endpoint.

Today `NATGatewayService.CreateNATGateway` calls
`POST /v3/products/nat_gateways`, which returns a gateway in `DESIGN`
status. Without the Orders endpoints there is no way to progress the
gateway into the normal provisioning lifecycle
(`DEPLOYABLE -> CONFIGURED -> LIVE`).

This was observed downstream in the Terraform provider: the
`megaport_nat_gateway` resource's provisioning wait loop was guaranteed
to time out after 10 minutes because the API never transitions a
design-state gateway on its own. The provider is being updated to
remove the pointless wait, and a follow-up PR there will use this new
service to actually purchase the gateway during `terraform apply`.

Other products (Port, MCR, MVE, VXC, IX) don't have this problem
because they go through `/v3/networkdesign/buy`, which combines design
and purchase in a single call. NAT Gateway — and likely future
products — use the two-step design-then-order flow instead.

## What's added

| Method | HTTP | Path |
|---|---|---|
| `CreateOrder` | POST | `/v3/orders` |
| `GetOrder` | GET | `/v3/orders/{uid}` |
| `UpdateOrder` | PUT | `/v3/orders/{uid}` |
| `DeleteOrder` | DELETE | `/v3/orders/{uid}` |
| `ValidateOrder` | POST | `/v3/orders/{uid}/validate` |
| `BuyOrder` | POST | `/v3/orders/{uid}/buy` |

Plus:
- `CreateOrderRequest` / `UpdateOrderRequest` request types
- `Order` response type (`uid`, `companyUid`, `createdBy`, `items`, `reference`, `state`)
- Input validation errors (`ErrOrderUIDRequired`, `ErrOrderItemsRequired`)
- Service registration in `client.go`

## Intended usage

```go
gw, _ := client.NATGatewayService.CreateNATGateway(ctx, createReq)
order, _ := client.OrderService.CreateOrder(ctx, &megaport.CreateOrderRequest{
    Items:     []string{gw.ProductUID},
    Reference: "tf-" + gw.ProductUID,
})
if _, err := client.OrderService.BuyOrder(ctx, order.UID); err != nil {
    // handle
}
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all existing suites pass
- [x] New `OrderServiceTestSuite` covers each endpoint (success path + missing-UID/items validation) using the existing `httptest.Server` pattern
- [ ] Integration test against staging (follow-up once the Terraform provider's consumer PR lands and can exercise the full chain)