### PR TITLE
feat: add NAT Gateway validate and buy methods

### DIFF
--- a/location.go
+++ b/location.go
@@ -26,6 +26,9 @@ type LocationService interface {
 	FilterLocationsByMarketCodeV3(ctx context.Context, marketCode string, locations []*LocationV3) ([]*LocationV3, error)
 	// FilterLocationsByMcrAvailabilityV3 filters locations by MCR availability in the Megaport Locations API v3.
 	FilterLocationsByMcrAvailabilityV3(ctx context.Context, mcrAvailable bool, locations []*LocationV3) []*LocationV3
+	// FilterLocationsByNATGatewaySpeedV3 filters locations by NAT Gateway
+	// speed availability (Mbps) advertised in the v3 API diversity zones.
+	FilterLocationsByNATGatewaySpeedV3(ctx context.Context, speedMbps int, locations []*LocationV3) []*LocationV3
 
 	// Shared methods (work with both v2 and v3)
 	// ListCountries returns a list of all countries in the Megaport Network Regions API.
@@ -132,10 +135,11 @@ type LocationV3DiversityZones struct {
 
 // LocationV3DiversityZone represents a single diversity zone with product availability
 type LocationV3DiversityZone struct {
-	McrSpeedMbps       []int `json:"mcrSpeedMbps,omitempty"`
-	MegaportSpeedMbps  []int `json:"megaportSpeedMbps,omitempty"`
-	MveMaxCpuCoreCount *int  `json:"mveMaxCpuCoreCount,omitempty"`
-	MveAvailable       bool  `json:"mveAvailable"`
+	McrSpeedMbps        []int `json:"mcrSpeedMbps,omitempty"`
+	MegaportSpeedMbps   []int `json:"megaportSpeedMbps,omitempty"`
+	MveMaxCpuCoreCount  *int  `json:"mveMaxCpuCoreCount,omitempty"`
+	MveAvailable        bool  `json:"mveAvailable"`
+	NATGatewaySpeedMbps []int `json:"natGatewaySpeedMbps,omitempty"`
 }
 
 // LocationV3ProductAddOns represents additional product options available at the location
@@ -311,6 +315,18 @@ func (svc *LocationServiceOp) FilterLocationsByMcrAvailabilityV3(ctx context.Con
 	return toReturn
 }
 
+// FilterLocationsByNATGatewaySpeedV3 returns only locations where at least
+// one diversity zone advertises the given NAT Gateway speed (Mbps).
+func (svc *LocationServiceOp) FilterLocationsByNATGatewaySpeedV3(ctx context.Context, speedMbps int, locations []*LocationV3) []*LocationV3 {
+	toReturn := []*LocationV3{}
+	for _, location := range locations {
+		if location.SupportsNATGatewaySpeed(speedMbps) {
+			toReturn = append(toReturn, location)
+		}
+	}
+	return toReturn
+}
+
 // ==========================================
 // HELPER METHODS FOR LOCATIONV3
 // ==========================================
@@ -382,6 +398,55 @@ func (l *LocationV3) GetMegaportSpeeds() []int {
 	}
 
 	return uniqueSpeeds
+}
+
+// HasNATGatewaySupport checks if the location supports NAT Gateway in any
+// diversity zone.
+func (l *LocationV3) HasNATGatewaySupport() bool {
+	if l.DiversityZones == nil {
+		return false
+	}
+	if l.DiversityZones.Red != nil && len(l.DiversityZones.Red.NATGatewaySpeedMbps) > 0 {
+		return true
+	}
+	if l.DiversityZones.Blue != nil && len(l.DiversityZones.Blue.NATGatewaySpeedMbps) > 0 {
+		return true
+	}
+	return false
+}
+
+// GetNATGatewaySpeeds returns the deduplicated list of NAT Gateway speeds
+// supported at this location across both diversity zones.
+func (l *LocationV3) GetNATGatewaySpeeds() []int {
+	var allSpeeds []int
+	if l.DiversityZones != nil {
+		if l.DiversityZones.Red != nil {
+			allSpeeds = append(allSpeeds, l.DiversityZones.Red.NATGatewaySpeedMbps...)
+		}
+		if l.DiversityZones.Blue != nil {
+			allSpeeds = append(allSpeeds, l.DiversityZones.Blue.NATGatewaySpeedMbps...)
+		}
+	}
+	seen := make(map[int]bool)
+	var unique []int
+	for _, s := range allSpeeds {
+		if !seen[s] {
+			seen[s] = true
+			unique = append(unique, s)
+		}
+	}
+	return unique
+}
+
+// SupportsNATGatewaySpeed reports whether the location supports a NAT
+// Gateway at the given speed (Mbps) in any diversity zone.
+func (l *LocationV3) SupportsNATGatewaySpeed(speedMbps int) bool {
+	for _, s := range l.GetNATGatewaySpeeds() {
+		if s == speedMbps {
+			return true
+		}
+	}
+	return false
 }
 
 // HasMVESupport checks if the location supports MVE.

--- a/location_test.go
+++ b/location_test.go
@@ -802,6 +802,69 @@ func (suite *LocationV3ClientTestSuite) TestFilterLocationsByMcrAvailabilityV3()
 	suite.Equal(want, got)
 }
 
