### PR TITLE
fix: route NAT Gateway delete through product cancel for provisioned records

### DIFF
--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -233,8 +233,9 @@ func (svc *NATGatewayServiceOp) UpdateNATGateway(ctx context.Context, req *Updat
 // returns 400 for non-DESIGN gateways, and CANCEL_NOW rolls back against
 // DESIGN-state records — so a single unified endpoint is not available from
 // the API side, and the SDK routes based on a pre-flight GET. Errors from
-// the pre-flight GET (including 404 for an unknown UID) are returned to
-// the caller verbatim.
+// the pre-flight GET (including 404 for an unknown UID) are wrapped with
+// a "nat gateway delete: could not inspect lifecycle state" prefix but
+// preserve the underlying error chain (use errors.Is / errors.As).
 //
 // The routing is not atomic: if a DESIGN-state gateway transitions to
 // DEPLOYABLE between the GET and the DELETE (e.g., another caller has just

--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -223,14 +223,27 @@ func (svc *NATGatewayServiceOp) UpdateNATGateway(ctx context.Context, req *Updat
 //
 //   - DESIGN-state designs that have never been purchased use
 //     DELETE /v3/products/nat_gateways/{uid} (the design-only endpoint).
+//     This hard-removes the record — the gateway disappears from list.
 //   - Provisioned gateways (DEPLOYABLE / CONFIGURED / LIVE) are cancelled
 //     via the generic product action POST /v3/product/{uid}/action/CANCEL_NOW,
 //     matching the teardown path used for Ports, MCRs, MVEs, and VXCs.
+//     The record is retained in DECOMMISSIONED / CANCELLED state.
 //
 // Callers do not need to inspect state themselves. The design endpoint
 // returns 400 for non-DESIGN gateways, and CANCEL_NOW rolls back against
 // DESIGN-state records — so a single unified endpoint is not available from
-// the API side, and the SDK routes based on a pre-flight GET.
+// the API side, and the SDK routes based on a pre-flight GET. Errors from
+// the pre-flight GET (including 404 for an unknown UID) are returned to
+// the caller verbatim.
+//
+// The routing is not atomic: if a DESIGN-state gateway transitions to
+// DEPLOYABLE between the GET and the DELETE (e.g., another caller has just
+// purchased it), the design endpoint will return 400. Retrying the delete
+// will route through the provisioned path on the next attempt.
+//
+// Unlike DeletePort / DeleteMCR / DeleteMVE, this method does not currently
+// accept a SafeDelete (end-of-term cancellation) option — provisioned
+// gateways are always cancelled immediately with DeleteNow: true.
 func (svc *NATGatewayServiceOp) DeleteNATGateway(ctx context.Context, productUID string) error {
 	if productUID == "" {
 		return ErrNATGatewayProductUIDRequired
@@ -238,7 +251,7 @@ func (svc *NATGatewayServiceOp) DeleteNATGateway(ctx context.Context, productUID
 
 	gw, err := svc.GetNATGateway(ctx, productUID)
 	if err != nil {
-		return err
+		return fmt.Errorf("nat gateway delete: could not inspect lifecycle state: %w", err)
 	}
 
 	if gw.ProvisioningStatus == STATUS_DESIGN {

--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -218,23 +218,48 @@ func (svc *NATGatewayServiceOp) UpdateNATGateway(ctx context.Context, req *Updat
 	return &natResp.Data, nil
 }
 
-// DeleteNATGateway deletes a NAT Gateway by its product UID.
+// DeleteNATGateway deletes a NAT Gateway by its product UID. It handles
+// both lifecycle stages transparently:
+//
+//   - DESIGN-state designs that have never been purchased use
+//     DELETE /v3/products/nat_gateways/{uid} (the design-only endpoint).
+//   - Provisioned gateways (DEPLOYABLE / CONFIGURED / LIVE) are cancelled
+//     via the generic product action POST /v3/product/{uid}/action/CANCEL_NOW,
+//     matching the teardown path used for Ports, MCRs, MVEs, and VXCs.
+//
+// Callers do not need to inspect state themselves. The design endpoint
+// returns 400 for non-DESIGN gateways, and CANCEL_NOW rolls back against
+// DESIGN-state records — so a single unified endpoint is not available from
+// the API side, and the SDK routes based on a pre-flight GET.
 func (svc *NATGatewayServiceOp) DeleteNATGateway(ctx context.Context, productUID string) error {
 	if productUID == "" {
 		return ErrNATGatewayProductUIDRequired
 	}
 
-	path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
-	clientReq, err := svc.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	gw, err := svc.GetNATGateway(ctx, productUID)
 	if err != nil {
 		return err
 	}
-	resp, err := svc.Client.Do(ctx, clientReq, nil)
-	if err != nil {
-		return err
+
+	if gw.ProvisioningStatus == STATUS_DESIGN {
+		path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
+		clientReq, err := svc.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := svc.Client.Do(ctx, clientReq, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		return nil
 	}
-	defer resp.Body.Close()
-	return nil
+
+	_, err = svc.Client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+		ProductID: productUID,
+		DeleteNow: true,
+	})
+	return err
 }
 
 // natGatewayOrderItem is the minimal payload expected by

--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -224,10 +224,12 @@ func (svc *NATGatewayServiceOp) UpdateNATGateway(ctx context.Context, req *Updat
 //   - DESIGN-state designs that have never been purchased use
 //     DELETE /v3/products/nat_gateways/{uid} (the design-only endpoint).
 //     This hard-removes the record — the gateway disappears from list.
-//   - Provisioned gateways (DEPLOYABLE / CONFIGURED / LIVE) are cancelled
-//     via the generic product action POST /v3/product/{uid}/action/CANCEL_NOW,
-//     matching the teardown path used for Ports, MCRs, MVEs, and VXCs.
-//     The record is retained in DECOMMISSIONED / CANCELLED state.
+//   - Any non-DESIGN gateway (e.g. DEPLOYABLE / CONFIGURED / LIVE) is
+//     cancelled via the generic product action
+//     POST /v3/product/{uid}/action/CANCEL_NOW, matching the teardown path
+//     used for Ports, MCRs, MVEs, and VXCs. The record is retained rather
+//     than being hard-deleted, typically transitioning to
+//     DECOMMISSIONED / CANCELLED.
 //
 // Callers do not need to inspect state themselves. The design endpoint
 // returns 400 for non-DESIGN gateways, and CANCEL_NOW rolls back against

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -2,7 +2,10 @@ package megaport
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"testing"
@@ -255,7 +258,24 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 	defer func() {
 		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
 
-		cancelDirect := func() error {
+		// deleteDesign hits the design-only endpoint directly, bypassing the
+		// pre-flight GET inside DeleteNATGateway so the teardown never
+		// incurs a second GET on the happy DESIGN path and stays usable when
+		// state-inspection is down.
+		deleteDesign := func() error {
+			path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
+			req, err := suite.client.NewRequest(ctx, http.MethodDelete, path, nil)
+			if err != nil {
+				return err
+			}
+			resp, err := suite.client.Do(ctx, req, nil)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			return nil
+		}
+		cancelNow := func() error {
 			_, err := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
 				ProductID: productUID,
 				DeleteNow: true,
@@ -265,16 +285,22 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 
 		current, getErr := natSvc.GetNATGateway(ctx, productUID)
 		if getErr != nil {
-			// Can't inspect state — avoid leaking a provisioned gateway by
-			// calling CANCEL_NOW directly. For a still-DESIGN record this will
-			// return 400 (harmless), but losing a provisioned gateway would
-			// leak billable resources on staging.
-			logger.WarnContext(ctx, "teardown: could not inspect state, attempting CANCEL_NOW best-effort",
+			// Can't tell which state we're in — attempt both paths so we do
+			// not leak either a DESIGN record or a provisioned gateway. Each
+			// endpoint returns 400 for the wrong state; we log but don't
+			// fail the teardown on those.
+			logger.WarnContext(ctx, "teardown: could not inspect state, attempting both cleanup paths",
 				slog.String("product_uid", productUID),
 				slog.String("error", getErr.Error()),
 			)
-			if err := cancelDirect(); err != nil {
-				logger.WarnContext(ctx, "teardown (CANCEL_NOW) failed",
+			if err := deleteDesign(); err != nil {
+				logger.WarnContext(ctx, "teardown (DESIGN DELETE) best-effort failed",
+					slog.String("product_uid", productUID),
+					slog.String("error", err.Error()),
+				)
+			}
+			if err := cancelNow(); err != nil {
+				logger.WarnContext(ctx, "teardown (CANCEL_NOW) best-effort failed",
 					slog.String("product_uid", productUID),
 					slog.String("error", err.Error()),
 				)
@@ -289,13 +315,12 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 			)
 			return
 		}
-		// Dispatch directly based on the state we already fetched, skipping
-		// the second GET that DeleteNATGateway would otherwise do.
+		// Dispatch directly from the state we already fetched — no second GET.
 		var dErr error
 		if current.ProvisioningStatus == STATUS_DESIGN {
-			dErr = natSvc.DeleteNATGateway(ctx, productUID)
+			dErr = deleteDesign()
 		} else {
-			dErr = cancelDirect()
+			dErr = cancelNow()
 		}
 		if dErr != nil {
 			logger.WarnContext(ctx, "teardown failed",

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -168,7 +168,7 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
 	for _, g := range postDeleteList {
 		suite.NotEqual(productUID, g.ProductUID, "deleted DESIGN NAT Gateway %s still appears in list", productUID)
 	}
-	logger.InfoContext(ctx, "NAT Gateway teardown verified", slog.String("product_uid", productUID))
+	logger.InfoContext(ctx, "design NAT Gateway teardown verified (hard-removed from list)", slog.String("product_uid", productUID))
 }
 
 // TestNATGatewayFullLifecycle exercises the end-to-end flow: create the
@@ -255,7 +255,12 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 	defer func() {
 		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
 		current, getErr := natSvc.GetNATGateway(ctx, productUID)
-		if getErr == nil && current != nil &&
+		if getErr != nil {
+			logger.WarnContext(ctx, "teardown could not inspect current state, attempting delete anyway",
+				slog.String("product_uid", productUID),
+				slog.String("error", getErr.Error()),
+			)
+		} else if current != nil &&
 			(current.ProvisioningStatus == STATUS_DECOMMISSIONED ||
 				current.ProvisioningStatus == STATUS_CANCELLED) {
 			logger.InfoContext(ctx, "teardown skipped: already in terminal state",
@@ -370,6 +375,12 @@ PollLoop:
 	// works even though the gateway is no longer in DESIGN state. This is
 	// the primary deletion path; the defer above remains as a safety net if
 	// any earlier step failed before reaching here.
+	//
+	// Unlike the DESIGN-state delete in TestNATGatewayLifecycle (which
+	// hard-removes the record so verification is by list-exclusion), the
+	// provisioned teardown via CANCEL_NOW leaves a tombstone record behind,
+	// so verification is by GET on the product UID and a check that the
+	// record has moved to DECOMMISSIONED/CANCELLED.
 	if err := natSvc.DeleteNATGateway(ctx, productUID); err != nil {
 		suite.FailNowf("could not delete provisioned NAT Gateway", "could not delete NAT Gateway: %v", err)
 	}
@@ -383,7 +394,7 @@ PollLoop:
 		"expected deleted NAT Gateway to be DECOMMISSIONED or CANCELLED, got %q",
 		postDelete.ProvisioningStatus,
 	)
-	logger.InfoContext(ctx, "NAT Gateway teardown verified",
+	logger.InfoContext(ctx, "provisioned NAT Gateway teardown verified (tombstone record in terminal state)",
 		slog.String("product_uid", productUID),
 		slog.String("provisioning_status", postDelete.ProvisioningStatus),
 	)

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -168,9 +168,14 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
 	if err != nil {
 		suite.FailNowf("could not list NAT Gateways post-delete", "could not list NAT Gateways: %v", err)
 	}
+	found = false
 	for _, g := range postDeleteList {
-		suite.NotEqual(productUID, g.ProductUID, "deleted DESIGN NAT Gateway %s still appears in list", productUID)
+		if g.ProductUID == productUID {
+			found = true
+			break
+		}
 	}
+	suite.False(found, "deleted DESIGN NAT Gateway %s still appears in list", productUID)
 	logger.InfoContext(ctx, "design NAT Gateway teardown verified (hard-removed from list)", slog.String("product_uid", productUID))
 }
 

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -254,24 +254,53 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 	// call if the gateway is already in a terminal state.
 	defer func() {
 		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
+
+		cancelDirect := func() error {
+			_, err := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+				ProductID: productUID,
+				DeleteNow: true,
+			})
+			return err
+		}
+
 		current, getErr := natSvc.GetNATGateway(ctx, productUID)
 		if getErr != nil {
-			logger.WarnContext(ctx, "teardown could not inspect current state, attempting delete anyway",
+			// Can't inspect state — avoid leaking a provisioned gateway by
+			// calling CANCEL_NOW directly. For a still-DESIGN record this will
+			// return 400 (harmless), but losing a provisioned gateway would
+			// leak billable resources on staging.
+			logger.WarnContext(ctx, "teardown: could not inspect state, attempting CANCEL_NOW best-effort",
 				slog.String("product_uid", productUID),
 				slog.String("error", getErr.Error()),
 			)
-		} else if current != nil &&
-			(current.ProvisioningStatus == STATUS_DECOMMISSIONED ||
-				current.ProvisioningStatus == STATUS_CANCELLED) {
+			if err := cancelDirect(); err != nil {
+				logger.WarnContext(ctx, "teardown (CANCEL_NOW) failed",
+					slog.String("product_uid", productUID),
+					slog.String("error", err.Error()),
+				)
+			}
+			return
+		}
+		if current.ProvisioningStatus == STATUS_DECOMMISSIONED ||
+			current.ProvisioningStatus == STATUS_CANCELLED {
 			logger.InfoContext(ctx, "teardown skipped: already in terminal state",
 				slog.String("product_uid", productUID),
 				slog.String("provisioning_status", current.ProvisioningStatus),
 			)
 			return
 		}
-		if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
+		// Dispatch directly based on the state we already fetched, skipping
+		// the second GET that DeleteNATGateway would otherwise do.
+		var dErr error
+		if current.ProvisioningStatus == STATUS_DESIGN {
+			dErr = natSvc.DeleteNATGateway(ctx, productUID)
+		} else {
+			dErr = cancelDirect()
+		}
+		if dErr != nil {
 			logger.WarnContext(ctx, "teardown failed",
 				slog.String("product_uid", productUID),
+				slog.String("provisioning_status", current.ProvisioningStatus),
 				slog.String("error", dErr.Error()),
 			)
 		}

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -149,13 +149,26 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
 	suite.False(updated.AutoRenewTerm)
 	logger.DebugContext(ctx, "NAT Gateway updated", slog.String("product_name", updated.ProductName))
 
-	// Step 7: Delete the NAT Gateway (allowed while provisioningStatus is NEW).
+	// Step 7: Delete the DESIGN-state NAT Gateway. DeleteNATGateway inspects
+	// ProvisioningStatus internally and routes to the design-only DELETE
+	// endpoint for gateways that have never been purchased.
 	logger.DebugContext(ctx, "Deleting NAT Gateway.")
 	err = natSvc.DeleteNATGateway(ctx, productUID)
 	if err != nil {
 		suite.FailNowf("could not delete NAT Gateway", "could not delete NAT Gateway: %v", err)
 	}
 	logger.DebugContext(ctx, "NAT Gateway deleted", slog.String("product_uid", productUID))
+
+	// Step 8: Verify the NAT Gateway is gone. DESIGN-state deletes hard-remove
+	// the record, so it should no longer appear in the list.
+	postDeleteList, err := natSvc.ListNATGateways(ctx)
+	if err != nil {
+		suite.FailNowf("could not list NAT Gateways post-delete", "could not list NAT Gateways: %v", err)
+	}
+	for _, g := range postDeleteList {
+		suite.NotEqual(productUID, g.ProductUID, "deleted DESIGN NAT Gateway %s still appears in list", productUID)
+	}
+	logger.InfoContext(ctx, "NAT Gateway teardown verified", slog.String("product_uid", productUID))
 }
 
 // TestNATGatewayFullLifecycle exercises the end-to-end flow: create the
@@ -235,48 +248,28 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayFullLifecycle() {
 		slog.String("provisioning_status", gw.ProvisioningStatus),
 	)
 
-	// Teardown: DESIGN gateways must be removed via DELETE /v3/products/nat_gateways/{uid};
-	// provisioned gateways are cancelled via ProductService. If we can't
-	// fetch the current state, fall through to best-effort cleanup via both
-	// paths so a transient GET failure doesn't orphan the resource.
+	// Teardown: DeleteNATGateway handles any lifecycle stage the gateway
+	// might be in when the defer fires. This is a safety net — the happy
+	// path below performs an explicit delete + verification — so skip the
+	// call if the gateway is already in a terminal state.
 	defer func() {
 		logger.InfoContext(ctx, "Tearing down NAT Gateway", slog.String("product_uid", productUID))
-
-		deleteDesign := func() {
-			if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
-				logger.WarnContext(ctx, "teardown failed (DESIGN delete)",
-					slog.String("product_uid", productUID),
-					slog.String("error", dErr.Error()),
-				)
-			}
-		}
-		cancelNow := func() {
-			if _, dErr := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
-				ProductID: productUID,
-				DeleteNow: true,
-			}); dErr != nil {
-				logger.WarnContext(ctx, "teardown failed (CANCEL_NOW)",
-					slog.String("product_uid", productUID),
-					slog.String("error", dErr.Error()),
-				)
-			}
-		}
-
 		current, getErr := natSvc.GetNATGateway(ctx, productUID)
-		if getErr != nil {
-			logger.WarnContext(ctx, "teardown: could not fetch current state; attempting best-effort cleanup",
+		if getErr == nil && current != nil &&
+			(current.ProvisioningStatus == STATUS_DECOMMISSIONED ||
+				current.ProvisioningStatus == STATUS_CANCELLED) {
+			logger.InfoContext(ctx, "teardown skipped: already in terminal state",
 				slog.String("product_uid", productUID),
-				slog.String("error", getErr.Error()),
+				slog.String("provisioning_status", current.ProvisioningStatus),
 			)
-			deleteDesign()
-			cancelNow()
 			return
 		}
-		if current.ProvisioningStatus == STATUS_DESIGN {
-			deleteDesign()
-			return
+		if dErr := natSvc.DeleteNATGateway(ctx, productUID); dErr != nil {
+			logger.WarnContext(ctx, "teardown failed",
+				slog.String("product_uid", productUID),
+				slog.String("error", dErr.Error()),
+			)
 		}
-		cancelNow()
 	}()
 
 	// Step 4: Validate the order (pricing preview).
@@ -372,5 +365,26 @@ PollLoop:
 	suite.Equal(updatedName, updated.ProductName)
 	logger.InfoContext(ctx, "NAT Gateway updated", slog.String("product_name", updated.ProductName))
 
-	// Step 8: Teardown runs via the deferred call above.
+	// Step 8: Delete the provisioned NAT Gateway and verify it's gone.
+	// DeleteNATGateway uses the generic product-cancellation endpoint so it
+	// works even though the gateway is no longer in DESIGN state. This is
+	// the primary deletion path; the defer above remains as a safety net if
+	// any earlier step failed before reaching here.
+	if err := natSvc.DeleteNATGateway(ctx, productUID); err != nil {
+		suite.FailNowf("could not delete provisioned NAT Gateway", "could not delete NAT Gateway: %v", err)
+	}
+	postDelete, err := natSvc.GetNATGateway(ctx, productUID)
+	if err != nil {
+		suite.FailNowf("could not GET deleted NAT Gateway", "could not GET deleted NAT Gateway: %v", err)
+	}
+	suite.Contains(
+		[]string{STATUS_DECOMMISSIONED, STATUS_CANCELLED},
+		postDelete.ProvisioningStatus,
+		"expected deleted NAT Gateway to be DECOMMISSIONED or CANCELLED, got %q",
+		postDelete.ProvisioningStatus,
+	)
+	logger.InfoContext(ctx, "NAT Gateway teardown verified",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", postDelete.ProvisioningStatus),
+	)
 }

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -380,6 +380,7 @@ func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayProvisioned() {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc // capture per-iteration copies for go <1.22 loopclosure safety
 		suite.Run(tc.name, func() {
 			// Each sub-test uses a distinct UID so the handler paths do not
 			// collide on the shared mux, avoiding the server leak that would

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -365,32 +365,49 @@ func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayDesignState() {
 }
 
 func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayProvisioned() {
-	ctx := context.Background()
-	natSvc := suite.client.NATGatewayService
-	productUID := "c1a2b3c4-d5e6-7890-1234-567890abcdef"
+	// DeleteNATGateway must route every non-DESIGN status through the
+	// generic product cancel endpoint. Covering each provisioned status
+	// explicitly guards against accidental regressions where the routing
+	// check is narrowed to a single status (e.g. STATUS_LIVE only).
+	cases := []struct {
+		name   string
+		status string
+	}{
+		{name: "deployable", status: "DEPLOYABLE"},
+		{name: "configured", status: SERVICE_CONFIGURED},
+		{name: "live", status: SERVICE_LIVE},
+	}
 
-	// Pre-flight GET returns a provisioned status (anything other than
-	// DESIGN) — DeleteNATGateway must route through the generic product
-	// cancel endpoint instead of the design-only DELETE.
-	getPath := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
-	suite.mux.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
-		suite.Equal(http.MethodGet, r.Method, "provisioned gateway must not hit DESIGN DELETE endpoint")
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"message":"","terms":"","data":{"productUid":"%s","provisioningStatus":"LIVE"}}`, productUID)
-	})
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			defer suite.TearDownTest()
 
-	cancelPath := "/v3/product/" + productUID + "/action/CANCEL_NOW"
-	cancelCalled := false
-	suite.mux.HandleFunc(cancelPath, func(w http.ResponseWriter, r *http.Request) {
-		suite.Equal(http.MethodPost, r.Method)
-		cancelCalled = true
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"message":"Action [CANCEL_NOW Service %s] has been done.","terms":""}`, productUID)
-	})
+			ctx := context.Background()
+			natSvc := suite.client.NATGatewayService
+			productUID := "c1a2b3c4-d5e6-7890-1234-567890abcdef"
 
-	err := natSvc.DeleteNATGateway(ctx, productUID)
-	suite.NoError(err)
-	suite.True(cancelCalled, "expected provisioned delete to hit /v3/product/{uid}/action/CANCEL_NOW")
+			getPath := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
+			suite.mux.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+				suite.Equal(http.MethodGet, r.Method, "provisioned gateway must not hit DESIGN DELETE endpoint")
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"message":"","terms":"","data":{"productUid":"%s","provisioningStatus":"%s"}}`, productUID, tc.status)
+			})
+
+			cancelPath := "/v3/product/" + productUID + "/action/CANCEL_NOW"
+			cancelCalled := false
+			suite.mux.HandleFunc(cancelPath, func(w http.ResponseWriter, r *http.Request) {
+				suite.Equal(http.MethodPost, r.Method)
+				cancelCalled = true
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"message":"Action [CANCEL_NOW Service %s] has been done.","terms":""}`, productUID)
+			})
+
+			err := natSvc.DeleteNATGateway(ctx, productUID)
+			suite.NoError(err)
+			suite.True(cancelCalled, "expected provisioned delete to hit /v3/product/{uid}/action/CANCEL_NOW")
+		})
+	}
 }
 
 func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayValidation() {

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -345,14 +346,14 @@ func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayDesignState() {
 	// the right endpoint. DESIGN-state gateways use the nat-gateway-specific
 	// DELETE path.
 	getPath := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
-	designDeleteCalled := false
+	var designDeleteCalled atomic.Bool
 	suite.mux.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method {
 		case http.MethodGet:
 			fmt.Fprintf(w, `{"message":"","terms":"","data":{"productUid":"%s","provisioningStatus":"DESIGN"}}`, productUID)
 		case http.MethodDelete:
-			designDeleteCalled = true
+			designDeleteCalled.Store(true)
 			fmt.Fprint(w, `{"message":"Nat gateway order item deleted successfully","terms":""}`)
 		default:
 			suite.FailNowf("unexpected method", "unexpected %s on %s", r.Method, getPath)
@@ -361,7 +362,7 @@ func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayDesignState() {
 
 	err := natSvc.DeleteNATGateway(ctx, productUID)
 	suite.NoError(err)
-	suite.True(designDeleteCalled, "expected DESIGN-state delete to hit /v3/products/nat_gateways/{uid}")
+	suite.True(designDeleteCalled.Load(), "expected DESIGN-state delete to hit /v3/products/nat_gateways/{uid}")
 }
 
 func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayProvisioned() {
@@ -395,17 +396,17 @@ func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayProvisioned() {
 			})
 
 			cancelPath := "/v3/product/" + productUID + "/action/CANCEL_NOW"
-			cancelCalled := false
+			var cancelCalled atomic.Bool
 			suite.mux.HandleFunc(cancelPath, func(w http.ResponseWriter, r *http.Request) {
 				suite.Equal(http.MethodPost, r.Method)
-				cancelCalled = true
+				cancelCalled.Store(true)
 				w.Header().Set("Content-Type", "application/json")
 				fmt.Fprintf(w, `{"message":"Action [CANCEL_NOW Service %s] has been done.","terms":""}`, productUID)
 			})
 
 			err := natSvc.DeleteNATGateway(ctx, productUID)
 			suite.NoError(err)
-			suite.True(cancelCalled, "expected provisioned delete to hit /v3/product/{uid}/action/CANCEL_NOW")
+			suite.True(cancelCalled.Load(), "expected provisioned delete to hit /v3/product/{uid}/action/CANCEL_NOW")
 		})
 	}
 }

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -63,7 +63,7 @@ func (suite *NATGatewayClientTestSuite) TestCreateNATGateway() {
 			"productName": "NAT Gateway",
 			"productUid": "e900d0d5-1030-4e29-b2d8-816ad4263190",
 			"promoCode": "PROMO123",
-			"provisioningStatus": "NEW",
+			"provisioningStatus": "DESIGN",
 			"resourceTags": [{"key": "env", "value": "test"}],
 			"serviceLevelReference": "SLR-1",
 			"speed": 1000,
@@ -104,7 +104,7 @@ func (suite *NATGatewayClientTestSuite) TestCreateNATGateway() {
 	suite.False(gw.Config.BGPShutdownDefault)
 	suite.Equal("red", gw.Config.DiversityZone)
 	suite.Equal(100, gw.Config.SessionCount)
-	suite.Equal("NEW", gw.ProvisioningStatus)
+	suite.Equal("DESIGN", gw.ProvisioningStatus)
 	suite.Equal("PENDING", gw.OrderApprovalStatus)
 	suite.Len(gw.ResourceTags, 1)
 	suite.Equal("env", gw.ResourceTags[0].Key)
@@ -166,7 +166,7 @@ func (suite *NATGatewayClientTestSuite) TestListNATGateways() {
 				"locationId": 789012,
 				"productName": "NAT Gateway 2",
 				"productUid": "uid-2",
-				"provisioningStatus": "NEW",
+				"provisioningStatus": "DESIGN",
 				"speed": 2500,
 				"term": 24
 			}

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -379,14 +379,14 @@ func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayProvisioned() {
 		{name: "live", status: SERVICE_LIVE},
 	}
 
-	for _, tc := range cases {
+	for i, tc := range cases {
 		suite.Run(tc.name, func() {
-			suite.SetupTest()
-			defer suite.TearDownTest()
-
+			// Each sub-test uses a distinct UID so the handler paths do not
+			// collide on the shared mux, avoiding the server leak that would
+			// occur from calling suite.SetupTest() per sub-test.
 			ctx := context.Background()
 			natSvc := suite.client.NATGatewayService
-			productUID := "c1a2b3c4-d5e6-7890-1234-567890abcdef"
+			productUID := fmt.Sprintf("c1a2b3c4-d5e6-7890-1234-%012d", i+1)
 
 			getPath := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
 			suite.mux.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -336,20 +336,61 @@ func (suite *NATGatewayClientTestSuite) TestUpdateNATGatewayValidation() {
 	suite.ErrorIs(err, ErrNATGatewayInvalidTerm)
 }
 
-func (suite *NATGatewayClientTestSuite) TestDeleteNATGateway() {
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayDesignState() {
 	ctx := context.Background()
 	natSvc := suite.client.NATGatewayService
 	productUID := "e900d0d5-1030-4e29-b2d8-816ad4263190"
 
-	path := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
-	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		suite.Equal(http.MethodDelete, r.Method)
+	// Pre-flight GET — DeleteNATGateway inspects ProvisioningStatus to pick
+	// the right endpoint. DESIGN-state gateways use the nat-gateway-specific
+	// DELETE path.
+	getPath := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
+	designDeleteCalled := false
+	suite.mux.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"message": "Nat gateway order item deleted successfully", "terms": ""}`)
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprintf(w, `{"message":"","terms":"","data":{"productUid":"%s","provisioningStatus":"DESIGN"}}`, productUID)
+		case http.MethodDelete:
+			designDeleteCalled = true
+			fmt.Fprint(w, `{"message":"Nat gateway order item deleted successfully","terms":""}`)
+		default:
+			suite.FailNowf("unexpected method", "unexpected %s on %s", r.Method, getPath)
+		}
 	})
 
 	err := natSvc.DeleteNATGateway(ctx, productUID)
 	suite.NoError(err)
+	suite.True(designDeleteCalled, "expected DESIGN-state delete to hit /v3/products/nat_gateways/{uid}")
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayProvisioned() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "c1a2b3c4-d5e6-7890-1234-567890abcdef"
+
+	// Pre-flight GET returns a provisioned status (anything other than
+	// DESIGN) — DeleteNATGateway must route through the generic product
+	// cancel endpoint instead of the design-only DELETE.
+	getPath := fmt.Sprintf("/v3/products/nat_gateways/%s", productUID)
+	suite.mux.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method, "provisioned gateway must not hit DESIGN DELETE endpoint")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"message":"","terms":"","data":{"productUid":"%s","provisioningStatus":"LIVE"}}`, productUID)
+	})
+
+	cancelPath := "/v3/product/" + productUID + "/action/CANCEL_NOW"
+	cancelCalled := false
+	suite.mux.HandleFunc(cancelPath, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+		cancelCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"message":"Action [CANCEL_NOW Service %s] has been done.","terms":""}`, productUID)
+	})
+
+	err := natSvc.DeleteNATGateway(ctx, productUID)
+	suite.NoError(err)
+	suite.True(cancelCalled, "expected provisioned delete to hit /v3/product/{uid}/action/CANCEL_NOW")
 }
 
 func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayValidation() {


### PR DESCRIPTION
## Summary

`DeleteNATGateway` currently only calls the design-only endpoint `DELETE /v3/products/nat_gateways/{uid}`, which returns 400 once a gateway has been purchased (`"NAT Gateway cannot be deleted as it is not in DESIGN state"`). That left no SDK path to tear down a provisioned gateway — the CLI and Terraform provider both hit this wall.

This change makes `DeleteNATGateway` transparent to lifecycle stage:

- DESIGN-state records still use the design-only DELETE endpoint (hard removal — the record disappears from list).
- Provisioned records (DEPLOYABLE / CONFIGURED / LIVE) are cancelled via `ProductService.DeleteProduct` with `DeleteNow: true`, i.e. `POST /v3/product/{uid}/action/CANCEL_NOW`. This matches the teardown path already used for Ports, MCRs, MVEs, and VXCs, and moves the record to DECOMMISSIONED.

A unified server-side endpoint is not available (CANCEL_NOW rolls back against DESIGN-state records with a transaction-rollback 400), so the SDK performs a pre-flight GET and routes based on `ProvisioningStatus`.

## Testing

- Unit tests updated: `TestDeleteNATGatewayDesignState` mocks GET → DESIGN then verifies DELETE to the design endpoint; `TestDeleteNATGatewayProvisioned` mocks GET → LIVE then verifies CANCEL_NOW.
- `TestNATGatewayLifecycle` (design-only) now asserts the record is absent from `ListNATGateways` after delete.
- `TestNATGatewayFullLifecycle` exercises full CRUD against staging: validate → buy → poll to LIVE → delete → verify DECOMMISSIONED/CANCELLED. Deferred teardown is idempotent (skips when already terminal).
- Confirmed end-to-end on staging: a LIVE gateway was successfully cancelled and reached DECOMMISSIONED.

## Test plan

- [x] `go test ./...` (unit)
- [x] `go test -timeout 20m -integration ./... -run TestNATGatewayLifecycle` on staging
- [x] `go test -timeout 20m -integration ./... -run TestNATGatewayFullLifecycle` on staging
- [x] `golangci-lint run`