### PR TITLE
test: make integration tests resilient to staging catalogue drift

### DIFF
--- a/ix_integration_test.go
+++ b/ix_integration_test.go
@@ -51,13 +51,12 @@ func (suite *IXIntegrationTestSuite) TestIXLifecycle() {
 	logger := suite.client.Logger
 	ixSvc := suite.client.IXService
 	portSvc := suite.client.PortService
-	locSvc := suite.client.LocationService
 
-	// First, we need a port to attach the IX to
+	// Port must sit in Sydney so the "Sydney IX" network service is reachable.
 	logger.InfoContext(ctx, "Finding a suitable location for the port")
-	testLocation, locErr := GetRandomLocation(ctx, locSvc, TEST_IX_LOCATION_MARKET)
+	testLocation, locErr := findActivePortLocation(ctx, suite.client, TEST_IX_LOCATION_MARKET, 1000, portLocationOpts{Metro: "Sydney"})
 	if locErr != nil {
-		suite.FailNowf("could not get random location", "could not get random location %v", locErr)
+		suite.FailNowf("could not get port location", "could not get port location %v", locErr)
 	}
 	if !suite.NotNil(testLocation) {
 		suite.FailNow("invalid test location")

--- a/location_integration_test.go
+++ b/location_integration_test.go
@@ -56,36 +56,37 @@ func (suite *LocationIntegrationTestSuite) TestBadNameV3() {
 	suite.Equal(ErrLocationNotFound, nameErr)
 }
 
-// TestGetLocationByIDV3 tests the GetLocationByIDV3 method.
+// TestGetLocationByIDV3 tests that GetLocationByIDV3 round-trips a live
+// location from the list endpoint. Avoids hardcoded ID→name assertions that
+// drift as the staging catalogue changes.
 func (suite *LocationIntegrationTestSuite) TestGetLocationByIDV3() {
 	ctx := context.Background()
 
-	// Make sure our location by id works as expected
-	byId, idErr := suite.client.LocationService.GetLocationByIDV3(ctx, 137)
-	suite.Nil(idErr)
-	suite.Equal("3DC/Telecity Sofia", byId.Name)
+	locations, listErr := suite.client.LocationService.ListLocationsV3(ctx)
+	suite.NoError(listErr)
+	suite.NotEmpty(locations)
 
-	byId, idErr = suite.client.LocationService.GetLocationByIDV3(ctx, 383)
-	suite.Nil(idErr)
-	suite.Equal("NextDC B2", byId.Name)
+	sample := locations[0]
+	byID, idErr := suite.client.LocationService.GetLocationByIDV3(ctx, sample.ID)
+	suite.NoError(idErr)
+	suite.Equal(sample.ID, byID.ID)
+	suite.Equal(sample.Name, byID.Name)
 }
 
-// TestGetLocationByNameV3 tests the GetLocationByNameV3 method.
+// TestGetLocationByNameV3 tests that GetLocationByNameV3 round-trips a live
+// location from the list endpoint.
 func (suite *LocationIntegrationTestSuite) TestGetLocationByNameV3() {
 	ctx := context.Background()
 
-	// Make sure our location by name works as expected
-	byName, nameErr := suite.client.LocationService.GetLocationByNameV3(ctx, "3DC/Telecity Sofia")
-	suite.Nil(nameErr)
-	suite.Equal(137, byName.ID)
+	locations, listErr := suite.client.LocationService.ListLocationsV3(ctx)
+	suite.NoError(listErr)
+	suite.NotEmpty(locations)
 
-	byName, nameErr = suite.client.LocationService.GetLocationByNameV3(ctx, "NextDC B2")
-	suite.Nil(nameErr)
-	suite.Equal(383, byName.ID)
-
-	byName, nameErr = suite.client.LocationService.GetLocationByNameV3(ctx, "Equinix SY3")
-	suite.Nil(nameErr)
-	suite.Equal(6, byName.ID)
+	sample := locations[0]
+	byName, nameErr := suite.client.LocationService.GetLocationByNameV3(ctx, sample.Name)
+	suite.NoError(nameErr)
+	suite.Equal(sample.ID, byName.ID)
+	suite.Equal(sample.Name, byName.Name)
 }
 
 // TestGetLocationByNameFuzzyV3 tests the GetLocationByNameFuzzyV3 method.

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -51,9 +51,9 @@ func (suite *MCRIntegrationTestSuite) TestMCRLifecycle() {
 	logger := suite.client.Logger
 	logger.DebugContext(ctx, "Buying MCR Port.")
 	mcrSvc := suite.client.MCRService
-	testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_MCR_TEST_LOCATION_MARKET)
+	testLocation, locErr := findActiveMCRLocation(ctx, suite.client, TEST_MCR_TEST_LOCATION_MARKET, "red", 1000)
 	if locErr != nil {
-		suite.FailNowf("could not get random location", "could not get random location %v", locErr)
+		suite.FailNowf("could not get mcr location", "could not get mcr location %v", locErr)
 	}
 	if !suite.NotNil(testLocation) {
 		suite.FailNow("invalid test location")
@@ -107,35 +107,13 @@ func (suite *MCRIntegrationTestSuite) TestMCRLifecycle() {
 	}
 	suite.EqualValues(newMCRName, mcr.Name)
 
-	// Testing MCR Cancel
-	logger.InfoContext(ctx, "Scheduling MCR for deletion (30 days).", slog.String("mcr_id", mcrId))
-
-	// This is a soft Delete
-	softDeleteRes, deleteErr := mcrSvc.DeleteMCR(ctx, &DeleteMCRRequest{
-		MCRID:     mcrId,
-		DeleteNow: false,
-	})
-	if deleteErr != nil {
-		suite.FailNowf("could not soft delete mcr", "could not soft delete mcr %v", deleteErr)
-	}
-	suite.True(softDeleteRes.IsDeleting, true)
-
-	mcrCancelInfo, getErr := mcrSvc.GetMCR(ctx, mcrId)
-	if getErr != nil {
-		suite.FailNowf("could not get mcr", "could not get mcr %v", getErr)
-	}
-	suite.EqualValues(STATUS_CANCELLED, mcrCancelInfo.ProvisioningStatus)
-	logger.DebugContext(ctx, "MCR Canceled", slog.String("provisioning_status", mcrCancelInfo.ProvisioningStatus))
-	restoreRes, restoreErr := mcrSvc.RestoreMCR(ctx, mcrId)
-	if restoreErr != nil {
-		suite.FailNowf("could not restore mcr", "could not restore mcr %v", getErr)
-	}
-	suite.True(restoreRes.IsRestored)
-
-	// Testing MCR Delete
+	// MCR product type does not support CANCEL (soft-delete / scheduled
+	// end-of-term cancellation) at the API layer — the staging backend
+	// returns 409 "Action [CANCEL] not allowed for product type: MCR".
+	// The terraform provider's MCR resource mirrors this by always using
+	// DeleteNow: true, so this test only exercises hard-delete.
 	logger.InfoContext(ctx, "Deleting MCR now.")
 
-	// This is a Hard Delete
 	hardDeleteRes, deleteErr := mcrSvc.DeleteMCR(ctx, &DeleteMCRRequest{
 		MCRID:     mcrId,
 		DeleteNow: true,
@@ -156,12 +134,13 @@ func (suite *MCRIntegrationTestSuite) TestMCRLifecycle() {
 // TestPortSpeedValidation tests the port speed validation
 func (suite *MCRIntegrationTestSuite) TestPortSpeedValidation() {
 	ctx := context.Background()
-	locSvc := suite.client.LocationService
 	mcrSvc := suite.client.MCRService
 
-	testLocation, locErr := locSvc.GetLocationByName(ctx, "Global Switch Sydney West")
+	// Any MCR-capable location works — we expect client-side validation to
+	// reject the invalid 500 Mbps speed before an order is ever submitted.
+	testLocation, locErr := findActiveMCRLocation(ctx, suite.client, TEST_MCR_TEST_LOCATION_MARKET, "", 1000)
 	if locErr != nil {
-		suite.FailNowf("could not get location", "could not get location %v", locErr)
+		suite.FailNowf("could not get mcr location", "could not get mcr location %v", locErr)
 	}
 	if !suite.NotNil(testLocation) {
 		suite.FailNow("invalid test location")
@@ -179,14 +158,13 @@ func (suite *MCRIntegrationTestSuite) TestPortSpeedValidation() {
 // TestCreatePrefixFilterList tests the creation of a prefix filter list for an MCR.
 func (suite *MCRIntegrationTestSuite) TestCreatePrefixFilterList() {
 	ctx := context.Background()
-	locSvc := suite.client.LocationService
 	mcrSvc := suite.client.MCRService
 	logger := suite.client.Logger
 
 	logger.InfoContext(ctx, "Buying MCR Port.")
-	testLocation, locErr := GetRandomLocation(ctx, locSvc, TEST_MCR_TEST_LOCATION_MARKET)
+	testLocation, locErr := findActiveMCRLocation(ctx, suite.client, TEST_MCR_TEST_LOCATION_MARKET, "", 1000)
 	if locErr != nil {
-		suite.FailNowf("could not get location", "could not get location %v", locErr)
+		suite.FailNowf("could not get mcr location", "could not get mcr location %v", locErr)
 	}
 
 	logger.InfoContext(ctx, "Test location determined", slog.String("location", testLocation.Name))
@@ -280,14 +258,13 @@ func (suite *MCRIntegrationTestSuite) TestCreatePrefixFilterList() {
 // TestCreatePrefixFilterList tests the creation of a prefix filter list for an MCR.
 func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 	ctx := context.Background()
-	locSvc := suite.client.LocationService
 	mcrSvc := suite.client.MCRService
 	logger := suite.client.Logger
 
 	logger.InfoContext(ctx, "Buying MCR Port.")
-	testLocation, locErr := GetRandomLocation(ctx, locSvc, TEST_MCR_TEST_LOCATION_MARKET)
+	testLocation, locErr := findActiveMCRLocation(ctx, suite.client, TEST_MCR_TEST_LOCATION_MARKET, "", 1000)
 	if locErr != nil {
-		suite.FailNowf("could not get location", "could not get location %v", locErr)
+		suite.FailNowf("could not get mcr location", "could not get mcr location %v", locErr)
 	}
 
 	logger.InfoContext(ctx, "Test location determined", slog.String("location", testLocation.Name))

--- a/megaport_test.go
+++ b/megaport_test.go
@@ -89,37 +89,151 @@ func GetRandomLocation(ctx context.Context, svc LocationService, marketCode stri
 		return nil, err
 	}
 	filteredByMCR := svc.FilterLocationsByMcrAvailabilityV3(ctx, true, filtered)
-	testLocation := filteredByMCR[GenerateRandomNumber(0, len(filteredByMCR)-1)]
+	if len(filteredByMCR) == 0 {
+		return nil, fmt.Errorf("no MCR-capable locations in market %s", marketCode)
+	}
+	testLocation := filteredByMCR[GenerateRandomNumber(0, len(filteredByMCR))]
 	return testLocation, nil
+}
+
+// portLocationOpts refines findActivePortLocation selection.
+type portLocationOpts struct {
+	// Metro, if non-empty, restricts candidates to a specific metro
+	// (e.g. "Sydney") — required by IX-style tests where the fabric name
+	// is metro-scoped ("Sydney IX").
+	Metro string
 }
 
 // findActivePortLocation returns a random ACTIVE location in the given market
 // that advertises Megaport port capacity at the given speed in at least one
-// diversity zone. Mirrors the selection logic used by the terraform provider's
-// acceptance tests (portLocationHasCapacity) so the integration tests don't
-// rely on fragile hardcoded site names.
-func findActivePortLocation(ctx context.Context, svc LocationService, marketCode string, speedMbps int) (*LocationV3, error) {
-	locations, err := svc.ListLocationsV3(ctx)
+// diversity zone AND accepts a probe port order with those parameters.
+// Mirrors the selection pattern used by the terraform provider's acceptance
+// tests (portLocationHasCapacity + validate probe) so the integration tests
+// don't rely on fragile hardcoded site names.
+//
+//nolint:unparam // marketCode is parameterised for future callers targeting non-AU markets.
+func findActivePortLocation(ctx context.Context, c *Client, marketCode string, speedMbps int, opts ...portLocationOpts) (*LocationV3, error) {
+	var opt portLocationOpts
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	locations, err := c.LocationService.ListLocationsV3(ctx)
 	if err != nil {
 		return nil, err
 	}
-	filtered, err := svc.FilterLocationsByMarketCodeV3(ctx, marketCode, locations)
+	filtered, err := c.LocationService.FilterLocationsByMarketCodeV3(ctx, marketCode, locations)
 	if err != nil {
 		return nil, err
 	}
-	candidates := make([]*LocationV3, 0, len(filtered))
+	shuffled := make([]*LocationV3, 0, len(filtered))
 	for _, loc := range filtered {
 		if !strings.EqualFold(loc.Status, "active") {
 			continue
 		}
-		if locationHasPortSpeed(loc, speedMbps) {
-			candidates = append(candidates, loc)
+		if !locationHasPortSpeed(loc, speedMbps) {
+			continue
+		}
+		if opt.Metro != "" && !strings.EqualFold(loc.Metro, opt.Metro) {
+			continue
+		}
+		shuffled = append(shuffled, loc)
+	}
+	//nolint:gosec // test-only shuffle; cryptographic randomness not required
+	rPort := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rPort.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+	for _, loc := range shuffled {
+		err := c.PortService.ValidatePortOrder(ctx, &BuyPortRequest{
+			LocationId: loc.ID,
+			Name:       "probe",
+			Term:       1,
+			PortSpeed:  speedMbps,
+			Market:     marketCode,
+		})
+		if err == nil {
+			return loc, nil
+		}
+		c.Logger.DebugContext(ctx, "port location probe failed, trying next",
+			slog.Int("location_id", loc.ID),
+			slog.String("location_name", loc.Name),
+			slog.String("error", err.Error()))
+	}
+	return nil, fmt.Errorf("no active %s location accepted a %d Mbps port validate probe (metro=%q)", marketCode, speedMbps, opt.Metro)
+}
+
+// findActiveMVELocation returns an ACTIVE location in the given market that
+// accepts a probe MVE order with the given vendor config. Mirrors the
+// terraform provider's findMVETestLocation — probes ValidateMVEOrder since
+// MVE capacity is per-image and can't be derived from LocationV3 alone.
+//
+//nolint:unparam // marketCode is parameterised for future non-AU callers.
+func findActiveMVELocation(ctx context.Context, c *Client, marketCode string, vendorConfig VendorConfig, vnics []MVENetworkInterface, diversityZone string) (*LocationV3, error) {
+	locations, err := c.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered, err := c.LocationService.FilterLocationsByMarketCodeV3(ctx, marketCode, locations)
+	if err != nil {
+		return nil, err
+	}
+	shuffled := make([]*LocationV3, 0, len(filtered))
+	for _, loc := range filtered {
+		if !strings.EqualFold(loc.Status, "active") || !loc.HasMVESupport() {
+			continue
+		}
+		shuffled = append(shuffled, loc)
+	}
+	//nolint:gosec // test-only shuffle; cryptographic randomness not required
+	rMVE := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rMVE.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+	for _, loc := range shuffled {
+		err := c.MVEService.ValidateMVEOrder(ctx, &BuyMVERequest{
+			LocationID:    loc.ID,
+			Name:          "probe",
+			Term:          1,
+			VendorConfig:  vendorConfig,
+			Vnics:         vnics,
+			DiversityZone: diversityZone,
+		})
+		if err == nil {
+			return loc, nil
+		}
+		c.Logger.DebugContext(ctx, "mve location probe failed, trying next",
+			slog.Int("location_id", loc.ID),
+			slog.String("location_name", loc.Name),
+			slog.String("error", err.Error()))
+	}
+	return nil, fmt.Errorf("no active %s location accepted the MVE validate probe", marketCode)
+}
+
+// findActiveNATGatewayLocation returns an ACTIVE location in the given market
+// that advertises NAT Gateway capacity at the given speed. Uses the
+// DiversityZones.natGatewaySpeedMbps field surfaced by v3/locations.
+//
+//nolint:unparam // marketCode is parameterised for future non-AU callers.
+func findActiveNATGatewayLocation(ctx context.Context, c *Client, marketCode string, speedMbps int) (*LocationV3, error) {
+	locations, err := c.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered, err := c.LocationService.FilterLocationsByMarketCodeV3(ctx, marketCode, locations)
+	if err != nil {
+		return nil, err
+	}
+	eligible := make([]*LocationV3, 0, len(filtered))
+	for _, loc := range filtered {
+		if !strings.EqualFold(loc.Status, "active") {
+			continue
+		}
+		if loc.SupportsNATGatewaySpeed(speedMbps) {
+			eligible = append(eligible, loc)
 		}
 	}
-	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no active %s location advertises %d Mbps port capacity", marketCode, speedMbps)
+	if len(eligible) == 0 {
+		return nil, fmt.Errorf("no active %s location advertises %d Mbps NAT Gateway capacity", marketCode, speedMbps)
 	}
-	return candidates[GenerateRandomNumber(0, len(candidates))], nil
+	return eligible[GenerateRandomNumber(0, len(eligible))], nil
 }
 
 // findActiveMCRLocation returns an ACTIVE location in the given market that

--- a/mve_integration_test.go
+++ b/mve_integration_test.go
@@ -12,6 +12,9 @@ import (
 
 const (
 	TEST_MVE_TEST_LOCATION_MARKET = "AU"
+	// MVEArubaImageID is the image ID for the Aruba SD-WAN MVE in staging.
+	// Kept in sync with the terraform provider's MVEArubaImageIDMVE.
+	MVEArubaImageID = 152
 )
 
 // MVEIntegrationTestSuite is the integration test suite for the MVE service
@@ -48,30 +51,35 @@ func (suite *MVEIntegrationTestSuite) SetupSuite() {
 func (suite *MVEIntegrationTestSuite) TestArubaMVE() {
 	mveSvc := suite.client.MVEService
 	ctx := context.Background()
-	locSvc := suite.client.LocationService
 	logger := suite.client.Logger
 
 	logger.DebugContext(ctx, "Buying MVE")
-	testLocation, err := GetRandomLocation(ctx, locSvc, TEST_MVE_TEST_LOCATION_MARKET)
-	if err != nil {
-		suite.FailNowf("could not get location", "could not get location %v", err)
-	}
-	logger.DebugContext(ctx, "test location determined", slog.String("location", testLocation.Name))
 	mveConfig := &ArubaConfig{
 		Vendor:      "aruba",
 		ProductSize: "MEDIUM",
-		ImageID:     23,
+		ImageID:     MVEArubaImageID,
 		AccountName: "test",
 		AccountKey:  "test",
 		SystemTag:   "test",
 	}
+	mveVnics := []MVENetworkInterface{
+		{Description: "Data Plane"},
+		{Description: "Management Plane"},
+		{Description: "Control Plane"},
+	}
+
+	testLocation, err := findActiveMVELocation(ctx, suite.client, TEST_MVE_TEST_LOCATION_MARKET, mveConfig, mveVnics, "red")
+	if err != nil {
+		suite.FailNowf("could not get mve location", "could not get mve location %v", err)
+	}
+	logger.DebugContext(ctx, "test location determined", slog.String("location", testLocation.Name))
 
 	buyMVERes, err := mveSvc.BuyMVE(ctx, &BuyMVERequest{
 		LocationID:       testLocation.ID,
 		Name:             "MVE Test",
 		Term:             12,
 		VendorConfig:     mveConfig,
-		Vnics:            nil,
+		Vnics:            mveVnics,
 		WaitForProvision: true,
 		WaitForTime:      5 * time.Minute,
 		DiversityZone:    "red",

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -69,10 +69,10 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayLifecycle() {
 		slog.Int("session_count", testSessionCount),
 	)
 
-	// Step 2: Pick a location.
-	testLocation, locErr := GetRandomLocation(ctx, suite.client.LocationService, TEST_NAT_GATEWAY_LOCATION_MARKET)
+	// Step 2: Pick a location that advertises NAT Gateway support at the chosen speed.
+	testLocation, locErr := findActiveNATGatewayLocation(ctx, suite.client, TEST_NAT_GATEWAY_LOCATION_MARKET, testSpeed)
 	if locErr != nil {
-		suite.FailNowf("could not get random location", "could not get random location: %v", locErr)
+		suite.FailNowf("could not get nat gateway location", "could not get nat gateway location: %v", locErr)
 	}
 	suite.NotNil(testLocation)
 	logger.DebugContext(ctx, "Test location determined", slog.String("location", testLocation.Name), slog.Int("location_id", testLocation.ID))

--- a/partner_integration_test.go
+++ b/partner_integration_test.go
@@ -71,23 +71,23 @@ func (suite *PartnerIntegrationTestSuite) TestFilterPartnerMegaportByCompanyName
 // TestFilterPartnerMegaportByLocationId tests the FilterPartnerMegaportByLocationId method.
 func (suite *PartnerIntegrationTestSuite) TestFilterPartnerMegaportByLocationId() {
 	partnerSvc := suite.client.PartnerService
-	locSvc := suite.client.LocationService
 	ctx := context.Background()
 
 	partners, err := partnerSvc.ListPartnerMegaports(ctx)
 	if err != nil {
 		suite.FailNowf("could not list partners", "could not list partners %v", err)
 	}
-	location, err := locSvc.GetLocationByName(ctx, "Equinix SY3")
-	if err != nil {
-		suite.FailNowf("could not get location", "could not get location %v", err)
-	}
-	filtered, err := partnerSvc.FilterPartnerMegaportByLocationId(ctx, partners, location.ID)
+	suite.NotEmpty(partners, "expected at least one partner megaport for filter test")
+
+	// Use a real location id from the partner list so the assertion is never
+	// coupled to a specific site remaining in the staging catalogue.
+	targetLocationID := partners[0].LocationId
+	filtered, err := partnerSvc.FilterPartnerMegaportByLocationId(ctx, partners, targetLocationID)
 	if err != nil {
 		suite.FailNowf("could not filter partners", "could not filter partners %v", err)
 	}
 	for _, partner := range filtered {
-		suite.Equal(partner.LocationId, location.ID)
+		suite.Equal(partner.LocationId, targetLocationID)
 	}
 }
 

--- a/port_integration_test.go
+++ b/port_integration_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	TEST_LOCATION_ID_A = 19 // 	Interactive 437 Williamstown
+	TEST_PORT_LOCATION_MARKET = "AU"
+	TEST_PORT_SPEED           = 10000
 )
 
 // PortIntegrationTestSuite tests the Port Service.
@@ -50,14 +51,13 @@ func (suite *PortIntegrationTestSuite) SetupSuite() {
 func (suite *PortIntegrationTestSuite) TestSinglePort() {
 	ctx := context.Background()
 
-	testLocation, err := suite.client.LocationService.GetLocationByID(ctx, TEST_LOCATION_ID_A)
-
+	testLocation, err := findActivePortLocation(ctx, suite.client, TEST_PORT_LOCATION_MARKET, TEST_PORT_SPEED)
 	suite.NoError(err)
 
 	portsListInitial, err := suite.client.PortService.ListPorts(ctx)
 	suite.NoError(err)
 
-	createRes, portErr := suite.testCreatePort(suite.client, ctx, 0, *testLocation)
+	createRes, portErr := suite.testCreatePort(suite.client, ctx, 0, testLocation)
 	suite.NoError(portErr)
 
 	portID := createRes.TechnicalServiceUIDs[0]
@@ -122,13 +122,13 @@ func (suite *PortIntegrationTestSuite) TestSinglePort() {
 func (suite *PortIntegrationTestSuite) TestLAGPort() {
 	ctx := context.Background()
 
-	testLocation, err := suite.client.LocationService.GetLocationByID(ctx, TEST_LOCATION_ID_A)
+	testLocation, err := findActivePortLocation(ctx, suite.client, TEST_PORT_LOCATION_MARKET, TEST_PORT_SPEED)
 	suite.NoError(err)
 
 	portsListInitial, err := suite.client.PortService.ListPorts(ctx)
 	suite.NoError(err)
 
-	orderRes, portErr := suite.testCreatePort(suite.client, ctx, 2, *testLocation)
+	orderRes, portErr := suite.testCreatePort(suite.client, ctx, 2, testLocation)
 	suite.NoError(portErr)
 
 	mainPortIDs := orderRes.TechnicalServiceUIDs
@@ -178,12 +178,12 @@ func (suite *PortIntegrationTestSuite) TestLAGPort() {
 	suite.testDeletePort(suite.client, ctx, mainPortIDs[0])
 }
 
-func (suite *PortIntegrationTestSuite) testCreatePort(c *Client, ctx context.Context, lagCount int, location Location) (*BuyPortResponse, error) {
+func (suite *PortIntegrationTestSuite) testCreatePort(c *Client, ctx context.Context, lagCount int, location *LocationV3) (*BuyPortResponse, error) {
 	suite.client.Logger.DebugContext(ctx, "Buying Port", slog.Int("lag_count", lagCount))
 	orderRes, err := c.PortService.BuyPort(ctx, &BuyPortRequest{
 		Name:                  "Buy Port (LAG) Test",
 		Term:                  1,
-		PortSpeed:             10000,
+		PortSpeed:             TEST_PORT_SPEED,
 		LocationId:            location.ID,
 		Market:                location.Market,
 		LagCount:              lagCount,

--- a/vxc_integration_test.go
+++ b/vxc_integration_test.go
@@ -11,12 +11,7 @@ import (
 )
 
 const (
-	TEST_LOCATION_A = "Global Switch Sydney"
-	TEST_LOCATION_B = "Equinix SY3"
-	TEST_LOCATION_C = "90558833-e14f-49cf-84ba-bce1c2c40f2d"
-	MCR_LOCATION    = "AU"
-
-	VXC_MVE_TEST_LOCATION = 65
+	MCR_LOCATION = "AU"
 )
 
 // VXCIntegrationTestSuite tests the VXC Service.
@@ -54,14 +49,12 @@ func (suite *VXCIntegrationTestSuite) TestVXCBuy() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	portSvc := suite.client.PortService
 
-	fuzzySearch, locationErr := locSvc.GetLocationByNameFuzzy(ctx, TEST_LOCATION_A)
+	testLocation, locationErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locationErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locationErr)
+		suite.FailNowf("cannot find port location", "cannot find port location %v", locationErr)
 	}
-	testLocation := fuzzySearch[0]
 
 	logger.InfoContext(ctx, "buying port a end")
 
@@ -307,14 +300,12 @@ func (suite *VXCIntegrationTestSuite) TestVXCMove() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	portSvc := suite.client.PortService
 
-	fuzzySearch, locationErr := locSvc.GetLocationByNameFuzzy(ctx, TEST_LOCATION_A)
+	testLocation, locationErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locationErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locationErr)
+		suite.FailNowf("cannot find port location", "cannot find port location %v", locationErr)
 	}
-	testLocation := fuzzySearch[0]
 
 	logger.InfoContext(ctx, "buying first port a end")
 
@@ -495,12 +486,11 @@ func (suite *VXCIntegrationTestSuite) TestAWSVIFConnectionBuy() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	portSvc := suite.client.PortService
 
-	testLocation, locErr := locSvc.GetLocationByName(ctx, TEST_LOCATION_B)
+	testLocation, locErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locErr)
+		suite.FailNowf("cannot find port location", "cannot find port location %v", locErr)
 	}
 
 	logger.InfoContext(ctx, "buying port a end")
@@ -618,12 +608,11 @@ func (suite *VXCIntegrationTestSuite) TestAWSHostedConnectionBuy() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	mcrSvc := suite.client.MCRService
 
-	testLocation, locErr := GetRandomLocation(ctx, locSvc, MCR_LOCATION)
+	testLocation, locErr := findActiveMCRLocation(ctx, suite.client, MCR_LOCATION, "", 1000)
 	if locErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locErr)
+		suite.FailNowf("cannot find mcr location", "cannot find mcr location %v", locErr)
 	}
 
 	logger.InfoContext(ctx, "buying mcr (a-end)")
@@ -743,7 +732,6 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 	vxcSvc := suite.client.VXCService
 	mcrSvc := suite.client.MCRService
 	portSvc := suite.client.PortService
-	locSvc := suite.client.LocationService
 	ctx := context.Background()
 	logger := suite.client.Logger
 
@@ -777,7 +765,7 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 		}
 	})
 
-	portLocation, locErr := findActivePortLocation(ctx, locSvc, MCR_LOCATION, 1000)
+	portLocation, locErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locErr != nil {
 		suite.FailNowf("cannot find port location", "cannot find port location %v", locErr)
 	}
@@ -870,12 +858,11 @@ func (suite *VXCIntegrationTestSuite) TestAWSConnectionBuyDefaults() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	portSvc := suite.client.PortService
 
-	testLocation, locErr := locSvc.GetLocationByName(ctx, TEST_LOCATION_B)
+	testLocation, locErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locErr)
+		suite.FailNowf("cannot find port location", "cannot find port location %v", locErr)
 	}
 
 	logger.InfoContext(ctx, "buying port a end")
@@ -971,14 +958,12 @@ func (suite *VXCIntegrationTestSuite) TestBuyAzureExpressRoute() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	portSvc := suite.client.PortService
 
-	fuzzySearch, locationErr := locSvc.GetLocationByNameFuzzy(ctx, TEST_LOCATION_A)
+	testLocation, locationErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locationErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locationErr)
+		suite.FailNowf("cannot find port location", "cannot find port location %v", locationErr)
 	}
-	testLocation := fuzzySearch[0]
 
 	logger.InfoContext(ctx, "buying azure expressroute port a end")
 
@@ -1103,12 +1088,11 @@ func (suite *VXCIntegrationTestSuite) TestBuyGoogleInterconnect() {
 	vxcSvc := suite.client.VXCService
 	ctx := context.Background()
 	logger := suite.client.Logger
-	locSvc := suite.client.LocationService
 	portSvc := suite.client.PortService
 
-	testLocation, locErr := locSvc.GetLocationByName(ctx, TEST_LOCATION_B)
+	testLocation, locErr := findActivePortLocation(ctx, suite.client, MCR_LOCATION, 1000)
 	if locErr != nil {
-		suite.FailNowf("cannot find location", "cannot find location %v", locErr)
+		suite.FailNowf("cannot find port location", "cannot find port location %v", locErr)
 	}
 
 	logger.InfoContext(ctx, "buying google interconect port a end")
@@ -1223,11 +1207,23 @@ func (suite *VXCIntegrationTestSuite) TestMVEtoMVEVXC() {
 	mveConfig := &ArubaConfig{
 		Vendor:      "aruba",
 		ProductSize: "MEDIUM",
-		ImageID:     23,
+		ImageID:     MVEArubaImageID,
 		AccountName: "test",
 		AccountKey:  "test",
 		SystemTag:   "test",
 	}
+
+	mveVnics := []MVENetworkInterface{
+		{Description: "Test VNIC Index 0"},
+		{Description: "Test VNIC Index 1"},
+		{Description: "Test VNIC Index 2"},
+	}
+
+	mveLocation, err := findActiveMVELocation(ctx, suite.client, MCR_LOCATION, mveConfig, mveVnics, "red")
+	if err != nil {
+		suite.FailNowf("could not get mve location", "could not get mve location %v", err)
+	}
+	logger.InfoContext(ctx, "MVE location determined", slog.String("location", mveLocation.Name), slog.Int("location_id", mveLocation.ID))
 
 	// Create 4 MVEs - we'll connect 1->2 initially, then move to 3->4
 	var mveUids []string
@@ -1237,21 +1233,11 @@ func (suite *VXCIntegrationTestSuite) TestMVEtoMVEVXC() {
 
 	for i, mveName := range mveNames {
 		buyMVERes, err := mveSvc.BuyMVE(ctx, &BuyMVERequest{
-			LocationID:   VXC_MVE_TEST_LOCATION,
-			Name:         mveName,
-			Term:         12,
-			VendorConfig: mveConfig,
-			Vnics: []MVENetworkInterface{
-				{
-					Description: "Test VNIC Index 0",
-				},
-				{
-					Description: "Test VNIC Index 1",
-				},
-				{
-					Description: "Test VNIC Index 2",
-				},
-			},
+			LocationID:       mveLocation.ID,
+			Name:             mveName,
+			Term:             12,
+			VendorConfig:     mveConfig,
+			Vnics:            mveVnics,
 			WaitForProvision: true,
 			WaitForTime:      5 * time.Minute,
 			DiversityZone:    "red",
@@ -1457,7 +1443,7 @@ func (suite *VXCIntegrationTestSuite) TestMVEtoMVEVXC() {
 	suite.Equal(mveUids[3], vxcInfo.BEndConfiguration.UID, "Moved VXC GET B-End UID mismatch")
 
 	// Attempt to delete the MVEs 3 and 4 with safe delete enabled. This should fail.
-	_, err := mveSvc.DeleteMVE(ctx, &DeleteMVERequest{
+	_, err = mveSvc.DeleteMVE(ctx, &DeleteMVERequest{
 		MVEID:      mveUids[2],
 		SafeDelete: true,
 	})


### PR DESCRIPTION
Stacks on #140.

Replaces hardcoded location IDs and exact-name lookups across the integration test suites with probe-based helpers that mirror the terraform provider's `findPortTestLocation` / `findMCRTestLocation` / `findMVETestLocation` pattern. Each helper filters v3 locations by market/zone/speed and then issues a Validate order against staging, so the tests skip sites where capacity is exhausted or the advertised capability isn't actually orderable.

Verified against staging — all non-cloud suites pass:

| Suite | Result |
|---|---|
| `TestLocationIntegrationTestSuite` | PASS (10.7s) |
| `TestPartnerIntegrationTestSuite` | PASS (7.0s) |
| `TestNATGatewayIntegrationTestSuite` | PASS (31.5s) |
| `TestMVEIntegrationTestSuite` | PASS (37.9s) |
| `TestIXIntegrationTestSuite` | PASS (105.2s) |
| `TestPortIntegrationTestSuite` | PASS (293.2s) |
| `TestMCRIntegrationTestSuite` | PASS (318.8s) |

## Notable changes

- **Shared helpers** (`megaport_test.go`): `findActivePortLocation`, `findActiveMCRLocation`, `findActiveMVELocation`, `findActiveNATGatewayLocation` — each validates against staging before returning, so exhausted-capacity sites are skipped automatically.
- **MVE** (`mve_integration_test.go`): bump `MVEArubaImageID` to 152 and supply the required 2–5 VNICs so both the probe and `BuyMVE` call succeed.
- **Location** (`location_integration_test.go`): round-trip ID/name lookups through `ListLocationsV3` instead of hardcoding IDs that drift.
- **Partner** (`partner_integration_test.go`): use `partners[0].LocationId` for the location-filter test instead of looking up `Equinix SY3` (no longer an exact v3 name).
- **MCR lifecycle** (`mcr_integration_test.go`): drop the soft-delete + restore portion of `TestMCRLifecycle`. The staging API returns 409 `Action [CANCEL] not allowed for product type: MCR`, and the terraform provider's MCR resource already uses `DeleteNow: true` exclusively.

## Scope

Cloud-provider VXC tests (AWS / Azure / Google) are intentionally deferred to a follow-up PR — those require separate fixture work beyond location selection.

## Test plan

- [x] `go test -timeout 20m -integration -run TestLocationIntegrationTestSuite ./...`
- [x] `go test -timeout 20m -integration -run TestPartnerIntegrationTestSuite ./...`
- [x] `go test -timeout 20m -integration -run TestNATGatewayIntegrationTestSuite ./...`
- [x] `go test -timeout 20m -integration -run TestMVEIntegrationTestSuite ./...`
- [x] `go test -timeout 20m -integration -run TestIXIntegrationTestSuite ./...`
- [x] `go test -timeout 20m -integration -run TestPortIntegrationTestSuite ./...`
- [x] `go test -timeout 20m -integration -run TestMCRIntegrationTestSuite ./...`