+// TestFilterLocationsByNATGatewaySpeedV3 tests the NAT Gateway speed filter.
+func (suite *LocationV3ClientTestSuite) TestFilterLocationsByNATGatewaySpeedV3() {
+	ctx := context.Background()
+	locSvc := suite.client.LocationService
+
+	locations := []*LocationV3{
+		{
+			ID: 1, Name: "has-1000-red",
+			DiversityZones: &LocationV3DiversityZones{
+				Red: &LocationV3DiversityZone{NATGatewaySpeedMbps: []int{1000, 2500}},
+			},
+		},
+		{
+			ID: 2, Name: "has-1000-blue",
+			DiversityZones: &LocationV3DiversityZones{
+				Blue: &LocationV3DiversityZone{NATGatewaySpeedMbps: []int{1000}},
+			},
+		},
+		{
+			ID: 3, Name: "has-5000-only",
+			DiversityZones: &LocationV3DiversityZones{
+				Red: &LocationV3DiversityZone{NATGatewaySpeedMbps: []int{5000}},
+			},
+		},
+		{
+			ID:             4,
+			Name:           "no-nat-gateway",
+			DiversityZones: &LocationV3DiversityZones{},
+		},
+	}
+
+	got := locSvc.FilterLocationsByNATGatewaySpeedV3(ctx, 1000, locations)
+	suite.Len(got, 2)
+	suite.Equal(1, got[0].ID)
+	suite.Equal(2, got[1].ID)
+
+	// Speed not supported at any location
+	suite.Empty(locSvc.FilterLocationsByNATGatewaySpeedV3(ctx, 400000, locations))
+}
+
+// TestLocationV3NATGatewayHelpers tests the NAT Gateway helper methods on LocationV3.
+func (suite *LocationV3ClientTestSuite) TestLocationV3NATGatewayHelpers() {
+	loc := &LocationV3{
+		DiversityZones: &LocationV3DiversityZones{
+			Red:  &LocationV3DiversityZone{NATGatewaySpeedMbps: []int{1000, 2500, 5000}},
+			Blue: &LocationV3DiversityZone{NATGatewaySpeedMbps: []int{1000}},
+		},
+	}
+	suite.True(loc.HasNATGatewaySupport())
+	suite.True(loc.SupportsNATGatewaySpeed(1000))
+	suite.True(loc.SupportsNATGatewaySpeed(5000))
+	suite.False(loc.SupportsNATGatewaySpeed(100000))
+	suite.ElementsMatch([]int{1000, 2500, 5000}, loc.GetNATGatewaySpeeds())
+
+	empty := &LocationV3{DiversityZones: &LocationV3DiversityZones{}}
+	suite.False(empty.HasNATGatewaySupport())
+	suite.False(empty.SupportsNATGatewaySpeed(1000))
+	suite.Empty(empty.GetNATGatewaySpeeds())
+
+	nilZones := &LocationV3{}
+	suite.False(nilZones.HasNATGatewaySupport())
+}
+
 // TestLocationV3HelperMethods tests the helper methods for LocationV3 struct.
 func (suite *LocationV3ClientTestSuite) TestLocationV3HelperMethods() {
 	// Test location with MCR support

--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -29,6 +29,14 @@ type NATGatewayService interface {
 	ListNATGatewaySessions(ctx context.Context) ([]*NATGatewaySession, error)
 	// GetNATGatewayTelemetry returns telemetry data for a NAT Gateway product.
 	GetNATGatewayTelemetry(ctx context.Context, req *GetNATGatewayTelemetryRequest) (*ServiceTelemetryResponse, error)
+	// ValidateNATGatewayOrder validates a NAT Gateway design via
+	// POST /v3/networkdesign/validate. The gateway must be in DESIGN state.
+	ValidateNATGatewayOrder(ctx context.Context, productUID string) error
+	// BuyNATGateway purchases (provisions) a NAT Gateway design via
+	// POST /v3/networkdesign/buy. The gateway must be in DESIGN state;
+	// after a successful call it transitions through the normal
+	// DEPLOYABLE -> CONFIGURED -> LIVE lifecycle.
+	BuyNATGateway(ctx context.Context, productUID string) error
 }
 
 // NewNATGatewayService creates a new instance of the NAT Gateway Service.
@@ -216,6 +224,43 @@ func (svc *NATGatewayServiceOp) DeleteNATGateway(ctx context.Context, productUID
 
 	path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Client.Do(ctx, clientReq, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// natGatewayOrderItem is the minimal payload expected by
+// /v3/networkdesign/validate and /v3/networkdesign/buy for NAT Gateway
+// designs. The endpoints accept an array of items.
+type natGatewayOrderItem struct {
+	ProductUID string `json:"productUid"`
+}
+
+// ValidateNATGatewayOrder validates a NAT Gateway design without purchasing.
+func (svc *NATGatewayServiceOp) ValidateNATGatewayOrder(ctx context.Context, productUID string) error {
+	if productUID == "" {
+		return ErrNATGatewayProductUIDRequired
+	}
+	return svc.postNetworkDesign(ctx, "/v3/networkdesign/validate", productUID)
+}
+
+// BuyNATGateway purchases a NAT Gateway design, kicking off provisioning.
+func (svc *NATGatewayServiceOp) BuyNATGateway(ctx context.Context, productUID string) error {
+	if productUID == "" {
+		return ErrNATGatewayProductUIDRequired
+	}
+	return svc.postNetworkDesign(ctx, "/v3/networkdesign/buy", productUID)
+}
+
+func (svc *NATGatewayServiceOp) postNetworkDesign(ctx context.Context, path, productUID string) error {
+	body := []natGatewayOrderItem{{ProductUID: productUID}}
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPost, path, body)
 	if err != nil {
 		return err
 	}

--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -31,12 +31,14 @@ type NATGatewayService interface {
 	GetNATGatewayTelemetry(ctx context.Context, req *GetNATGatewayTelemetryRequest) (*ServiceTelemetryResponse, error)
 	// ValidateNATGatewayOrder validates a NAT Gateway design via
 	// POST /v3/networkdesign/validate. The gateway must be in DESIGN state.
-	ValidateNATGatewayOrder(ctx context.Context, productUID string) error
+	// Returns an order preview including pricing.
+	ValidateNATGatewayOrder(ctx context.Context, productUID string) (*NATGatewayValidateResult, error)
 	// BuyNATGateway purchases (provisions) a NAT Gateway design via
 	// POST /v3/networkdesign/buy. The gateway must be in DESIGN state;
 	// after a successful call it transitions through the normal
-	// DEPLOYABLE -> CONFIGURED -> LIVE lifecycle.
-	BuyNATGateway(ctx context.Context, productUID string) error
+	// DEPLOYABLE -> CONFIGURED -> LIVE lifecycle. Returns the provisioning
+	// service record.
+	BuyNATGateway(ctx context.Context, productUID string) (*NATGatewayBuyResult, error)
 }
 
 // NewNATGatewayService creates a new instance of the NAT Gateway Service.
@@ -242,33 +244,60 @@ type natGatewayOrderItem struct {
 	ProductUID string `json:"productUid"`
 }
 
+// ErrNATGatewayOrderResponseEmpty is returned when the API response data
+// array is empty (the endpoints are expected to return one entry per
+// submitted productUid).
+var ErrNATGatewayOrderResponseEmpty = errors.New("nat gateway order response contained no data")
+
 // ValidateNATGatewayOrder validates a NAT Gateway design without purchasing.
-func (svc *NATGatewayServiceOp) ValidateNATGatewayOrder(ctx context.Context, productUID string) error {
+// The returned result includes a pricing preview.
+func (svc *NATGatewayServiceOp) ValidateNATGatewayOrder(ctx context.Context, productUID string) (*NATGatewayValidateResult, error) {
 	if productUID == "" {
-		return ErrNATGatewayProductUIDRequired
+		return nil, ErrNATGatewayProductUIDRequired
 	}
-	return svc.postNetworkDesign(ctx, "/v3/networkdesign/validate", productUID)
+	var envelope natGatewayValidateEnvelope
+	if err := svc.postNetworkDesign(ctx, "/v3/networkdesign/validate", productUID, &envelope); err != nil {
+		return nil, err
+	}
+	if len(envelope.Data) == 0 {
+		return nil, ErrNATGatewayOrderResponseEmpty
+	}
+	return envelope.Data[0], nil
 }
 
 // BuyNATGateway purchases a NAT Gateway design, kicking off provisioning.
-func (svc *NATGatewayServiceOp) BuyNATGateway(ctx context.Context, productUID string) error {
+// The returned result contains the initial provisioning service record.
+func (svc *NATGatewayServiceOp) BuyNATGateway(ctx context.Context, productUID string) (*NATGatewayBuyResult, error) {
 	if productUID == "" {
-		return ErrNATGatewayProductUIDRequired
+		return nil, ErrNATGatewayProductUIDRequired
 	}
-	return svc.postNetworkDesign(ctx, "/v3/networkdesign/buy", productUID)
+	var envelope natGatewayBuyEnvelope
+	if err := svc.postNetworkDesign(ctx, "/v3/networkdesign/buy", productUID, &envelope); err != nil {
+		return nil, err
+	}
+	if len(envelope.Data) == 0 {
+		return nil, ErrNATGatewayOrderResponseEmpty
+	}
+	return envelope.Data[0], nil
 }
 
-func (svc *NATGatewayServiceOp) postNetworkDesign(ctx context.Context, path, productUID string) error {
+func (svc *NATGatewayServiceOp) postNetworkDesign(ctx context.Context, path, productUID string, out interface{}) error {
 	body := []natGatewayOrderItem{{ProductUID: productUID}}
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodPost, path, body)
 	if err != nil {
 		return err
 	}
-	resp, err := svc.Client.Do(ctx, clientReq, nil)
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+	if out != nil {
+		if err := json.Unmarshal(buf.Bytes(), out); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -168,65 +168,114 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 	logger := suite.client.Logger
 	natSvc := suite.client.NATGatewayService
 
-	// Step 1: List sessions to pick a valid speed/session count.
+	// Step 1: List sessions to pick the smallest speed/session-count combo
+	// (small speeds are supported at more locations).
 	sessions, err := natSvc.ListNATGatewaySessions(ctx)
 	if err != nil {
 		suite.FailNowf("could not list sessions", "could not list NAT Gateway sessions: %v", err)
 	}
 	suite.NotEmpty(sessions, "expected at least one session configuration")
-	testSpeed := sessions[0].SpeedMbps
-	testSessionCount := sessions[0].SessionCount[0]
-
-	// Step 2: Pick a location.
-	testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
-	if locErr != nil {
-		suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
+	minSession := sessions[0]
+	for _, s := range sessions[1:] {
+		if s.SpeedMbps < minSession.SpeedMbps {
+			minSession = s
+		}
 	}
-	suite.NotNil(testLocation)
-
-	// Step 3: Create the NAT Gateway (returns in DESIGN).
-	createReq := &CreateNATGatewayRequest{
-		AutoRenewTerm: true,
-		Config: NATGatewayNetworkConfig{
-			ASN:                64512,
-			BGPShutdownDefault: false,
-			DiversityZone:      "red",
-			SessionCount:       testSessionCount,
-		},
-		LocationID:  testLocation.ID,
-		ProductName: "Integration Test NAT Gateway (Full Lifecycle)",
-		Speed:       testSpeed,
-		Term:        1,
-	}
-	gw, err := natSvc.CreateNATGateway(ctx, createReq)
-	if err != nil {
-		suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", err)
-	}
-	productUID := gw.ProductUID
-	suite.NotEmpty(productUID)
-	logger.InfoContext(ctx, "NAT Gateway design created",
-		slog.String("product_uid", productUID),
-		slog.String("provisioning_status", gw.ProvisioningStatus),
+	testSpeed := minSession.SpeedMbps
+	testSessionCount := minSession.SessionCount[0]
+	logger.InfoContext(ctx, "Selected session config",
+		slog.Int("speed", testSpeed),
+		slog.Int("session_count", testSessionCount),
 	)
 
-	// Teardown: cancel the product immediately. Works regardless of state
-	// (DESIGN or post-buy) and runs even if a later step fails.
+	// Step 2: Pick a location and create the gateway, then probe
+	// /networkdesign/validate. If the location doesn't support the chosen
+	// speed, the API returns 400 at validate time — delete the design and
+	// retry with a different location. Bounded retries so a wholly broken
+	// environment doesn't loop forever.
+	const maxLocationAttempts = 5
+
+	var (
+		productUID string
+		gw         *NATGateway
+	)
+	for attempt := 1; attempt <= maxLocationAttempts; attempt++ {
+		testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
+		if locErr != nil {
+			suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
+		}
+		suite.NotNil(testLocation)
+
+		createReq := &CreateNATGatewayRequest{
+			AutoRenewTerm: false,
+			Config: NATGatewayNetworkConfig{
+				ASN:                64512,
+				BGPShutdownDefault: false,
+				DiversityZone:      "red",
+				SessionCount:       testSessionCount,
+			},
+			LocationID:  testLocation.ID,
+			ProductName: "Integration Test NAT Gateway (Full Lifecycle)",
+			Speed:       testSpeed,
+			Term:        1,
+		}
+		candidate, createErr := natSvc.CreateNATGateway(ctx, createReq)
+		if createErr != nil {
+			suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", createErr)
+		}
+		logger.InfoContext(ctx, "NAT Gateway design created",
+			slog.Int("attempt", attempt),
+			slog.String("product_uid", candidate.ProductUID),
+			slog.String("location", testLocation.Name),
+			slog.Int("location_id", testLocation.ID),
+		)
+
+		if vErr := natSvc.ValidateNATGatewayOrder(ctx, candidate.ProductUID); vErr != nil {
+			logger.WarnContext(ctx, "validation failed at location, retrying",
+				slog.String("location", testLocation.Name),
+				slog.String("error", vErr.Error()),
+			)
+			if dErr := natSvc.DeleteNATGateway(ctx, candidate.ProductUID); dErr != nil {
+				logger.WarnContext(ctx, "could not clean up DESIGN gateway after failed validate",
+					slog.String("product_uid", candidate.ProductUID),
+					slog.String("error", dErr.Error()),
+				)
+			}
+			continue
+		}
+
+		gw = candidate
+		productUID = candidate.ProductUID
+		logger.InfoContext(ctx, "NAT Gateway order validated", slog.String("product_uid", productUID))
+		break
+	}
+	if productUID == "" {
+		suite.FailNowf("could not validate at any location", "exhausted %d location attempts", maxLocationAttempts)
+	}
+	suite.NotNil(gw)
+
+	// Teardown: DESIGN gateways must be removed via DELETE /v3/products/nat_gateways/{uid};
+	// provisioned gateways are cancelled via ProductService.
 	defer func() {
 		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
-		_, delErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+		current, getErr := natSvc.GetNATGateway(ctx, productUID)
+		if getErr != nil {
+			logger.WarnContext(ctx, "teardown: could not fetch current state", slog.String("error", getErr.Error()))
+			return
+		}
+		if current.ProvisioningStatus == "DESIGN" {
+			if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
+				logger.WarnContext(ctx, "teardown failed (DESIGN delete)", slog.String("error", dErr.Error()))
+			}
+			return
+		}
+		if _, dErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
 			ProductID: productUID,
 			DeleteNow: true,
-		})
-		if delErr != nil {
-			logger.WarnContext(ctx, "teardown failed", slog.String("error", delErr.Error()))
+		}); dErr != nil {
+			logger.WarnContext(ctx, "teardown failed (CANCEL_NOW)", slog.String("error", dErr.Error()))
 		}
 	}()
-
-	// Step 4: Validate the gateway via /v3/networkdesign/validate.
-	if err := natSvc.ValidateNATGatewayOrder(ctx, productUID); err != nil {
-		suite.FailNowf("could not validate NAT Gateway", "could not validate NAT Gateway: %v", err)
-	}
-	logger.InfoContext(ctx, "NAT Gateway order validated", slog.String("product_uid", productUID))
 
 	// Step 5: Buy the gateway via /v3/networkdesign/buy — kicks off provisioning.
 	if err := natSvc.BuyNATGateway(ctx, productUID); err != nil {

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -230,7 +230,8 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 			slog.Int("location_id", testLocation.ID),
 		)
 
-		if vErr := natSvc.ValidateNATGatewayOrder(ctx, candidate.ProductUID); vErr != nil {
+		validation, vErr := natSvc.ValidateNATGatewayOrder(ctx, candidate.ProductUID)
+		if vErr != nil {
 			logger.WarnContext(ctx, "validation failed at location, retrying",
 				slog.String("location", testLocation.Name),
 				slog.String("error", vErr.Error()),
@@ -246,7 +247,11 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 
 		gw = candidate
 		productUID = candidate.ProductUID
-		logger.InfoContext(ctx, "NAT Gateway order validated", slog.String("product_uid", productUID))
+		logger.InfoContext(ctx, "NAT Gateway order validated",
+			slog.String("product_uid", productUID),
+			slog.Float64("monthly_rate", validation.Price.MonthlyRate),
+			slog.String("currency", validation.Price.Currency),
+		)
 		break
 	}
 	if productUID == "" {
@@ -263,7 +268,7 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 			logger.WarnContext(ctx, "teardown: could not fetch current state", slog.String("error", getErr.Error()))
 			return
 		}
-		if current.ProvisioningStatus == "DESIGN" {
+		if current.ProvisioningStatus == STATUS_DESIGN {
 			if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
 				logger.WarnContext(ctx, "teardown failed (DESIGN delete)", slog.String("error", dErr.Error()))
 			}
@@ -278,10 +283,15 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 	}()
 
 	// Step 5: Buy the gateway via /v3/networkdesign/buy — kicks off provisioning.
-	if err := natSvc.BuyNATGateway(ctx, productUID); err != nil {
+	bought, err := natSvc.BuyNATGateway(ctx, productUID)
+	if err != nil {
 		suite.FailNowf("could not buy NAT Gateway", "could not buy NAT Gateway: %v", err)
 	}
-	logger.InfoContext(ctx, "NAT Gateway order bought", slog.String("product_uid", productUID))
+	suite.Equal(productUID, bought.ProductUID)
+	logger.InfoContext(ctx, "NAT Gateway order bought",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", bought.ProvisioningStatus),
+	)
 
 	// Step 6: Poll until the gateway reaches CONFIGURED/LIVE, or fail fast
 	// on a terminal error state.

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -188,76 +188,52 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 		slog.Int("session_count", testSessionCount),
 	)
 
-	// Step 2: Pick a location and create the gateway, then probe
-	// /networkdesign/validate. If the location doesn't support the chosen
-	// speed, the API returns 400 at validate time — delete the design and
-	// retry with a different location. Bounded retries so a wholly broken
-	// environment doesn't loop forever.
-	const maxLocationAttempts = 5
-
-	var (
-		productUID string
-		gw         *NATGateway
+	// Step 2: Pick a location that advertises NAT Gateway support at the
+	// chosen speed. v3/locations surfaces availability via
+	// diversityZones.{red,blue}.natGatewaySpeedMbps, so we can filter
+	// up front instead of probing with validate.
+	locations, err := suite.client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		suite.FailNowf("could not list locations", "could not list locations: %v", err)
+	}
+	marketLocations, err := suite.client.LocationService.FilterLocationsByMarketCodeV3(ctx, TEST_NAT_GATEWAY_LOCATION_MARKET, locations)
+	if err != nil {
+		suite.FailNowf("could not filter by market", "could not filter by market: %v", err)
+	}
+	eligible := suite.client.LocationService.FilterLocationsByNATGatewaySpeedV3(ctx, testSpeed, marketLocations)
+	if len(eligible) == 0 {
+		suite.FailNowf("no eligible location", "no location in market %q advertises NAT Gateway speed %d", TEST_NAT_GATEWAY_LOCATION_MARKET, testSpeed)
+	}
+	testLocation := eligible[0]
+	logger.InfoContext(ctx, "Selected eligible location",
+		slog.String("location", testLocation.Name),
+		slog.Int("location_id", testLocation.ID),
+		slog.Int("eligible_count", len(eligible)),
 	)
-	for attempt := 1; attempt <= maxLocationAttempts; attempt++ {
-		testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
-		if locErr != nil {
-			suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
-		}
-		suite.NotNil(testLocation)
 
-		createReq := &CreateNATGatewayRequest{
-			AutoRenewTerm: false,
-			Config: NATGatewayNetworkConfig{
-				ASN:                64512,
-				BGPShutdownDefault: false,
-				DiversityZone:      "red",
-				SessionCount:       testSessionCount,
-			},
-			LocationID:  testLocation.ID,
-			ProductName: "Integration Test NAT Gateway (Full Lifecycle)",
-			Speed:       testSpeed,
-			Term:        1,
-		}
-		candidate, createErr := natSvc.CreateNATGateway(ctx, createReq)
-		if createErr != nil {
-			suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", createErr)
-		}
-		logger.InfoContext(ctx, "NAT Gateway design created",
-			slog.Int("attempt", attempt),
-			slog.String("product_uid", candidate.ProductUID),
-			slog.String("location", testLocation.Name),
-			slog.Int("location_id", testLocation.ID),
-		)
-
-		validation, vErr := natSvc.ValidateNATGatewayOrder(ctx, candidate.ProductUID)
-		if vErr != nil {
-			logger.WarnContext(ctx, "validation failed at location, retrying",
-				slog.String("location", testLocation.Name),
-				slog.String("error", vErr.Error()),
-			)
-			if dErr := natSvc.DeleteNATGateway(ctx, candidate.ProductUID); dErr != nil {
-				logger.WarnContext(ctx, "could not clean up DESIGN gateway after failed validate",
-					slog.String("product_uid", candidate.ProductUID),
-					slog.String("error", dErr.Error()),
-				)
-			}
-			continue
-		}
-
-		gw = candidate
-		productUID = candidate.ProductUID
-		logger.InfoContext(ctx, "NAT Gateway order validated",
-			slog.String("product_uid", productUID),
-			slog.Float64("monthly_rate", validation.Price.MonthlyRate),
-			slog.String("currency", validation.Price.Currency),
-		)
-		break
+	// Step 3: Create the NAT Gateway design.
+	gw, err := natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		AutoRenewTerm: false,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: false,
+			DiversityZone:      "red",
+			SessionCount:       testSessionCount,
+		},
+		LocationID:  testLocation.ID,
+		ProductName: "Integration Test NAT Gateway (Full Lifecycle)",
+		Speed:       testSpeed,
+		Term:        1,
+	})
+	if err != nil {
+		suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", err)
 	}
-	if productUID == "" {
-		suite.FailNowf("could not validate at any location", "exhausted %d location attempts", maxLocationAttempts)
-	}
-	suite.NotNil(gw)
+	productUID := gw.ProductUID
+	suite.NotEmpty(productUID)
+	logger.InfoContext(ctx, "NAT Gateway design created",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", gw.ProvisioningStatus),
+	)
 
 	// Teardown: DESIGN gateways must be removed via DELETE /v3/products/nat_gateways/{uid};
 	// provisioned gateways are cancelled via ProductService.
@@ -281,6 +257,18 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 			logger.WarnContext(ctx, "teardown failed (CANCEL_NOW)", slog.String("error", dErr.Error()))
 		}
 	}()
+
+	// Step 4: Validate the order (pricing preview).
+	validation, err := natSvc.ValidateNATGatewayOrder(ctx, productUID)
+	if err != nil {
+		suite.FailNowf("could not validate NAT Gateway", "could not validate NAT Gateway: %v", err)
+	}
+	suite.Equal(productUID, validation.ProductUID)
+	logger.InfoContext(ctx, "NAT Gateway order validated",
+		slog.String("product_uid", productUID),
+		slog.Float64("monthly_rate", validation.Price.MonthlyRate),
+		slog.String("currency", validation.Price.Currency),
+	)
 
 	// Step 5: Buy the gateway via /v3/networkdesign/buy — kicks off provisioning.
 	bought, err := natSvc.BuyNATGateway(ctx, productUID)

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -154,4 +156,153 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
 		suite.FailNowf("could not delete NAT Gateway", "could not delete NAT Gateway: %v", err)
 	}
 	logger.DebugContext(ctx, "NAT Gateway deleted", slog.String("product_uid", productUID))
+}
+
+// TestNATGatewayFullLifecycle exercises the end-to-end flow: create the
+// design record, validate and buy the gateway via the network-design
+// endpoints, wait for it to reach CONFIGURED/LIVE, update a mutable field,
+// and tear down via ProductService (the DESIGN-only DELETE endpoint no
+// longer applies once the order has been bought).
+func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	// Step 1: List sessions to pick a valid speed/session count.
+	sessions, err := natSvc.ListNATGatewaySessions(ctx)
+	if err != nil {
+		suite.FailNowf("could not list sessions", "could not list NAT Gateway sessions: %v", err)
+	}
+	suite.NotEmpty(sessions, "expected at least one session configuration")
+	testSpeed := sessions[0].SpeedMbps
+	testSessionCount := sessions[0].SessionCount[0]
+
+	// Step 2: Pick a location.
+	testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
+	if locErr != nil {
+		suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
+	}
+	suite.NotNil(testLocation)
+
+	// Step 3: Create the NAT Gateway (returns in DESIGN).
+	createReq := &CreateNATGatewayRequest{
+		AutoRenewTerm: true,
+		Config: NATGatewayNetworkConfig{
+			ASN:                64512,
+			BGPShutdownDefault: false,
+			DiversityZone:      "red",
+			SessionCount:       testSessionCount,
+		},
+		LocationID:  testLocation.ID,
+		ProductName: "Integration Test NAT Gateway (Full Lifecycle)",
+		Speed:       testSpeed,
+		Term:        1,
+	}
+	gw, err := natSvc.CreateNATGateway(ctx, createReq)
+	if err != nil {
+		suite.FailNowf("could not create NAT Gateway", "could not create NAT Gateway: %v", err)
+	}
+	productUID := gw.ProductUID
+	suite.NotEmpty(productUID)
+	logger.InfoContext(ctx, "NAT Gateway design created",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", gw.ProvisioningStatus),
+	)
+
+	// Teardown: cancel the product immediately. Works regardless of state
+	// (DESIGN or post-buy) and runs even if a later step fails.
+	defer func() {
+		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
+		_, delErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+			ProductID: productUID,
+			DeleteNow: true,
+		})
+		if delErr != nil {
+			logger.WarnContext(ctx, "teardown failed", slog.String("error", delErr.Error()))
+		}
+	}()
+
+	// Step 4: Validate the gateway via /v3/networkdesign/validate.
+	if err := natSvc.ValidateNATGatewayOrder(ctx, productUID); err != nil {
+		suite.FailNowf("could not validate NAT Gateway", "could not validate NAT Gateway: %v", err)
+	}
+	logger.InfoContext(ctx, "NAT Gateway order validated", slog.String("product_uid", productUID))
+
+	// Step 5: Buy the gateway via /v3/networkdesign/buy — kicks off provisioning.
+	if err := natSvc.BuyNATGateway(ctx, productUID); err != nil {
+		suite.FailNowf("could not buy NAT Gateway", "could not buy NAT Gateway: %v", err)
+	}
+	logger.InfoContext(ctx, "NAT Gateway order bought", slog.String("product_uid", productUID))
+
+	// Step 6: Poll until the gateway reaches CONFIGURED/LIVE, or fail fast
+	// on a terminal error state.
+	const (
+		pollInterval = 10 * time.Second
+		pollTimeout  = 15 * time.Minute
+	)
+	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
+	defer cancel()
+
+	var provisioned *NATGateway
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+PollLoop:
+	for {
+		fetched, getErr := natSvc.GetNATGateway(pollCtx, productUID)
+		if getErr != nil {
+			suite.FailNowf("could not poll NAT Gateway", "error while polling NAT Gateway %s: %v", productUID, getErr)
+		}
+		logger.DebugContext(pollCtx, "poll",
+			slog.String("product_uid", productUID),
+			slog.String("provisioning_status", fetched.ProvisioningStatus),
+		)
+		switch {
+		case slices.Contains(SERVICE_STATE_READY, fetched.ProvisioningStatus):
+			provisioned = fetched
+			break PollLoop
+		case fetched.ProvisioningStatus == STATUS_DECOMMISSIONED ||
+			fetched.ProvisioningStatus == STATUS_CANCELLED:
+			suite.FailNowf("NAT Gateway reached terminal state", "gateway %s reached %s", productUID, fetched.ProvisioningStatus)
+		}
+
+		select {
+		case <-pollCtx.Done():
+			suite.FailNowf("timed out waiting for provisioning", "gateway %s did not reach CONFIGURED/LIVE within %s (last status %q)", productUID, pollTimeout, fetched.ProvisioningStatus)
+		case <-ticker.C:
+		}
+	}
+
+	suite.NotNil(provisioned)
+	suite.Contains(SERVICE_STATE_READY, provisioned.ProvisioningStatus)
+	logger.InfoContext(ctx, "NAT Gateway provisioned",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", provisioned.ProvisioningStatus),
+	)
+
+	// Step 7: Update a field that remains mutable after deployment
+	// (productName). Speed/location/promoCode are immutable post-deploy per
+	// the API docs.
+	const updatedName = "Integration Test NAT Gateway (Updated)"
+	updated, err := natSvc.UpdateNATGateway(ctx, &UpdateNATGatewayRequest{
+		ProductUID:    productUID,
+		AutoRenewTerm: false,
+		Config: NATGatewayNetworkConfig{
+			ASN:                provisioned.Config.ASN,
+			BGPShutdownDefault: provisioned.Config.BGPShutdownDefault,
+			DiversityZone:      provisioned.Config.DiversityZone,
+			SessionCount:       provisioned.Config.SessionCount,
+		},
+		LocationID:  provisioned.LocationID,
+		ProductName: updatedName,
+		Speed:       provisioned.Speed,
+		Term:        provisioned.Term,
+	})
+	if err != nil {
+		suite.FailNowf("could not update NAT Gateway", "could not update provisioned NAT Gateway: %v", err)
+	}
+	suite.Equal(updatedName, updated.ProductName)
+	logger.InfoContext(ctx, "NAT Gateway updated", slog.String("product_name", updated.ProductName))
+
+	// Step 8: Teardown runs via the deferred call above.
 }

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -236,26 +236,47 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 	)
 
 	// Teardown: DESIGN gateways must be removed via DELETE /v3/products/nat_gateways/{uid};
-	// provisioned gateways are cancelled via ProductService.
+	// provisioned gateways are cancelled via ProductService. If we can't
+	// fetch the current state, fall through to best-effort cleanup via both
+	// paths so a transient GET failure doesn't orphan the resource.
 	defer func() {
 		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
+
+		deleteDesign := func() {
+			if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
+				logger.WarnContext(ctx, "teardown failed (DESIGN delete)",
+					slog.String("product_uid", productUID),
+					slog.String("error", dErr.Error()),
+				)
+			}
+		}
+		cancelNow := func() {
+			if _, dErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+				ProductID: productUID,
+				DeleteNow: true,
+			}); dErr != nil {
+				logger.WarnContext(ctx, "teardown failed (CANCEL_NOW)",
+					slog.String("product_uid", productUID),
+					slog.String("error", dErr.Error()),
+				)
+			}
+		}
+
 		current, getErr := natSvc.GetNATGateway(ctx, productUID)
 		if getErr != nil {
-			logger.WarnContext(ctx, "teardown: could not fetch current state", slog.String("error", getErr.Error()))
+			logger.WarnContext(ctx, "teardown: could not fetch current state; attempting best-effort cleanup",
+				slog.String("product_uid", productUID),
+				slog.String("error", getErr.Error()),
+			)
+			deleteDesign()
+			cancelNow()
 			return
 		}
 		if current.ProvisioningStatus == STATUS_DESIGN {
-			if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
-				logger.WarnContext(ctx, "teardown failed (DESIGN delete)", slog.String("error", dErr.Error()))
-			}
+			deleteDesign()
 			return
 		}
-		if _, dErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
-			ProductID: productUID,
-			DeleteNow: true,
-		}); dErr != nil {
-			logger.WarnContext(ctx, "teardown failed (CANCEL_NOW)", slog.String("error", dErr.Error()))
-		}
+		cancelNow()
 	}()
 
 	// Step 4: Validate the order (pricing preview).

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -578,15 +578,49 @@ func (suite *NATGatewayClientTestSuite) TestValidateNATGatewayOrder() {
 		suite.Equal([]map[string]string{{"productUid": productUID}}, payload)
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"message":"ok","terms":""}`)
+		fmt.Fprintf(w, `{
+			"message":"Validation passed",
+			"terms":"",
+			"data":[{
+				"productUid":%q,
+				"productType":"NAT_GATEWAY",
+				"string":"Sydney",
+				"price":{
+					"monthlyRate":600,
+					"mbpsRate":0.6,
+					"currency":"AUD",
+					"productType":"NAT_GATEWAY",
+					"monthlyRackRate":600
+				}
+			}]
+		}`, productUID)
 	})
 
-	suite.NoError(natSvc.ValidateNATGatewayOrder(ctx, productUID))
+	result, err := natSvc.ValidateNATGatewayOrder(ctx, productUID)
+	suite.NoError(err)
 	suite.True(called)
+	suite.Equal(productUID, result.ProductUID)
+	suite.Equal("NAT_GATEWAY", result.ProductType)
+	suite.Equal("Sydney", result.Location)
+	suite.Equal(float64(600), result.Price.MonthlyRate)
+	suite.Equal("AUD", result.Price.Currency)
+}
+
+func (suite *NATGatewayClientTestSuite) TestValidateNATGatewayOrder_EmptyData() {
+	ctx := context.Background()
+	productUID := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/networkdesign/validate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[]}`)
+	})
+
+	_, err := suite.client.NATGatewayService.ValidateNATGatewayOrder(ctx, productUID)
+	suite.ErrorIs(err, ErrNATGatewayOrderResponseEmpty)
 }
 
 func (suite *NATGatewayClientTestSuite) TestValidateNATGatewayOrder_MissingUID() {
-	err := suite.client.NATGatewayService.ValidateNATGatewayOrder(context.Background(), "")
+	_, err := suite.client.NATGatewayService.ValidateNATGatewayOrder(context.Background(), "")
 	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
 }
 
@@ -607,14 +641,47 @@ func (suite *NATGatewayClientTestSuite) TestBuyNATGateway() {
 		suite.Equal([]map[string]string{{"productUid": productUID}}, payload)
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"message":"ok","terms":""}`)
+		fmt.Fprintf(w, `{
+			"message":"NAT_GATEWAY created",
+			"terms":"",
+			"data":[{
+				"uid":%q,
+				"name":"gw-name",
+				"serviceName":"gw-name",
+				"productType":"NAT_GATEWAY",
+				"provisioningStatus":"DEPLOYABLE",
+				"rateLimit":1000,
+				"aLocationId":10,
+				"contractTermMonths":1,
+				"createDate":1776431685787
+			}]
+		}`, productUID)
 	})
 
-	suite.NoError(natSvc.BuyNATGateway(ctx, productUID))
+	result, err := natSvc.BuyNATGateway(ctx, productUID)
+	suite.NoError(err)
 	suite.True(called)
+	suite.Equal(productUID, result.ProductUID)
+	suite.Equal("DEPLOYABLE", result.ProvisioningStatus)
+	suite.Equal(1000, result.RateLimit)
+	suite.Equal(10, result.LocationID)
+	suite.Equal(1, result.ContractTermMonths)
+}
+
+func (suite *NATGatewayClientTestSuite) TestBuyNATGateway_EmptyData() {
+	ctx := context.Background()
+	productUID := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[]}`)
+	})
+
+	_, err := suite.client.NATGatewayService.BuyNATGateway(ctx, productUID)
+	suite.ErrorIs(err, ErrNATGatewayOrderResponseEmpty)
 }
 
 func (suite *NATGatewayClientTestSuite) TestBuyNATGateway_MissingUID() {
-	err := suite.client.NATGatewayService.BuyNATGateway(context.Background(), "")
+	_, err := suite.client.NATGatewayService.BuyNATGateway(context.Background(), "")
 	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
 }

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -601,7 +601,7 @@ func (suite *NATGatewayClientTestSuite) TestValidateNATGatewayOrder() {
 	suite.True(called)
 	suite.Equal(productUID, result.ProductUID)
 	suite.Equal("NAT_GATEWAY", result.ProductType)
-	suite.Equal("Sydney", result.Location)
+	suite.Equal("Sydney", result.Metro)
 	suite.Equal(float64(600), result.Price.MonthlyRate)
 	suite.Equal("AUD", result.Price.Currency)
 }

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -2,7 +2,9 @@ package megaport
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -557,4 +559,62 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayTelemetryValidation() {
 		To:         PtrTo(time.UnixMilli(1608603936000)),
 	})
 	suite.ErrorIs(err, ErrNATGatewayTelemetryFromToIncomplete)
+}
+
+func (suite *NATGatewayClientTestSuite) TestValidateNATGatewayOrder() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "11111111-2222-3333-4444-555555555555"
+
+	called := false
+	suite.mux.HandleFunc("/v3/networkdesign/validate", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		suite.Equal(http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		suite.NoError(err)
+		var payload []map[string]string
+		suite.NoError(json.Unmarshal(body, &payload))
+		suite.Equal([]map[string]string{{"productUid": productUID}}, payload)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":""}`)
+	})
+
+	suite.NoError(natSvc.ValidateNATGatewayOrder(ctx, productUID))
+	suite.True(called)
+}
+
+func (suite *NATGatewayClientTestSuite) TestValidateNATGatewayOrder_MissingUID() {
+	err := suite.client.NATGatewayService.ValidateNATGatewayOrder(context.Background(), "")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+}
+
+func (suite *NATGatewayClientTestSuite) TestBuyNATGateway() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "11111111-2222-3333-4444-555555555555"
+
+	called := false
+	suite.mux.HandleFunc("/v3/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		suite.Equal(http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		suite.NoError(err)
+		var payload []map[string]string
+		suite.NoError(json.Unmarshal(body, &payload))
+		suite.Equal([]map[string]string{{"productUid": productUID}}, payload)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":""}`)
+	})
+
+	suite.NoError(natSvc.BuyNATGateway(ctx, productUID))
+	suite.True(called)
+}
+
+func (suite *NATGatewayClientTestSuite) TestBuyNATGateway_MissingUID() {
+	err := suite.client.NATGatewayService.BuyNATGateway(context.Background(), "")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
 }

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -151,3 +151,57 @@ type DeleteNATGatewayResponse struct {
 	Message string `json:"message"`
 	Terms   string `json:"terms"`
 }
+
+// NATGatewayOrderPrice captures the pricing preview returned by
+// POST /v3/networkdesign/validate for a NAT Gateway order.
+type NATGatewayOrderPrice struct {
+	HourlySetup          float64 `json:"hourlySetup"`
+	DailySetup           float64 `json:"dailySetup"`
+	MonthlySetup         float64 `json:"monthlySetup"`
+	HourlyRate           float64 `json:"hourlyRate"`
+	DailyRate            float64 `json:"dailyRate"`
+	MonthlyRate          float64 `json:"monthlyRate"`
+	FixedRecurringCharge float64 `json:"fixedRecurringCharge"`
+	LongHaulMbpsRate     float64 `json:"longHaulMbpsRate"`
+	MbpsRate             float64 `json:"mbpsRate"`
+	Currency             string  `json:"currency"`
+	ProductType          string  `json:"productType"`
+	MonthlyRackRate      float64 `json:"monthlyRackRate"`
+}
+
+// NATGatewayValidateResult is a single entry returned by
+// POST /v3/networkdesign/validate.
+type NATGatewayValidateResult struct {
+	ProductUID  string               `json:"productUid"`
+	ProductType string               `json:"productType"`
+	Location    string               `json:"string"`
+	Price       NATGatewayOrderPrice `json:"price"`
+}
+
+// NATGatewayBuyResult is a single entry returned by
+// POST /v3/networkdesign/buy after a NAT Gateway design is purchased.
+type NATGatewayBuyResult struct {
+	ProductUID         string `json:"uid"`
+	ProductName        string `json:"name"`
+	ServiceName        string `json:"serviceName"`
+	ProductType        string `json:"productType"`
+	ProvisioningStatus string `json:"provisioningStatus"`
+	RateLimit          int    `json:"rateLimit"`
+	LocationID         int    `json:"aLocationId"`
+	ContractTermMonths int    `json:"contractTermMonths"`
+	CreateDate         int64  `json:"createDate"`
+}
+
+// natGatewayValidateEnvelope is the API response envelope for validate.
+type natGatewayValidateEnvelope struct {
+	Message string                      `json:"message"`
+	Terms   string                      `json:"terms"`
+	Data    []*NATGatewayValidateResult `json:"data"`
+}
+
+// natGatewayBuyEnvelope is the API response envelope for buy.
+type natGatewayBuyEnvelope struct {
+	Message string                 `json:"message"`
+	Terms   string                 `json:"terms"`
+	Data    []*NATGatewayBuyResult `json:"data"`
+}

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -172,10 +172,13 @@ type NATGatewayOrderPrice struct {
 // NATGatewayValidateResult is a single entry returned by
 // POST /v3/networkdesign/validate.
 type NATGatewayValidateResult struct {
-	ProductUID  string               `json:"productUid"`
-	ProductType string               `json:"productType"`
-	Location    string               `json:"string"`
-	Price       NATGatewayOrderPrice `json:"price"`
+	ProductUID  string `json:"productUid"`
+	ProductType string `json:"productType"`
+	// Metro is the metro/city name returned by the API for the gateway's
+	// location (e.g. "Sydney"). The API ships this as a field literally
+	// named "string" in the JSON response, hence the unusual json tag.
+	Metro string               `json:"string"`
+	Price NATGatewayOrderPrice `json:"price"`
 }
 
 // NATGatewayBuyResult is a single entry returned by

--- a/shared_types.go
+++ b/shared_types.go
@@ -8,6 +8,9 @@ import (
 const (
 	SERVICE_CONFIGURED = "CONFIGURED" // The CONFIGURED service state.
 	SERVICE_LIVE       = "LIVE"       // The LIVE service state.
+	// STATUS_DESIGN is the pre-order state for products that are created but
+	// not yet validated or purchased (currently: NAT Gateways).
+	STATUS_DESIGN = "DESIGN"
 
 	// Product types
 	PRODUCT_MEGAPORT    = "megaport"


### PR DESCRIPTION
## Summary

Adds `ValidateNATGatewayOrder` and `BuyNATGateway` methods on `NATGatewayService`, enabling NAT Gateways created in DESIGN state to be validated and purchased through the SDK.

## Why

NAT Gateways are created via `POST /v3/products/nat_gateways` and returned in a DESIGN state. To enter the normal provisioning lifecycle (`DEPLOYABLE` -> `CONFIGURED` -> `LIVE`), they must be validated and bought. Per ENG-26770, NAT Gateway ordering intentionally reuses the existing `/v3/networkdesign` flow with a minimal payload `[{"productUid": "<uid>"}]`, rather than the separate `/v3/orders` endpoints (which are gated behind the `v3_orders_enabled` feature flag — ENG-29237).

Without these methods, the terraform-provider and CLI cannot actually provision a NAT Gateway end-to-end.

## Changes

- `NATGatewayService.ValidateNATGatewayOrder(ctx, productUID) error` — POSTs to `/v3/networkdesign/validate`
- `NATGatewayService.BuyNATGateway(ctx, productUID) error` — POSTs to `/v3/networkdesign/buy`
- Unit tests covering success and missing-UID paths
- `TestNATGatewayFullLifecycle` integration test: create → validate → buy → poll to `CONFIGURED`/`LIVE` → update → teardown via `ProductService.DeleteProduct`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit tests, including new validate/buy cases)
- [ ] `go test -timeout 30m -integration -run TestNATGatewayIntegrationTestSuite ./...` (staging)