### PR TITLE
feat: NAT Gateway VXC attachment, packet filters, prefix lists, diagnostics

### DIFF
--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -39,6 +39,68 @@ type NATGatewayService interface {
 	// DEPLOYABLE -> CONFIGURED -> LIVE lifecycle. Returns the provisioning
 	// service record.
 	BuyNATGateway(ctx context.Context, productUID string) (*NATGatewayBuyResult, error)
+
+	// ListNATGatewayPacketFilters returns all packet filter summaries for
+	// a NAT Gateway.
+	ListNATGatewayPacketFilters(ctx context.Context, productUID string) ([]*NATGatewayPacketFilterSummary, error)
+	// CreateNATGatewayPacketFilter creates a new packet filter on a NAT
+	// Gateway.
+	CreateNATGatewayPacketFilter(ctx context.Context, productUID string, req *NATGatewayPacketFilterRequest) (*NATGatewayPacketFilter, error)
+	// GetNATGatewayPacketFilter returns a packet filter by its numeric ID.
+	GetNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) (*NATGatewayPacketFilter, error)
+	// UpdateNATGatewayPacketFilter replaces a packet filter's description
+	// and entries.
+	UpdateNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int, req *NATGatewayPacketFilterRequest) (*NATGatewayPacketFilter, error)
+	// DeleteNATGatewayPacketFilter removes a packet filter from a NAT
+	// Gateway. Any VXC interfaces referencing the filter will be detached
+	// server-side.
+	DeleteNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) error
+
+	// ListNATGatewayPrefixLists returns all prefix list summaries for a
+	// NAT Gateway.
+	ListNATGatewayPrefixLists(ctx context.Context, productUID string) ([]*NATGatewayPrefixListSummary, error)
+	// CreateNATGatewayPrefixList creates a new prefix list on a NAT
+	// Gateway.
+	CreateNATGatewayPrefixList(ctx context.Context, productUID string, req *NATGatewayPrefixList) (*NATGatewayPrefixList, error)
+	// GetNATGatewayPrefixList returns a prefix list by its numeric ID.
+	GetNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) (*NATGatewayPrefixList, error)
+	// UpdateNATGatewayPrefixList replaces a prefix list's description,
+	// address family, and entries.
+	UpdateNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int, req *NATGatewayPrefixList) (*NATGatewayPrefixList, error)
+	// DeleteNATGatewayPrefixList removes a prefix list from a NAT Gateway.
+	DeleteNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) error
+
+	// ListNATGatewayIPRoutesAsync submits an IP routes diagnostics request
+	// and returns the operation ID to poll with
+	// GetNATGatewayDiagnosticsRoutes. The endpoint is rate-limited and
+	// intended for troubleshooting only. If ipAddress is empty, the
+	// response will include both IPv4 and IPv6 routes; otherwise the
+	// response is narrowed to routes matching the supplied address.
+	ListNATGatewayIPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error)
+	// ListNATGatewayBGPRoutesAsync submits a BGP routes diagnostics
+	// request and returns the operation ID to poll with
+	// GetNATGatewayDiagnosticsRoutes. Rate-limited and intended for
+	// troubleshooting only.
+	ListNATGatewayBGPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error)
+	// ListNATGatewayBGPNeighborRoutesAsync submits a BGP neighbor routes
+	// diagnostics request and returns the operation ID to poll with
+	// GetNATGatewayDiagnosticsRoutes.
+	ListNATGatewayBGPNeighborRoutesAsync(ctx context.Context, req *NATGatewayBGPNeighborRoutesRequest) (string, error)
+	// GetNATGatewayDiagnosticsRoutes retrieves the routes for a prior
+	// asynchronous diagnostics request. Returns the heterogeneous slice
+	// of IP and/or BGP routes produced by the async operation.
+	GetNATGatewayDiagnosticsRoutes(ctx context.Context, productUID, operationID string) ([]*NATGatewayRoute, error)
+
+	// ListNATGatewayIPRoutes submits an IP routes diagnostics request and
+	// polls until the routes are available. The returned slice contains
+	// only IP routes extracted from the heterogeneous result.
+	ListNATGatewayIPRoutes(ctx context.Context, productUID, ipAddress string) ([]*NATGatewayIPRoute, error)
+	// ListNATGatewayBGPRoutes submits a BGP routes diagnostics request
+	// and polls until the routes are available.
+	ListNATGatewayBGPRoutes(ctx context.Context, productUID, ipAddress string) ([]*NATGatewayBGPRoute, error)
+	// ListNATGatewayBGPNeighborRoutes submits a BGP neighbor routes
+	// diagnostics request and polls until the routes are available.
+	ListNATGatewayBGPNeighborRoutes(ctx context.Context, req *NATGatewayBGPNeighborRoutesRequest) ([]*NATGatewayBGPRoute, error)
 }
 
 // NewNATGatewayService creates a new instance of the NAT Gateway Service.
@@ -88,6 +150,29 @@ var ErrNATGatewaySpeedRequired = errors.New("speed must be greater than 0")
 
 // ErrNATGatewayInvalidTerm is returned when a Term is not a valid contract term.
 var ErrNATGatewayInvalidTerm = errors.New("term must be one of: 1, 12, 24, 36, 48, 60")
+
+// Packet filter validation errors.
+var (
+	ErrNATGatewayPacketFilterIDRequired       = errors.New("packet filter ID must be greater than 0")
+	ErrNATGatewayPacketFilterDescriptionEmpty = errors.New("packet filter description is required")
+	ErrNATGatewayPacketFilterEntriesEmpty     = errors.New("packet filter requires at least one entry")
+)
+
+// Prefix list validation errors.
+var (
+	ErrNATGatewayPrefixListIDRequired         = errors.New("prefix list ID must be greater than 0")
+	ErrNATGatewayPrefixListDescriptionEmpty   = errors.New("prefix list description is required")
+	ErrNATGatewayPrefixListAddressFamilyEmpty = errors.New("prefix list addressFamily is required")
+	ErrNATGatewayPrefixListEntriesEmpty       = errors.New("prefix list requires at least one entry")
+)
+
+// Diagnostics validation errors.
+var (
+	ErrNATGatewayDiagnosticsPeerIPRequired   = errors.New("BGP neighbor diagnostics require a peer IP address")
+	ErrNATGatewayDiagnosticsDirectionInvalid = errors.New("BGP neighbor diagnostics require a direction (RECEIVED or ADVERTISED)")
+	ErrNATGatewayDiagnosticsOperationEmpty   = errors.New("operation ID is required")
+	ErrNATGatewayDiagnosticsTimeout          = errors.New("timed out waiting for diagnostics operation to complete")
+)
 
 // validateCreateNATGatewayRequest validates the request parameters for creating a NAT Gateway.
 func validateCreateNATGatewayRequest(req *CreateNATGatewayRequest) error {
@@ -419,4 +504,386 @@ func (svc *NATGatewayServiceOp) GetNATGatewayTelemetry(ctx context.Context, req 
 		return nil, err
 	}
 	return telemetryResp, nil
+}
+
+// --- Packet filters -------------------------------------------------------
+
+func validateNATGatewayPacketFilterRequest(req *NATGatewayPacketFilterRequest) error {
+	if req == nil || req.Description == "" {
+		return ErrNATGatewayPacketFilterDescriptionEmpty
+	}
+	if len(req.Entries) == 0 {
+		return ErrNATGatewayPacketFilterEntriesEmpty
+	}
+	return nil
+}
+
+// ListNATGatewayPacketFilters returns all packet filter summaries for a NAT Gateway.
+func (svc *NATGatewayServiceOp) ListNATGatewayPacketFilters(ctx context.Context, productUID string) ([]*NATGatewayPacketFilterSummary, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/packet_filter_summaries", url.PathEscape(productUID))
+	var envelope natGatewayPacketFilterSummariesResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+// CreateNATGatewayPacketFilter creates a new packet filter on a NAT Gateway.
+func (svc *NATGatewayServiceOp) CreateNATGatewayPacketFilter(ctx context.Context, productUID string, req *NATGatewayPacketFilterRequest) (*NATGatewayPacketFilter, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if err := validateNATGatewayPacketFilterRequest(req); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/packet_filters", url.PathEscape(productUID))
+	var envelope natGatewayPacketFilterResponse
+	if err := svc.doJSON(ctx, http.MethodPost, path, req, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+// GetNATGatewayPacketFilter returns a packet filter by its numeric ID.
+func (svc *NATGatewayServiceOp) GetNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) (*NATGatewayPacketFilter, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if packetFilterID < 1 {
+		return nil, ErrNATGatewayPacketFilterIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/packet_filters/%d", url.PathEscape(productUID), packetFilterID)
+	var envelope natGatewayPacketFilterResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+// UpdateNATGatewayPacketFilter replaces a packet filter's description and entries.
+func (svc *NATGatewayServiceOp) UpdateNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int, req *NATGatewayPacketFilterRequest) (*NATGatewayPacketFilter, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if packetFilterID < 1 {
+		return nil, ErrNATGatewayPacketFilterIDRequired
+	}
+	if err := validateNATGatewayPacketFilterRequest(req); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/packet_filters/%d", url.PathEscape(productUID), packetFilterID)
+	var envelope natGatewayPacketFilterResponse
+	if err := svc.doJSON(ctx, http.MethodPut, path, req, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+// DeleteNATGatewayPacketFilter removes a packet filter from a NAT Gateway.
+func (svc *NATGatewayServiceOp) DeleteNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) error {
+	if productUID == "" {
+		return ErrNATGatewayProductUIDRequired
+	}
+	if packetFilterID < 1 {
+		return ErrNATGatewayPacketFilterIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/packet_filters/%d", url.PathEscape(productUID), packetFilterID)
+	return svc.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// --- Prefix lists ---------------------------------------------------------
+
+func validateNATGatewayPrefixList(req *NATGatewayPrefixList) error {
+	if req == nil || req.Description == "" {
+		return ErrNATGatewayPrefixListDescriptionEmpty
+	}
+	if req.AddressFamily == "" {
+		return ErrNATGatewayPrefixListAddressFamilyEmpty
+	}
+	if len(req.Entries) == 0 {
+		return ErrNATGatewayPrefixListEntriesEmpty
+	}
+	return nil
+}
+
+// ListNATGatewayPrefixLists returns all prefix list summaries for a NAT Gateway.
+func (svc *NATGatewayServiceOp) ListNATGatewayPrefixLists(ctx context.Context, productUID string) ([]*NATGatewayPrefixListSummary, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/prefix_list_summaries", url.PathEscape(productUID))
+	var envelope natGatewayPrefixListSummariesResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+// CreateNATGatewayPrefixList creates a new prefix list on a NAT Gateway.
+func (svc *NATGatewayServiceOp) CreateNATGatewayPrefixList(ctx context.Context, productUID string, req *NATGatewayPrefixList) (*NATGatewayPrefixList, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if err := validateNATGatewayPrefixList(req); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/prefix_lists", url.PathEscape(productUID))
+	var envelope natGatewayPrefixListResponse
+	if err := svc.doJSON(ctx, http.MethodPost, path, req.toAPI(), &envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Data == nil {
+		return nil, nil
+	}
+	return envelope.Data.toPrefixList()
+}
+
+// GetNATGatewayPrefixList returns a prefix list by its numeric ID.
+func (svc *NATGatewayServiceOp) GetNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) (*NATGatewayPrefixList, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if prefixListID < 1 {
+		return nil, ErrNATGatewayPrefixListIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/prefix_lists/%d", url.PathEscape(productUID), prefixListID)
+	var envelope natGatewayPrefixListResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Data == nil {
+		return nil, nil
+	}
+	return envelope.Data.toPrefixList()
+}
+
+// UpdateNATGatewayPrefixList replaces a prefix list's description, address family, and entries.
+func (svc *NATGatewayServiceOp) UpdateNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int, req *NATGatewayPrefixList) (*NATGatewayPrefixList, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if prefixListID < 1 {
+		return nil, ErrNATGatewayPrefixListIDRequired
+	}
+	if err := validateNATGatewayPrefixList(req); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/prefix_lists/%d", url.PathEscape(productUID), prefixListID)
+	var envelope natGatewayPrefixListResponse
+	if err := svc.doJSON(ctx, http.MethodPut, path, req.toAPI(), &envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Data == nil {
+		return nil, nil
+	}
+	return envelope.Data.toPrefixList()
+}
+
+// DeleteNATGatewayPrefixList removes a prefix list from a NAT Gateway.
+func (svc *NATGatewayServiceOp) DeleteNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) error {
+	if productUID == "" {
+		return ErrNATGatewayProductUIDRequired
+	}
+	if prefixListID < 1 {
+		return ErrNATGatewayPrefixListIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/prefix_lists/%d", url.PathEscape(productUID), prefixListID)
+	return svc.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// --- Diagnostics ----------------------------------------------------------
+
+// diagnosticsPollInterval and diagnosticsPollTimeout are the defaults used by
+// the convenience diagnostics wrappers.
+const (
+	diagnosticsPollInitialDelay = 2 * time.Second
+	diagnosticsPollInterval     = 3 * time.Second
+	diagnosticsPollTimeout      = 60 * time.Second
+)
+
+// ListNATGatewayIPRoutesAsync submits an IP routes diagnostics request.
+func (svc *NATGatewayServiceOp) ListNATGatewayIPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error) {
+	if productUID == "" {
+		return "", ErrNATGatewayProductUIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/diagnostics/routes/ip", url.PathEscape(productUID))
+	if ipAddress != "" {
+		params := url.Values{}
+		params.Set("ip_address", ipAddress)
+		path = path + "?" + params.Encode()
+	}
+	var envelope natGatewayDiagnosticsAsyncResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return "", err
+	}
+	return envelope.Data, nil
+}
+
+// ListNATGatewayBGPRoutesAsync submits a BGP routes diagnostics request.
+func (svc *NATGatewayServiceOp) ListNATGatewayBGPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error) {
+	if productUID == "" {
+		return "", ErrNATGatewayProductUIDRequired
+	}
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/diagnostics/routes/bgp", url.PathEscape(productUID))
+	if ipAddress != "" {
+		params := url.Values{}
+		params.Set("ip_address", ipAddress)
+		path = path + "?" + params.Encode()
+	}
+	var envelope natGatewayDiagnosticsAsyncResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return "", err
+	}
+	return envelope.Data, nil
+}
+
+// ListNATGatewayBGPNeighborRoutesAsync submits a BGP neighbor routes diagnostics request.
+func (svc *NATGatewayServiceOp) ListNATGatewayBGPNeighborRoutesAsync(ctx context.Context, req *NATGatewayBGPNeighborRoutesRequest) (string, error) {
+	if req == nil || req.ProductUID == "" {
+		return "", ErrNATGatewayProductUIDRequired
+	}
+	if req.PeerIPAddress == "" {
+		return "", ErrNATGatewayDiagnosticsPeerIPRequired
+	}
+	if req.Direction != BGPRouteDirectionReceived && req.Direction != BGPRouteDirectionAdvertised {
+		return "", ErrNATGatewayDiagnosticsDirectionInvalid
+	}
+	params := url.Values{}
+	params.Set("direction", req.Direction)
+	params.Set("peer_ip_address", req.PeerIPAddress)
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/diagnostics/routes/bgp/neighbor?%s", url.PathEscape(req.ProductUID), params.Encode())
+	var envelope natGatewayDiagnosticsAsyncResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return "", err
+	}
+	return envelope.Data, nil
+}
+
+// GetNATGatewayDiagnosticsRoutes fetches the routes for a prior async request.
+func (svc *NATGatewayServiceOp) GetNATGatewayDiagnosticsRoutes(ctx context.Context, productUID, operationID string) ([]*NATGatewayRoute, error) {
+	if productUID == "" {
+		return nil, ErrNATGatewayProductUIDRequired
+	}
+	if operationID == "" {
+		return nil, ErrNATGatewayDiagnosticsOperationEmpty
+	}
+	params := url.Values{}
+	params.Set("operationId", operationID)
+	path := fmt.Sprintf("/v3/products/nat_gateways/%s/diagnostics/routes/operation?%s", url.PathEscape(productUID), params.Encode())
+	var envelope natGatewayDiagnosticsRoutesResponse
+	if err := svc.doJSON(ctx, http.MethodGet, path, nil, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+// pollDiagnosticsRoutes polls GetNATGatewayDiagnosticsRoutes until the
+// operation returns a non-empty result, or the caller-supplied timeout
+// elapses. Empty responses are treated as "still processing".
+func (svc *NATGatewayServiceOp) pollDiagnosticsRoutes(ctx context.Context, productUID, operationID string) ([]*NATGatewayRoute, error) {
+	pollCtx, cancel := context.WithTimeout(ctx, diagnosticsPollTimeout)
+	defer cancel()
+	select {
+	case <-pollCtx.Done():
+		return nil, ErrNATGatewayDiagnosticsTimeout
+	case <-time.After(diagnosticsPollInitialDelay):
+	}
+	ticker := time.NewTicker(diagnosticsPollInterval)
+	defer ticker.Stop()
+	for {
+		routes, err := svc.GetNATGatewayDiagnosticsRoutes(pollCtx, productUID, operationID)
+		if err != nil {
+			return nil, err
+		}
+		if len(routes) > 0 {
+			return routes, nil
+		}
+		select {
+		case <-pollCtx.Done():
+			return nil, ErrNATGatewayDiagnosticsTimeout
+		case <-ticker.C:
+		}
+	}
+}
+
+// ListNATGatewayIPRoutes submits an IP routes request and polls until results are available.
+func (svc *NATGatewayServiceOp) ListNATGatewayIPRoutes(ctx context.Context, productUID, ipAddress string) ([]*NATGatewayIPRoute, error) {
+	opID, err := svc.ListNATGatewayIPRoutesAsync(ctx, productUID, ipAddress)
+	if err != nil {
+		return nil, err
+	}
+	routes, err := svc.pollDiagnosticsRoutes(ctx, productUID, opID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*NATGatewayIPRoute, 0, len(routes))
+	for _, r := range routes {
+		if r.IP != nil {
+			out = append(out, r.IP)
+		}
+	}
+	return out, nil
+}
+
+// ListNATGatewayBGPRoutes submits a BGP routes request and polls until results are available.
+func (svc *NATGatewayServiceOp) ListNATGatewayBGPRoutes(ctx context.Context, productUID, ipAddress string) ([]*NATGatewayBGPRoute, error) {
+	opID, err := svc.ListNATGatewayBGPRoutesAsync(ctx, productUID, ipAddress)
+	if err != nil {
+		return nil, err
+	}
+	routes, err := svc.pollDiagnosticsRoutes(ctx, productUID, opID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*NATGatewayBGPRoute, 0, len(routes))
+	for _, r := range routes {
+		if r.BGP != nil {
+			out = append(out, r.BGP)
+		}
+	}
+	return out, nil
+}
+
+// ListNATGatewayBGPNeighborRoutes submits a BGP neighbor routes request and polls for results.
+func (svc *NATGatewayServiceOp) ListNATGatewayBGPNeighborRoutes(ctx context.Context, req *NATGatewayBGPNeighborRoutesRequest) ([]*NATGatewayBGPRoute, error) {
+	opID, err := svc.ListNATGatewayBGPNeighborRoutesAsync(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	routes, err := svc.pollDiagnosticsRoutes(ctx, req.ProductUID, opID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*NATGatewayBGPRoute, 0, len(routes))
+	for _, r := range routes {
+		if r.BGP != nil {
+			out = append(out, r.BGP)
+		}
+	}
+	return out, nil
+}
+
+// --- shared helper --------------------------------------------------------
+
+// doJSON sends a JSON request and decodes the response into out (or discards
+// the body if out is nil). It centralises the NewRequest/Do/Unmarshal dance
+// shared by the packet filter, prefix list, and diagnostics methods.
+func (svc *NATGatewayServiceOp) doJSON(ctx context.Context, method, path string, body, out interface{}) error {
+	clientReq, err := svc.Client.NewRequest(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if out == nil || buf.Len() == 0 {
+		return nil
+	}
+	return json.Unmarshal(buf.Bytes(), out)
 }

--- a/nat_gateway.go
+++ b/nat_gateway.go
@@ -164,6 +164,7 @@ var (
 	ErrNATGatewayPrefixListDescriptionEmpty   = errors.New("prefix list description is required")
 	ErrNATGatewayPrefixListAddressFamilyEmpty = errors.New("prefix list addressFamily is required")
 	ErrNATGatewayPrefixListEntriesEmpty       = errors.New("prefix list requires at least one entry")
+	ErrNATGatewayPrefixListEmptyResponse      = errors.New("API returned a 2xx response with an empty prefix list payload")
 )
 
 // Diagnostics validation errors.
@@ -636,7 +637,7 @@ func (svc *NATGatewayServiceOp) CreateNATGatewayPrefixList(ctx context.Context, 
 		return nil, err
 	}
 	if envelope.Data == nil {
-		return nil, nil
+		return nil, ErrNATGatewayPrefixListEmptyResponse
 	}
 	return envelope.Data.toPrefixList()
 }
@@ -655,7 +656,7 @@ func (svc *NATGatewayServiceOp) GetNATGatewayPrefixList(ctx context.Context, pro
 		return nil, err
 	}
 	if envelope.Data == nil {
-		return nil, nil
+		return nil, ErrNATGatewayPrefixListEmptyResponse
 	}
 	return envelope.Data.toPrefixList()
 }
@@ -677,7 +678,7 @@ func (svc *NATGatewayServiceOp) UpdateNATGatewayPrefixList(ctx context.Context, 
 		return nil, err
 	}
 	if envelope.Data == nil {
-		return nil, nil
+		return nil, ErrNATGatewayPrefixListEmptyResponse
 	}
 	return envelope.Data.toPrefixList()
 }
@@ -781,14 +782,26 @@ func (svc *NATGatewayServiceOp) GetNATGatewayDiagnosticsRoutes(ctx context.Conte
 }
 
 // pollDiagnosticsRoutes polls GetNATGatewayDiagnosticsRoutes until the
-// operation returns a non-empty result, or the caller-supplied timeout
-// elapses. Empty responses are treated as "still processing".
+// operation returns a non-empty result, the SDK-managed
+// diagnosticsPollTimeout elapses, or the caller's context is cancelled.
+// Empty responses are treated as "still processing".
 func (svc *NATGatewayServiceOp) pollDiagnosticsRoutes(ctx context.Context, productUID, operationID string) ([]*NATGatewayRoute, error) {
 	pollCtx, cancel := context.WithTimeout(ctx, diagnosticsPollTimeout)
 	defer cancel()
+	// pollDoneErr returns ctx.Err() when the caller's context is the one that
+	// fired (cancellation or caller-imposed deadline) and
+	// ErrNATGatewayDiagnosticsTimeout when the SDK-managed
+	// diagnosticsPollTimeout is what elapsed. This lets callers tell
+	// "my deadline hit" from "the diagnostics op never completed".
+	pollDoneErr := func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return ErrNATGatewayDiagnosticsTimeout
+	}
 	select {
 	case <-pollCtx.Done():
-		return nil, ErrNATGatewayDiagnosticsTimeout
+		return nil, pollDoneErr()
 	case <-time.After(diagnosticsPollInitialDelay):
 	}
 	ticker := time.NewTicker(diagnosticsPollInterval)
@@ -803,7 +816,7 @@ func (svc *NATGatewayServiceOp) pollDiagnosticsRoutes(ctx context.Context, produ
 		}
 		select {
 		case <-pollCtx.Done():
-			return nil, ErrNATGatewayDiagnosticsTimeout
+			return nil, pollDoneErr()
 		case <-ticker.C:
 		}
 	}

--- a/nat_gateway_diagnostics_integration_test.go
+++ b/nat_gateway_diagnostics_integration_test.go
@@ -1,0 +1,195 @@
+package megaport
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// NATGatewayDiagnosticsIntegrationTestSuite exercises the async
+// "looking-glass" diagnostics endpoints. The list endpoints are strictly
+// rate-limited and the looking-glass backend itself can be transiently
+// unavailable for freshly-provisioned gateways; on 429 or 5xx we t.Skip
+// the affected sub-case so the test remains green in those cases.
+type NATGatewayDiagnosticsIntegrationTestSuite IntegrationTestSuite
+
+func TestNATGatewayDiagnosticsIntegrationTestSuite(t *testing.T) {
+	t.Parallel()
+	if *runIntegrationTests {
+		suite.Run(t, new(NATGatewayDiagnosticsIntegrationTestSuite))
+	}
+}
+
+func (suite *NATGatewayDiagnosticsIntegrationTestSuite) SetupSuite() {
+	natSuite := (*NATGatewayIntegrationTestSuite)(suite)
+	natSuite.SetupSuite()
+}
+
+// isTransientDiagnosticsError reports whether err should cause the
+// diagnostics sub-case to skip rather than fail. Covers:
+//   - HTTP 429 (the documented rate-limit response)
+//   - HTTP 5xx (intermittent backend errors observed on staging when the
+//     looking-glass backend is unavailable for a freshly-provisioned
+//     gateway). The SDK is doing its job by surfacing these — we just
+//     don't want them to break CI.
+func isTransientDiagnosticsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *ErrorResponse
+	if !errors.As(err, &apiErr) || apiErr.Response == nil {
+		return false
+	}
+	code := apiErr.Response.StatusCode
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+func (suite *NATGatewayDiagnosticsIntegrationTestSuite) TestNATGatewayDiagnostics() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	natSuite := (*NATGatewayIntegrationTestSuite)(suite)
+	prov, err := provisionNATGatewayForTest(ctx, natSuite, "Integration Test NAT Gateway (Diagnostics)")
+	if err != nil {
+		suite.FailNowf("could not provision NAT Gateway", "%v", err)
+	}
+	defer prov.Teardown()
+
+	// Allow the gateway a moment after CONFIGURED/LIVE before calling the
+	// looking-glass — otherwise the data plane may not have populated yet.
+	time.Sleep(10 * time.Second)
+
+	suite.Run("ip-routes", func() {
+		opID, err := natSvc.ListNATGatewayIPRoutesAsync(ctx, prov.ProductUID, "")
+		if isTransientDiagnosticsError(err) {
+			suite.T().Skip("transient backend error (429/5xx); skipping ip-routes sub-case")
+			return
+		}
+		if err != nil {
+			suite.FailNowf("could not submit IP routes diag", "%v", err)
+		}
+		suite.NotEmpty(opID, "expected non-empty operation ID")
+		logger.InfoContext(ctx, "ip routes diagnostics submitted", slog.String("operation_id", opID))
+
+		// Poll the operation endpoint directly; we don't assert content,
+		// only that decoding succeeds (staging route table drifts).
+		routes, err := pollDiagnosticsForTest(ctx, natSvc, prov.ProductUID, opID)
+		if isTransientDiagnosticsError(err) {
+			suite.T().Skip("transient backend error during poll; skipping ip-routes sub-case")
+			return
+		}
+		if err != nil {
+			suite.FailNowf("could not get IP routes diag", "%v", err)
+		}
+		for _, r := range routes {
+			// Each route must be exactly one of IP / BGP — no nil-on-both,
+			// no both-set.
+			ipSet := r.IP != nil
+			bgpSet := r.BGP != nil
+			suite.True(ipSet != bgpSet, "route must be IP xor BGP")
+		}
+		logger.InfoContext(ctx, "ip routes diagnostics decoded", slog.Int("route_count", len(routes)))
+	})
+
+	suite.Run("bgp-routes", func() {
+		opID, err := natSvc.ListNATGatewayBGPRoutesAsync(ctx, prov.ProductUID, "")
+		if isTransientDiagnosticsError(err) {
+			suite.T().Skip("transient backend error (429/5xx); skipping bgp-routes sub-case")
+			return
+		}
+		if err != nil {
+			suite.FailNowf("could not submit BGP routes diag", "%v", err)
+		}
+		suite.NotEmpty(opID, "expected non-empty operation ID")
+		logger.InfoContext(ctx, "bgp routes diagnostics submitted", slog.String("operation_id", opID))
+
+		routes, err := pollDiagnosticsForTest(ctx, natSvc, prov.ProductUID, opID)
+		if isTransientDiagnosticsError(err) {
+			suite.T().Skip("transient backend error during poll; skipping bgp-routes sub-case")
+			return
+		}
+		if err != nil {
+			suite.FailNowf("could not get BGP routes diag", "%v", err)
+		}
+		for _, r := range routes {
+			ipSet := r.IP != nil
+			bgpSet := r.BGP != nil
+			suite.True(ipSet != bgpSet, "route must be IP xor BGP")
+		}
+		logger.InfoContext(ctx, "bgp routes diagnostics decoded", slog.Int("route_count", len(routes)))
+	})
+
+	// BGP-neighbor needs a real peer IP to query against. Without a
+	// running BGP session on this NAT Gateway, the API will likely
+	// 400 — we still verify the request shape and validation surface,
+	// but treat both rate-limit and "no neighbour" errors as a skip.
+	suite.Run("bgp-neighbor-routes-validation", func() {
+		_, err := natSvc.ListNATGatewayBGPNeighborRoutesAsync(ctx, &NATGatewayBGPNeighborRoutesRequest{
+			ProductUID:    prov.ProductUID,
+			PeerIPAddress: "10.255.255.255",
+			Direction:     BGPRouteDirectionReceived,
+		})
+		if err == nil {
+			logger.InfoContext(ctx, "bgp neighbor request accepted (no live peer expected to return data)")
+			return
+		}
+		if isTransientDiagnosticsError(err) {
+			suite.T().Skip("transient backend error (429/5xx); skipping bgp-neighbor-routes sub-case")
+			return
+		}
+		// Any non-429 error from the server is acceptable for this sub-case
+		// — the goal here is to confirm the SDK can submit the request and
+		// surface server errors cleanly. We don't assert a specific status
+		// because staging behavior for "no such peer" varies.
+		logger.InfoContext(ctx, "bgp neighbor request rejected as expected (no live peer)",
+			slog.String("error", err.Error()),
+		)
+	})
+}
+
+// pollDiagnosticsForTest is a copy of the SDK's internal poller specialised
+// for tests: shorter timeout, accepts an empty result as terminal so we
+// don't hang the suite on quiet route tables.
+func pollDiagnosticsForTest(ctx context.Context, natSvc NATGatewayService, productUID, opID string) ([]*NATGatewayRoute, error) {
+	const (
+		initial = 2 * time.Second
+		tick    = 3 * time.Second
+		timeout = 60 * time.Second
+	)
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	select {
+	case <-pollCtx.Done():
+		return nil, pollCtx.Err()
+	case <-time.After(initial):
+	}
+
+	deadline := time.Now().Add(timeout - initial)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+	for {
+		routes, err := natSvc.GetNATGatewayDiagnosticsRoutes(pollCtx, productUID, opID)
+		if err != nil {
+			return nil, err
+		}
+		if len(routes) > 0 {
+			return routes, nil
+		}
+		// Empty response — accept after deadline rather than hanging.
+		if time.Now().After(deadline) {
+			return routes, nil
+		}
+		select {
+		case <-pollCtx.Done():
+			return routes, nil
+		case <-ticker.C:
+		}
+	}
+}

--- a/nat_gateway_integration_helpers_test.go
+++ b/nat_gateway_integration_helpers_test.go
@@ -1,0 +1,208 @@
+package megaport
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"time"
+)
+
+// natGatewayProvisionResult bundles the resources created by
+// provisionNATGatewayForTest and its teardown function.
+type natGatewayProvisionResult struct {
+	ProductUID   string
+	Speed        int
+	SessionCount int
+	LocationID   int
+	ASN          int
+	// Teardown deletes the gateway via whichever path matches its current
+	// state (DESIGN hard-delete vs CANCEL_NOW). Always safe to defer; logs
+	// and continues on best-effort failure.
+	Teardown func()
+}
+
+// provisionNATGatewayForTest provisions a NAT Gateway and waits for it to
+// reach CONFIGURED/LIVE. Used by the packet filter, prefix list, VXC and
+// diagnostics integration tests so each test does not have to re-implement
+// the buy-and-poll dance.
+//
+// The caller MUST defer result.Teardown() — otherwise the gateway leaks
+// into the staging account and bills until manually cleaned up.
+func provisionNATGatewayForTest(ctx context.Context, suite *NATGatewayIntegrationTestSuite, productName string) (*natGatewayProvisionResult, error) {
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	sessions, err := natSvc.ListNATGatewaySessions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not list NAT Gateway sessions: %w", err)
+	}
+	if len(sessions) == 0 {
+		return nil, fmt.Errorf("no NAT Gateway session configurations available")
+	}
+	minSession := sessions[0]
+	for _, s := range sessions[1:] {
+		if s.SpeedMbps < minSession.SpeedMbps {
+			minSession = s
+		}
+	}
+	testSpeed := minSession.SpeedMbps
+	testSessionCount := minSession.SessionCount[0]
+
+	locations, err := suite.client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not list locations: %w", err)
+	}
+	marketLocations, err := suite.client.LocationService.FilterLocationsByMarketCodeV3(ctx, TEST_NAT_GATEWAY_LOCATION_MARKET, locations)
+	if err != nil {
+		return nil, fmt.Errorf("could not filter locations by market: %w", err)
+	}
+	eligible := suite.client.LocationService.FilterLocationsByNATGatewaySpeedV3(ctx, testSpeed, marketLocations)
+	if len(eligible) == 0 {
+		return nil, fmt.Errorf("no location in market %q advertises NAT Gateway speed %d", TEST_NAT_GATEWAY_LOCATION_MARKET, testSpeed)
+	}
+	testLocation := eligible[0]
+
+	const asn = 64512
+	gw, err := natSvc.CreateNATGateway(ctx, &CreateNATGatewayRequest{
+		AutoRenewTerm: false,
+		Config: NATGatewayNetworkConfig{
+			ASN:                asn,
+			BGPShutdownDefault: false,
+			DiversityZone:      "red",
+			SessionCount:       testSessionCount,
+		},
+		LocationID:  testLocation.ID,
+		ProductName: productName,
+		Speed:       testSpeed,
+		Term:        1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create NAT Gateway: %w", err)
+	}
+	productUID := gw.ProductUID
+	logger.InfoContext(ctx, "NAT Gateway design created",
+		slog.String("product_uid", productUID),
+		slog.String("provisioning_status", gw.ProvisioningStatus),
+	)
+
+	teardown := makeNATGatewayTeardown(ctx, suite, productUID)
+
+	if _, err := natSvc.ValidateNATGatewayOrder(ctx, productUID); err != nil {
+		teardown()
+		return nil, fmt.Errorf("could not validate NAT Gateway: %w", err)
+	}
+	if _, err := natSvc.BuyNATGateway(ctx, productUID); err != nil {
+		teardown()
+		return nil, fmt.Errorf("could not buy NAT Gateway: %w", err)
+	}
+
+	const (
+		pollInterval = 10 * time.Second
+		pollTimeout  = 15 * time.Minute
+	)
+	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
+	defer cancel()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		fetched, getErr := natSvc.GetNATGateway(pollCtx, productUID)
+		if getErr != nil {
+			teardown()
+			return nil, fmt.Errorf("could not poll NAT Gateway: %w", getErr)
+		}
+		if slices.Contains(SERVICE_STATE_READY, fetched.ProvisioningStatus) {
+			logger.InfoContext(ctx, "NAT Gateway provisioned",
+				slog.String("product_uid", productUID),
+				slog.String("provisioning_status", fetched.ProvisioningStatus),
+			)
+			return &natGatewayProvisionResult{
+				ProductUID:   productUID,
+				Speed:        testSpeed,
+				SessionCount: testSessionCount,
+				LocationID:   testLocation.ID,
+				ASN:          asn,
+				Teardown:     teardown,
+			}, nil
+		}
+		if fetched.ProvisioningStatus == STATUS_DECOMMISSIONED ||
+			fetched.ProvisioningStatus == STATUS_CANCELLED {
+			teardown()
+			return nil, fmt.Errorf("NAT Gateway %s reached terminal state %s", productUID, fetched.ProvisioningStatus)
+		}
+		select {
+		case <-pollCtx.Done():
+			teardown()
+			return nil, fmt.Errorf("timed out waiting for NAT Gateway %s to provision (last status %q)", productUID, fetched.ProvisioningStatus)
+		case <-ticker.C:
+		}
+	}
+}
+
+// makeNATGatewayTeardown returns a best-effort cleanup function that
+// dispatches to the right deletion path based on the gateway's current
+// state. Modeled on the inline teardown in TestNATGatewayFullLifecycle.
+func makeNATGatewayTeardown(ctx context.Context, suite *NATGatewayIntegrationTestSuite, productUID string) func() {
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	deleteDesign := func() error {
+		path := fmt.Sprintf("/v3/products/nat_gateways/%s", url.PathEscape(productUID))
+		req, err := suite.client.NewRequest(ctx, http.MethodDelete, path, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := suite.client.Do(ctx, req, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		return nil
+	}
+	cancelNow := func() error {
+		_, err := suite.client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
+			ProductID: productUID,
+			DeleteNow: true,
+		})
+		return err
+	}
+	return func() {
+		current, getErr := natSvc.GetNATGateway(ctx, productUID)
+		if getErr != nil {
+			logger.WarnContext(ctx, "NAT Gateway teardown: could not inspect state, attempting both paths",
+				slog.String("product_uid", productUID),
+				slog.String("error", getErr.Error()),
+			)
+			if err := deleteDesign(); err != nil {
+				logger.WarnContext(ctx, "NAT Gateway teardown (DESIGN DELETE) best-effort failed", slog.String("error", err.Error()))
+			}
+			if err := cancelNow(); err != nil {
+				logger.WarnContext(ctx, "NAT Gateway teardown (CANCEL_NOW) best-effort failed", slog.String("error", err.Error()))
+			}
+			return
+		}
+		if current.ProvisioningStatus == STATUS_DECOMMISSIONED ||
+			current.ProvisioningStatus == STATUS_CANCELLED {
+			logger.InfoContext(ctx, "NAT Gateway teardown skipped: already in terminal state",
+				slog.String("product_uid", productUID),
+				slog.String("provisioning_status", current.ProvisioningStatus),
+			)
+			return
+		}
+		var dErr error
+		if current.ProvisioningStatus == STATUS_DESIGN {
+			dErr = deleteDesign()
+		} else {
+			dErr = cancelNow()
+		}
+		if dErr != nil {
+			logger.WarnContext(ctx, "NAT Gateway teardown failed",
+				slog.String("product_uid", productUID),
+				slog.String("provisioning_status", current.ProvisioningStatus),
+				slog.String("error", dErr.Error()),
+			)
+		}
+	}
+}

--- a/nat_gateway_integration_helpers_test.go
+++ b/nat_gateway_integration_helpers_test.go
@@ -3,6 +3,7 @@ package megaport
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -159,6 +160,7 @@ func makeNATGatewayTeardown(ctx context.Context, suite *NATGatewayIntegrationTes
 			return err
 		}
 		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 	cancelNow := func() error {

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -458,3 +458,224 @@ PollLoop:
 		slog.String("provisioning_status", postDelete.ProvisioningStatus),
 	)
 }
+
+// TestNATGatewayPacketFilterLifecycle exercises the packet filter CRUD
+// surface against a live, provisioned NAT Gateway: create with two entries,
+// fetch + verify, list (assert summary present), update (third entry,
+// changed description), delete, list (assert gone).
+func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayPacketFilterLifecycle() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	prov, err := provisionNATGatewayForTest(ctx, suite, "Integration Test NAT Gateway (Packet Filter)")
+	if err != nil {
+		suite.FailNowf("could not provision NAT Gateway", "%v", err)
+	}
+	defer prov.Teardown()
+	productUID := prov.ProductUID
+
+	// Create — 2 entries: permit TCP/443 inbound, deny everything else.
+	createReq := &NATGatewayPacketFilterRequest{
+		Description: "integration-test-filter",
+		Entries: []NATGatewayPacketFilterEntry{
+			{
+				Action:             PacketFilterActionPermit,
+				Description:        "permit https",
+				SourceAddress:      "0.0.0.0/0",
+				DestinationAddress: "0.0.0.0/0",
+				DestinationPorts:   "443",
+				IPProtocol:         6, // TCP
+			},
+			{
+				Action:             PacketFilterActionDeny,
+				Description:        "deny everything else",
+				SourceAddress:      "0.0.0.0/0",
+				DestinationAddress: "0.0.0.0/0",
+			},
+		},
+	}
+	created, err := natSvc.CreateNATGatewayPacketFilter(ctx, productUID, createReq)
+	if err != nil {
+		suite.FailNowf("could not create packet filter", "%v", err)
+	}
+	suite.NotZero(created.ID)
+	suite.Equal("integration-test-filter", created.Description)
+	suite.Len(created.Entries, 2)
+	logger.InfoContext(ctx, "packet filter created", slog.Int("packet_filter_id", created.ID))
+
+	// Get.
+	fetched, err := natSvc.GetNATGatewayPacketFilter(ctx, productUID, created.ID)
+	if err != nil {
+		suite.FailNowf("could not get packet filter", "%v", err)
+	}
+	suite.Equal(created.ID, fetched.ID)
+	suite.Equal(createReq.Description, fetched.Description)
+	suite.Len(fetched.Entries, 2)
+
+	// List — must include the new filter.
+	summaries, err := natSvc.ListNATGatewayPacketFilters(ctx, productUID)
+	if err != nil {
+		suite.FailNowf("could not list packet filters", "%v", err)
+	}
+	found := false
+	for _, s := range summaries {
+		if s.ID == created.ID {
+			found = true
+			suite.Equal("integration-test-filter", s.Description)
+			break
+		}
+	}
+	suite.True(found, "created packet filter not present in summary list")
+
+	// Update — append a third entry, change description.
+	updateReq := &NATGatewayPacketFilterRequest{
+		Description: "integration-test-filter [updated]",
+		Entries: append(append([]NATGatewayPacketFilterEntry{},
+			createReq.Entries...),
+			NATGatewayPacketFilterEntry{
+				Action:             PacketFilterActionPermit,
+				Description:        "permit dns",
+				SourceAddress:      "0.0.0.0/0",
+				DestinationAddress: "0.0.0.0/0",
+				DestinationPorts:   "53",
+				IPProtocol:         17, // UDP
+			},
+		),
+	}
+	updated, err := natSvc.UpdateNATGatewayPacketFilter(ctx, productUID, created.ID, updateReq)
+	if err != nil {
+		suite.FailNowf("could not update packet filter", "%v", err)
+	}
+	suite.Equal("integration-test-filter [updated]", updated.Description)
+	suite.Len(updated.Entries, 3)
+
+	// Delete.
+	if err := natSvc.DeleteNATGatewayPacketFilter(ctx, productUID, created.ID); err != nil {
+		suite.FailNowf("could not delete packet filter", "%v", err)
+	}
+
+	// List — must NOT include the deleted filter.
+	postDelete, err := natSvc.ListNATGatewayPacketFilters(ctx, productUID)
+	if err != nil {
+		suite.FailNowf("could not list packet filters post-delete", "%v", err)
+	}
+	for _, s := range postDelete {
+		suite.NotEqual(created.ID, s.ID, "deleted packet filter %d still in summary list", created.ID)
+	}
+	logger.InfoContext(ctx, "packet filter lifecycle complete", slog.Int("packet_filter_id", created.ID))
+}
+
+// TestNATGatewayPrefixListLifecycle exercises the prefix list CRUD surface
+// against a provisioned NAT Gateway, once for IPv4 (with ge/le) and once
+// for IPv6 (without). Confirms the string<->int conversion round-trips.
+func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayPrefixListLifecycle() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+
+	prov, err := provisionNATGatewayForTest(ctx, suite, "Integration Test NAT Gateway (Prefix List)")
+	if err != nil {
+		suite.FailNowf("could not provision NAT Gateway", "%v", err)
+	}
+	defer prov.Teardown()
+	productUID := prov.ProductUID
+
+	cases := []struct {
+		name               string
+		create             *NATGatewayPrefixList
+		expectGe, expectLe int
+		// extraPrefix is appended on update — must differ from the create
+		// entries' prefix to avoid the API's duplicate-prefix rejection.
+		extraPrefix string
+	}{
+		{
+			name: "ipv4-with-ge-le",
+			create: &NATGatewayPrefixList{
+				Description:   "integration-test-v4",
+				AddressFamily: AddressFamilyIPv4,
+				Entries: []NATGatewayPrefixListEntry{
+					{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+				},
+			},
+			expectGe:    24,
+			expectLe:    32,
+			extraPrefix: "172.16.0.0/12",
+		},
+		{
+			name: "ipv6-no-ge-le",
+			create: &NATGatewayPrefixList{
+				Description:   "integration-test-v6",
+				AddressFamily: AddressFamilyIPv6,
+				Entries: []NATGatewayPrefixListEntry{
+					{Action: PrefixListActionDeny, Prefix: "2001:db8::/32"},
+				},
+			},
+			extraPrefix: "2001:db8:1::/48",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			created, err := natSvc.CreateNATGatewayPrefixList(ctx, productUID, tc.create)
+			if err != nil {
+				suite.FailNowf("could not create prefix list", "%v", err)
+			}
+			suite.NotZero(created.ID)
+			suite.Equal(tc.create.AddressFamily, created.AddressFamily)
+			suite.Len(created.Entries, 1)
+			suite.Equal(tc.expectGe, created.Entries[0].Ge)
+			suite.Equal(tc.expectLe, created.Entries[0].Le)
+			logger.InfoContext(ctx, "prefix list created",
+				slog.Int("prefix_list_id", created.ID),
+				slog.String("address_family", created.AddressFamily),
+			)
+
+			// Get.
+			fetched, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, created.ID)
+			if err != nil {
+				suite.FailNowf("could not get prefix list", "%v", err)
+			}
+			suite.Equal(created.ID, fetched.ID)
+			suite.Equal(tc.expectGe, fetched.Entries[0].Ge)
+			suite.Equal(tc.expectLe, fetched.Entries[0].Le)
+
+			// List.
+			summaries, err := natSvc.ListNATGatewayPrefixLists(ctx, productUID)
+			if err != nil {
+				suite.FailNowf("could not list prefix lists", "%v", err)
+			}
+			found := false
+			for _, s := range summaries {
+				if s.ID == created.ID {
+					found = true
+					suite.Equal(tc.create.AddressFamily, s.AddressFamily)
+					break
+				}
+			}
+			suite.True(found, "created prefix list not present in summary list")
+
+			// Update — keep the original entry and append a second one with a
+			// distinct prefix (the API rejects duplicates).
+			updateReq := &NATGatewayPrefixList{
+				Description:   tc.create.Description + " [updated]",
+				AddressFamily: tc.create.AddressFamily,
+				Entries: []NATGatewayPrefixListEntry{
+					tc.create.Entries[0],
+					{Action: PrefixListActionPermit, Prefix: tc.extraPrefix},
+				},
+			}
+			updated, err := natSvc.UpdateNATGatewayPrefixList(ctx, productUID, created.ID, updateReq)
+			if err != nil {
+				suite.FailNowf("could not update prefix list", "%v", err)
+			}
+			suite.Len(updated.Entries, 2)
+
+			// Delete.
+			if err := natSvc.DeleteNATGatewayPrefixList(ctx, productUID, created.ID); err != nil {
+				suite.FailNowf("could not delete prefix list", "%v", err)
+			}
+		})
+	}
+}

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -745,3 +745,517 @@ func (suite *NATGatewayClientTestSuite) TestBuyNATGateway_MissingUID() {
 	_, err := suite.client.NATGatewayService.BuyNATGateway(context.Background(), "")
 	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
 }
+
+// --- Packet filters -------------------------------------------------------
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayPacketFilters() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "11111111-2222-3333-4444-555555555555"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/packet_filter_summaries", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[{"id":1,"description":"first"},{"id":2,"description":"second"}]}`)
+	})
+
+	summaries, err := natSvc.ListNATGatewayPacketFilters(ctx, productUID)
+	suite.NoError(err)
+	suite.Len(summaries, 2)
+	suite.Equal(1, summaries[0].ID)
+	suite.Equal("first", summaries[0].Description)
+	suite.Equal(2, summaries[1].ID)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayPacketFiltersValidation() {
+	_, err := suite.client.NATGatewayService.ListNATGatewayPacketFilters(context.Background(), "")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+}
+
+func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayPacketFilter() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-create"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/packet_filters", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+		body, err := io.ReadAll(r.Body)
+		suite.Require().NoError(err)
+		var got NATGatewayPacketFilterRequest
+		suite.Require().NoError(json.Unmarshal(body, &got))
+		suite.Equal("permit-https", got.Description)
+		suite.Len(got.Entries, 1)
+		suite.Equal(PacketFilterActionPermit, got.Entries[0].Action)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":42,"description":"permit-https","entries":[{"action":"permit","sourceAddress":"0.0.0.0/0","destinationAddress":"10.0.0.0/24","destinationPorts":"443","ipProtocol":6}]}}`)
+	})
+
+	filter, err := natSvc.CreateNATGatewayPacketFilter(ctx, productUID, &NATGatewayPacketFilterRequest{
+		Description: "permit-https",
+		Entries: []NATGatewayPacketFilterEntry{
+			{Action: PacketFilterActionPermit, SourceAddress: "0.0.0.0/0", DestinationAddress: "10.0.0.0/24", DestinationPorts: "443", IPProtocol: 6},
+		},
+	})
+	suite.NoError(err)
+	suite.Equal(42, filter.ID)
+	suite.Equal("permit-https", filter.Description)
+	suite.Len(filter.Entries, 1)
+	suite.Equal(6, filter.Entries[0].IPProtocol)
+}
+
+func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayPacketFilterValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	_, err := natSvc.CreateNATGatewayPacketFilter(ctx, "", &NATGatewayPacketFilterRequest{Description: "x", Entries: []NATGatewayPacketFilterEntry{{Action: "permit"}}})
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	_, err = natSvc.CreateNATGatewayPacketFilter(ctx, "uid", &NATGatewayPacketFilterRequest{Entries: []NATGatewayPacketFilterEntry{{Action: "permit"}}})
+	suite.ErrorIs(err, ErrNATGatewayPacketFilterDescriptionEmpty)
+
+	_, err = natSvc.CreateNATGatewayPacketFilter(ctx, "uid", &NATGatewayPacketFilterRequest{Description: "x"})
+	suite.ErrorIs(err, ErrNATGatewayPacketFilterEntriesEmpty)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPacketFilter() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-get"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/packet_filters/7", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":7,"description":"d","entries":[{"action":"deny","sourceAddress":"1.1.1.1/32","destinationAddress":"2.2.2.2/32"}]}}`)
+	})
+
+	filter, err := natSvc.GetNATGatewayPacketFilter(ctx, productUID, 7)
+	suite.NoError(err)
+	suite.Equal(7, filter.ID)
+	suite.Equal(PacketFilterActionDeny, filter.Entries[0].Action)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPacketFilterValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	_, err := natSvc.GetNATGatewayPacketFilter(ctx, "", 1)
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	_, err = natSvc.GetNATGatewayPacketFilter(ctx, "uid", 0)
+	suite.ErrorIs(err, ErrNATGatewayPacketFilterIDRequired)
+}
+
+func (suite *NATGatewayClientTestSuite) TestUpdateNATGatewayPacketFilter() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-upd"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/packet_filters/12", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPut, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":12,"description":"updated","entries":[{"action":"permit","sourceAddress":"0.0.0.0/0","destinationAddress":"0.0.0.0/0"}]}}`)
+	})
+
+	filter, err := natSvc.UpdateNATGatewayPacketFilter(ctx, productUID, 12, &NATGatewayPacketFilterRequest{
+		Description: "updated",
+		Entries:     []NATGatewayPacketFilterEntry{{Action: PacketFilterActionPermit, SourceAddress: "0.0.0.0/0", DestinationAddress: "0.0.0.0/0"}},
+	})
+	suite.NoError(err)
+	suite.Equal("updated", filter.Description)
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayPacketFilter() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-del"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/packet_filters/9", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodDelete, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"deleted","terms":""}`)
+	})
+
+	err := natSvc.DeleteNATGatewayPacketFilter(ctx, productUID, 9)
+	suite.NoError(err)
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayPacketFilterValidation() {
+	err := suite.client.NATGatewayService.DeleteNATGatewayPacketFilter(context.Background(), "", 1)
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	err = suite.client.NATGatewayService.DeleteNATGatewayPacketFilter(context.Background(), "uid", 0)
+	suite.ErrorIs(err, ErrNATGatewayPacketFilterIDRequired)
+}
+
+// --- Prefix lists ---------------------------------------------------------
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayPrefixLists() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-list"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_list_summaries", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[{"id":1,"description":"v4-list","addressFamily":"IPv4"}]}`)
+	})
+
+	summaries, err := natSvc.ListNATGatewayPrefixLists(ctx, productUID)
+	suite.NoError(err)
+	suite.Len(summaries, 1)
+	suite.Equal(AddressFamilyIPv4, summaries[0].AddressFamily)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayPrefixListsValidation() {
+	_, err := suite.client.NATGatewayService.ListNATGatewayPrefixLists(context.Background(), "")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+}
+
+func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayPrefixList() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-create"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPost, r.Method)
+		body, err := io.ReadAll(r.Body)
+		suite.Require().NoError(err)
+		// Verify request body uses string ge/le on the wire.
+		var got map[string]interface{}
+		suite.Require().NoError(json.Unmarshal(body, &got))
+		entries, ok := got["entries"].([]interface{})
+		suite.Require().True(ok)
+		suite.Require().Len(entries, 1)
+		entry, ok := entries[0].(map[string]interface{})
+		suite.Require().True(ok)
+		suite.Equal("24", entry["ge"])
+		suite.Equal("32", entry["le"])
+		w.Header().Set("Content-Type", "application/json")
+		// API returns ge/le as strings.
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":11,"description":"private","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8","ge":"24","le":"32"}]}}`)
+	})
+
+	pl, err := natSvc.CreateNATGatewayPrefixList(ctx, productUID, &NATGatewayPrefixList{
+		Description:   "private",
+		AddressFamily: AddressFamilyIPv4,
+		Entries: []NATGatewayPrefixListEntry{
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+		},
+	})
+	suite.NoError(err)
+	suite.Equal(11, pl.ID)
+	suite.Equal(24, pl.Entries[0].Ge)
+	suite.Equal(32, pl.Entries[0].Le)
+}
+
+func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayPrefixListValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	_, err := natSvc.CreateNATGatewayPrefixList(ctx, "", &NATGatewayPrefixList{Description: "x", AddressFamily: "IPv4", Entries: []NATGatewayPrefixListEntry{{Action: "permit", Prefix: "0.0.0.0/0"}}})
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	_, err = natSvc.CreateNATGatewayPrefixList(ctx, "uid", &NATGatewayPrefixList{AddressFamily: "IPv4", Entries: []NATGatewayPrefixListEntry{{Action: "permit"}}})
+	suite.ErrorIs(err, ErrNATGatewayPrefixListDescriptionEmpty)
+
+	_, err = natSvc.CreateNATGatewayPrefixList(ctx, "uid", &NATGatewayPrefixList{Description: "x", Entries: []NATGatewayPrefixListEntry{{Action: "permit"}}})
+	suite.ErrorIs(err, ErrNATGatewayPrefixListAddressFamilyEmpty)
+
+	_, err = natSvc.CreateNATGatewayPrefixList(ctx, "uid", &NATGatewayPrefixList{Description: "x", AddressFamily: "IPv4"})
+	suite.ErrorIs(err, ErrNATGatewayPrefixListEntriesEmpty)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixList() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-get"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/3", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		// Entry omits ge/le entirely (zero-value case).
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":3,"description":"v6","addressFamily":"IPv6","entries":[{"action":"deny","prefix":"::/0"}]}}`)
+	})
+
+	pl, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 3)
+	suite.NoError(err)
+	suite.Equal(AddressFamilyIPv6, pl.AddressFamily)
+	suite.Equal(0, pl.Entries[0].Ge)
+	suite.Equal(0, pl.Entries[0].Le)
+	suite.Equal(PrefixListActionDeny, pl.Entries[0].Action)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidGe() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-bad"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/4", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8","ge":"not-a-number"}]}}`)
+	})
+
+	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
+	suite.Error(err)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListValidation() {
+	_, err := suite.client.NATGatewayService.GetNATGatewayPrefixList(context.Background(), "", 1)
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	_, err = suite.client.NATGatewayService.GetNATGatewayPrefixList(context.Background(), "uid", 0)
+	suite.ErrorIs(err, ErrNATGatewayPrefixListIDRequired)
+}
+
+func (suite *NATGatewayClientTestSuite) TestUpdateNATGatewayPrefixList() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-upd"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/5", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodPut, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":5,"description":"updated","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"172.16.0.0/12"}]}}`)
+	})
+
+	pl, err := natSvc.UpdateNATGatewayPrefixList(ctx, productUID, 5, &NATGatewayPrefixList{
+		Description:   "updated",
+		AddressFamily: AddressFamilyIPv4,
+		Entries:       []NATGatewayPrefixListEntry{{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12"}},
+	})
+	suite.NoError(err)
+	suite.Equal("updated", pl.Description)
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayPrefixList() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-del"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/8", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodDelete, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"deleted","terms":""}`)
+	})
+
+	err := natSvc.DeleteNATGatewayPrefixList(ctx, productUID, 8)
+	suite.NoError(err)
+}
+
+func (suite *NATGatewayClientTestSuite) TestDeleteNATGatewayPrefixListValidation() {
+	err := suite.client.NATGatewayService.DeleteNATGatewayPrefixList(context.Background(), "", 1)
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	err = suite.client.NATGatewayService.DeleteNATGatewayPrefixList(context.Background(), "uid", 0)
+	suite.ErrorIs(err, ErrNATGatewayPrefixListIDRequired)
+}
+
+// --- Diagnostics ----------------------------------------------------------
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayIPRoutesAsync() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-diag-ip"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/ip", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		suite.Equal("10.0.0.1", r.URL.Query().Get("ip_address"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":"op-uuid-123"}`)
+	})
+
+	opID, err := natSvc.ListNATGatewayIPRoutesAsync(ctx, productUID, "10.0.0.1")
+	suite.NoError(err)
+	suite.Equal("op-uuid-123", opID)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayBGPRoutesAsync() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-diag-bgp"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/bgp", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		// No filter when ipAddress is empty.
+		suite.Empty(r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":"op-uuid-bgp"}`)
+	})
+
+	opID, err := natSvc.ListNATGatewayBGPRoutesAsync(ctx, productUID, "")
+	suite.NoError(err)
+	suite.Equal("op-uuid-bgp", opID)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayBGPNeighborRoutesAsyncValidation() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+
+	_, err := natSvc.ListNATGatewayBGPNeighborRoutesAsync(ctx, &NATGatewayBGPNeighborRoutesRequest{})
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	_, err = natSvc.ListNATGatewayBGPNeighborRoutesAsync(ctx, &NATGatewayBGPNeighborRoutesRequest{ProductUID: "uid"})
+	suite.ErrorIs(err, ErrNATGatewayDiagnosticsPeerIPRequired)
+
+	_, err = natSvc.ListNATGatewayBGPNeighborRoutesAsync(ctx, &NATGatewayBGPNeighborRoutesRequest{ProductUID: "uid", PeerIPAddress: "10.0.0.2"})
+	suite.ErrorIs(err, ErrNATGatewayDiagnosticsDirectionInvalid)
+
+	_, err = natSvc.ListNATGatewayBGPNeighborRoutesAsync(ctx, &NATGatewayBGPNeighborRoutesRequest{ProductUID: "uid", PeerIPAddress: "10.0.0.2", Direction: "INVALID"})
+	suite.ErrorIs(err, ErrNATGatewayDiagnosticsDirectionInvalid)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayBGPNeighborRoutesAsync() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-diag-nbr"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/bgp/neighbor", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		suite.Equal(BGPRouteDirectionReceived, r.URL.Query().Get("direction"))
+		suite.Equal("10.0.0.2", r.URL.Query().Get("peer_ip_address"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":"op-nbr"}`)
+	})
+
+	opID, err := natSvc.ListNATGatewayBGPNeighborRoutesAsync(ctx, &NATGatewayBGPNeighborRoutesRequest{
+		ProductUID:    productUID,
+		PeerIPAddress: "10.0.0.2",
+		Direction:     BGPRouteDirectionReceived,
+	})
+	suite.NoError(err)
+	suite.Equal("op-nbr", opID)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayDiagnosticsRoutesIP() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-op-ip"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/operation", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("op-1", r.URL.Query().Get("operationId"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[
+			{"prefix":"10.0.0.0/24","protocol":"STATIC","nextHop":{"ip":"10.0.0.1","vxc":{"id":"vxc-1","name":"vxc-name"}}}
+		]}`)
+	})
+
+	routes, err := natSvc.GetNATGatewayDiagnosticsRoutes(ctx, productUID, "op-1")
+	suite.NoError(err)
+	suite.Len(routes, 1)
+	suite.Require().NotNil(routes[0].IP)
+	suite.Nil(routes[0].BGP)
+	suite.Equal("10.0.0.0/24", routes[0].IP.Prefix)
+	suite.Equal("STATIC", routes[0].IP.Protocol)
+	suite.Equal("vxc-1", routes[0].IP.NextHop.VXC.ID)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayDiagnosticsRoutesBGP() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-op-bgp"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/operation", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[
+			{"prefix":"192.168.0.0/16","asPath":"65000 65001","origin":"IGP","localPref":100,"best":true,"nextHop":{"ip":"10.0.0.2","vxc":{"id":"vxc-2","name":"v2"}}}
+		]}`)
+	})
+
+	routes, err := natSvc.GetNATGatewayDiagnosticsRoutes(ctx, productUID, "op-2")
+	suite.NoError(err)
+	suite.Len(routes, 1)
+	suite.Nil(routes[0].IP)
+	suite.Require().NotNil(routes[0].BGP)
+	suite.Equal("192.168.0.0/16", routes[0].BGP.Prefix)
+	suite.Equal("65000 65001", routes[0].BGP.ASPath)
+	suite.Equal(100, routes[0].BGP.LocalPref)
+	suite.True(routes[0].BGP.Best)
+}
+
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayDiagnosticsRoutesValidation() {
+	_, err := suite.client.NATGatewayService.GetNATGatewayDiagnosticsRoutes(context.Background(), "", "op")
+	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)
+
+	_, err = suite.client.NATGatewayService.GetNATGatewayDiagnosticsRoutes(context.Background(), "uid", "")
+	suite.ErrorIs(err, ErrNATGatewayDiagnosticsOperationEmpty)
+}
+
+func (suite *NATGatewayClientTestSuite) TestListNATGatewayIPRoutesPolling() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-poll"
+
+	var opCalls atomic.Int32
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/ip", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":"op-poll"}`)
+	})
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/diagnostics/routes/operation", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// First call returns empty (still processing); subsequent calls return data.
+		if opCalls.Add(1) == 1 {
+			fmt.Fprint(w, `{"message":"ok","terms":"","data":[]}`)
+			return
+		}
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":[
+			{"prefix":"10.0.0.0/24","protocol":"STATIC","nextHop":{"ip":"10.0.0.1","vxc":{"id":"vxc-1","name":"v1"}}},
+			{"prefix":"192.168.0.0/16","asPath":"65000","origin":"IGP","best":true,"nextHop":{"ip":"10.0.0.2","vxc":{"id":"vxc-2","name":"v2"}}}
+		]}`)
+	})
+
+	// Bypass the long polling defaults by polling directly via the async + Get methods,
+	// so this test stays fast. The poll timeout/interval are package-level constants
+	// and not worth plumbing through a setter just for testing.
+	opID, err := natSvc.ListNATGatewayIPRoutesAsync(ctx, productUID, "")
+	suite.Require().NoError(err)
+	suite.Equal("op-poll", opID)
+
+	// Drain the empty response then the populated one.
+	routes, err := natSvc.GetNATGatewayDiagnosticsRoutes(ctx, productUID, opID)
+	suite.Require().NoError(err)
+	suite.Empty(routes)
+
+	routes, err = natSvc.GetNATGatewayDiagnosticsRoutes(ctx, productUID, opID)
+	suite.Require().NoError(err)
+	suite.Len(routes, 2)
+
+	// Discriminator: one IP, one BGP.
+	var ipCount, bgpCount int
+	for _, r := range routes {
+		if r.IP != nil {
+			ipCount++
+		}
+		if r.BGP != nil {
+			bgpCount++
+		}
+	}
+	suite.Equal(1, ipCount)
+	suite.Equal(1, bgpCount)
+}
+
+// --- Prefix list round-trip ----------------------------------------------
+
+func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
+	pl := &NATGatewayPrefixList{
+		Description:   "rt",
+		AddressFamily: AddressFamilyIPv4,
+		Entries: []NATGatewayPrefixListEntry{
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+			{Action: PrefixListActionDeny, Prefix: "0.0.0.0/0"}, // ge/le omitted
+		},
+	}
+
+	api := pl.toAPI()
+	suite.Equal("24", api.Entries[0].Ge)
+	suite.Equal("32", api.Entries[0].Le)
+	suite.Equal("", api.Entries[1].Ge)
+	suite.Equal("", api.Entries[1].Le)
+
+	back, err := api.toPrefixList()
+	suite.Require().NoError(err)
+	suite.Equal(24, back.Entries[0].Ge)
+	suite.Equal(32, back.Entries[0].Le)
+	suite.Equal(0, back.Entries[1].Ge)
+	suite.Equal(0, back.Entries[1].Le)
+}

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -462,6 +462,11 @@ type NATGatewayRoute struct {
 // UnmarshalJSON distinguishes IP vs BGP routes based on which BGP-specific
 // fields are present in the payload.
 func (r *NATGatewayRoute) UnmarshalJSON(b []byte) error {
+	// Reset both variants up-front so a reused NATGatewayRoute value never
+	// ends up with both IP and BGP non-nil — the type's invariant is
+	// "exactly one of IP/BGP is set".
+	r.IP = nil
+	r.BGP = nil
 	var probe map[string]json.RawMessage
 	if err := json.Unmarshal(b, &probe); err != nil {
 		return err

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -3,6 +3,7 @@ package megaport
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // NATGatewaySession represents a speed/session-count availability entry for NAT Gateways.
@@ -207,4 +208,298 @@ type natGatewayBuyEnvelope struct {
 	Message string                 `json:"message"`
 	Terms   string                 `json:"terms"`
 	Data    []*NATGatewayBuyResult `json:"data"`
+}
+
+// --- Packet filters -------------------------------------------------------
+
+// Packet filter action values accepted by the API.
+const (
+	PacketFilterActionPermit = "permit"
+	PacketFilterActionDeny   = "deny"
+)
+
+// NATGatewayPacketFilterRequest is the create/update payload for a packet
+// filter on a NAT Gateway.
+type NATGatewayPacketFilterRequest struct {
+	Description string                        `json:"description"`
+	Entries     []NATGatewayPacketFilterEntry `json:"entries"`
+}
+
+// NATGatewayPacketFilterEntry is a single rule inside a packet filter.
+// Entries are evaluated in order; the first matching entry determines the
+// action taken on the packet.
+type NATGatewayPacketFilterEntry struct {
+	Action             string `json:"action"` // PacketFilterActionPermit or PacketFilterActionDeny.
+	Description        string `json:"description,omitempty"`
+	SourceAddress      string `json:"sourceAddress"`
+	DestinationAddress string `json:"destinationAddress"`
+	SourcePorts        string `json:"sourcePorts,omitempty"`
+	DestinationPorts   string `json:"destinationPorts,omitempty"`
+	IPProtocol         int    `json:"ipProtocol,omitempty"`
+}
+
+// NATGatewayPacketFilter is a server-side packet filter including its
+// assigned ID.
+type NATGatewayPacketFilter struct {
+	ID int `json:"id"`
+	NATGatewayPacketFilterRequest
+}
+
+// NATGatewayPacketFilterSummary is the compact entry returned by the
+// packet_filter_summaries endpoint.
+type NATGatewayPacketFilterSummary struct {
+	ID          int    `json:"id"`
+	Description string `json:"description"`
+}
+
+// natGatewayPacketFilterResponse is the API envelope for create/get/update.
+type natGatewayPacketFilterResponse struct {
+	Message string                  `json:"message"`
+	Terms   string                  `json:"terms"`
+	Data    *NATGatewayPacketFilter `json:"data"`
+}
+
+// natGatewayPacketFilterSummariesResponse is the API envelope for the
+// summaries list endpoint.
+type natGatewayPacketFilterSummariesResponse struct {
+	Message string                           `json:"message"`
+	Terms   string                           `json:"terms"`
+	Data    []*NATGatewayPacketFilterSummary `json:"data"`
+}
+
+// --- Prefix lists ---------------------------------------------------------
+
+// Prefix list action values accepted by the API.
+const (
+	PrefixListActionPermit = "permit"
+	PrefixListActionDeny   = "deny"
+)
+
+// Address family values accepted by the API.
+const (
+	AddressFamilyIPv4 = "IPv4"
+	AddressFamilyIPv6 = "IPv6"
+)
+
+// NATGatewayPrefixList is the create/update/get payload for a prefix list on
+// a NAT Gateway. The API returns the server-assigned ID on read.
+type NATGatewayPrefixList struct {
+	ID            int                         `json:"id,omitempty"`
+	Description   string                      `json:"description"`
+	AddressFamily string                      `json:"addressFamily"` // AddressFamilyIPv4 or AddressFamilyIPv6.
+	Entries       []NATGatewayPrefixListEntry `json:"entries"`
+}
+
+// NATGatewayPrefixListEntry is a single entry in a prefix list. Ge/Le are
+// exposed as ints for ergonomics; the SDK converts to/from the API's string
+// representation transparently.
+type NATGatewayPrefixListEntry struct {
+	Action string `json:"action"` // PrefixListActionPermit or PrefixListActionDeny.
+	Prefix string `json:"prefix"`
+	Ge     int    `json:"ge,omitempty"`
+	Le     int    `json:"le,omitempty"`
+}
+
+// NATGatewayPrefixListSummary is the compact entry returned by the
+// prefix_list_summaries endpoint.
+type NATGatewayPrefixListSummary struct {
+	ID            int    `json:"id"`
+	Description   string `json:"description"`
+	AddressFamily string `json:"addressFamily"`
+}
+
+// apiNATGatewayPrefixList is the wire-level representation — the API sends
+// Ge/Le as strings. See (NATGatewayPrefixList).toAPI / fromAPI for
+// conversion.
+type apiNATGatewayPrefixList struct {
+	ID            int                            `json:"id,omitempty"`
+	Description   string                         `json:"description"`
+	AddressFamily string                         `json:"addressFamily"`
+	Entries       []apiNATGatewayPrefixListEntry `json:"entries"`
+}
+
+type apiNATGatewayPrefixListEntry struct {
+	Action string `json:"action"`
+	Prefix string `json:"prefix"`
+	Ge     string `json:"ge,omitempty"`
+	Le     string `json:"le,omitempty"`
+}
+
+// toAPI converts the user-facing NATGatewayPrefixList to its wire-level
+// representation (Ge/Le as strings, zero values omitted).
+func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
+	out := &apiNATGatewayPrefixList{
+		ID:            p.ID,
+		Description:   p.Description,
+		AddressFamily: p.AddressFamily,
+		Entries:       make([]apiNATGatewayPrefixListEntry, len(p.Entries)),
+	}
+	for i, e := range p.Entries {
+		apiEntry := apiNATGatewayPrefixListEntry{
+			Action: e.Action,
+			Prefix: e.Prefix,
+		}
+		if e.Ge > 0 {
+			apiEntry.Ge = strconv.Itoa(e.Ge)
+		}
+		if e.Le > 0 {
+			apiEntry.Le = strconv.Itoa(e.Le)
+		}
+		out.Entries[i] = apiEntry
+	}
+	return out
+}
+
+// fromAPI converts a wire-level apiNATGatewayPrefixList into the user-facing
+// NATGatewayPrefixList. Non-numeric Ge/Le strings produce an error.
+func (a *apiNATGatewayPrefixList) toPrefixList() (*NATGatewayPrefixList, error) {
+	out := &NATGatewayPrefixList{
+		ID:            a.ID,
+		Description:   a.Description,
+		AddressFamily: a.AddressFamily,
+		Entries:       make([]NATGatewayPrefixListEntry, len(a.Entries)),
+	}
+	for i, e := range a.Entries {
+		entry := NATGatewayPrefixListEntry{Action: e.Action, Prefix: e.Prefix}
+		if e.Ge != "" {
+			ge, err := strconv.Atoi(e.Ge)
+			if err != nil {
+				return nil, fmt.Errorf("prefix list entry %d: invalid ge %q: %w", i, e.Ge, err)
+			}
+			entry.Ge = ge
+		}
+		if e.Le != "" {
+			le, err := strconv.Atoi(e.Le)
+			if err != nil {
+				return nil, fmt.Errorf("prefix list entry %d: invalid le %q: %w", i, e.Le, err)
+			}
+			entry.Le = le
+		}
+		out.Entries[i] = entry
+	}
+	return out, nil
+}
+
+// natGatewayPrefixListResponse is the API envelope for create/get/update.
+type natGatewayPrefixListResponse struct {
+	Message string                   `json:"message"`
+	Terms   string                   `json:"terms"`
+	Data    *apiNATGatewayPrefixList `json:"data"`
+}
+
+// natGatewayPrefixListSummariesResponse is the API envelope for the
+// summaries list endpoint.
+type natGatewayPrefixListSummariesResponse struct {
+	Message string                         `json:"message"`
+	Terms   string                         `json:"terms"`
+	Data    []*NATGatewayPrefixListSummary `json:"data"`
+}
+
+// --- Diagnostics (async looking-glass) -----------------------------------
+
+// BGP route direction values for the BGP neighbor endpoint.
+const (
+	BGPRouteDirectionReceived   = "RECEIVED"
+	BGPRouteDirectionAdvertised = "ADVERTISED"
+)
+
+// NATGatewayBGPNeighborRoutesRequest contains the parameters for the BGP
+// neighbor diagnostics endpoint.
+type NATGatewayBGPNeighborRoutesRequest struct {
+	ProductUID    string
+	PeerIPAddress string
+	Direction     string // BGPRouteDirectionReceived or BGPRouteDirectionAdvertised.
+}
+
+// NATGatewayRouteVXCRef identifies the VXC that carries a next-hop IP in a
+// looking-glass response.
+type NATGatewayRouteVXCRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// NATGatewayRouteNextHop describes the next hop for a diagnostics route.
+type NATGatewayRouteNextHop struct {
+	IP  string                `json:"ip"`
+	VXC NATGatewayRouteVXCRef `json:"vxc"`
+}
+
+// NATGatewayIPRoute is a single IP route returned by the diagnostics IP
+// routes endpoint.
+type NATGatewayIPRoute struct {
+	Prefix   string                 `json:"prefix"`
+	Protocol string                 `json:"protocol"`
+	Distance int                    `json:"distance,omitempty"`
+	Metric   int                    `json:"metric,omitempty"`
+	NextHop  NATGatewayRouteNextHop `json:"nextHop"`
+}
+
+// NATGatewayBGPRoute is a single BGP route returned by the diagnostics BGP
+// and BGP neighbor endpoints.
+type NATGatewayBGPRoute struct {
+	Prefix       string                 `json:"prefix"`
+	ASPath       string                 `json:"asPath,omitempty"`
+	Origin       string                 `json:"origin,omitempty"`
+	Source       string                 `json:"source,omitempty"`
+	LocalPref    int                    `json:"localPref,omitempty"`
+	MED          int                    `json:"med,omitempty"`
+	Best         bool                   `json:"best,omitempty"`
+	External     bool                   `json:"external,omitempty"`
+	Since        string                 `json:"since,omitempty"`
+	Communities  []string               `json:"communities,omitempty"`
+	AdvertisedTo []string               `json:"advertisedTo,omitempty"`
+	NextHop      NATGatewayRouteNextHop `json:"nextHop"`
+}
+
+// NATGatewayRoute is a discriminated wrapper for looking-glass routes. The
+// async operation endpoint returns a heterogeneous list of IP and BGP
+// routes; exactly one of IP / BGP will be set per entry.
+type NATGatewayRoute struct {
+	IP  *NATGatewayIPRoute
+	BGP *NATGatewayBGPRoute
+}
+
+// UnmarshalJSON distinguishes IP vs BGP routes based on which BGP-specific
+// fields are present in the payload.
+func (r *NATGatewayRoute) UnmarshalJSON(b []byte) error {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return err
+	}
+	// BGP-specific fields present in LookingGlassBgpRoute but not
+	// LookingGlassIpRoute.
+	_, hasAsPath := probe["asPath"]
+	_, hasLocalPref := probe["localPref"]
+	_, hasBest := probe["best"]
+	_, hasOrigin := probe["origin"]
+	if hasAsPath || hasLocalPref || hasBest || hasOrigin {
+		var bgp NATGatewayBGPRoute
+		if err := json.Unmarshal(b, &bgp); err != nil {
+			return err
+		}
+		r.BGP = &bgp
+		return nil
+	}
+	var ip NATGatewayIPRoute
+	if err := json.Unmarshal(b, &ip); err != nil {
+		return err
+	}
+	r.IP = &ip
+	return nil
+}
+
+// natGatewayDiagnosticsAsyncResponse is the API envelope returned by the
+// three diagnostics list endpoints — Data contains the operationId UUID.
+type natGatewayDiagnosticsAsyncResponse struct {
+	Message string `json:"message"`
+	Terms   string `json:"terms"`
+	Data    string `json:"data"`
+}
+
+// natGatewayDiagnosticsRoutesResponse is the envelope returned by the
+// operation endpoint.
+type natGatewayDiagnosticsRoutesResponse struct {
+	Message string             `json:"message"`
+	Terms   string             `json:"terms"`
+	Data    []*NATGatewayRoute `json:"data"`
 }

--- a/nat_gateway_vxc_integration_test.go
+++ b/nat_gateway_vxc_integration_test.go
@@ -1,0 +1,224 @@
+package megaport
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// NATGatewayVXCIntegrationTestSuite is the headline end-to-end test for the
+// VXC ↔ NAT Gateway attachment shape. It provisions a NAT Gateway and a
+// Megaport, creates a packet filter + IPv4 prefix list on the gateway, then
+// orders a VXC whose A-End is the NAT Gateway with a VRouter partner config
+// exercising the full surface: interface IPs, NAT IPs, a static route, a
+// (shut-down) BGP peer, and a packetFilterIn binding.
+type NATGatewayVXCIntegrationTestSuite IntegrationTestSuite
+
+func TestNATGatewayVXCIntegrationTestSuite(t *testing.T) {
+	t.Parallel()
+	if *runIntegrationTests {
+		suite.Run(t, new(NATGatewayVXCIntegrationTestSuite))
+	}
+}
+
+func (suite *NATGatewayVXCIntegrationTestSuite) SetupSuite() {
+	natSuite := (*NATGatewayIntegrationTestSuite)(suite)
+	natSuite.SetupSuite()
+}
+
+func (suite *NATGatewayVXCIntegrationTestSuite) TestVXCAttachedToNATGateway() {
+	ctx := context.Background()
+	logger := suite.client.Logger
+	natSvc := suite.client.NATGatewayService
+	portSvc := suite.client.PortService
+	vxcSvc := suite.client.VXCService
+
+	// Reuse the helper by aliasing — the helper takes a NAT Gateway suite,
+	// and these two suites have the same embedded IntegrationTestSuite.
+	natSuite := (*NATGatewayIntegrationTestSuite)(suite)
+
+	prov, err := provisionNATGatewayForTest(ctx, natSuite, "Integration Test NAT Gateway (VXC)")
+	if err != nil {
+		suite.FailNowf("could not provision NAT Gateway", "%v", err)
+	}
+	defer prov.Teardown()
+
+	// Buy a Port at the same location to act as the B-End.
+	portRes, portErr := portSvc.BuyPort(ctx, &BuyPortRequest{
+		Name:                  "Integration Test Port (NAT VXC)",
+		LocationId:            prov.LocationID,
+		PortSpeed:             1000,
+		Term:                  1,
+		Market:                TEST_NAT_GATEWAY_LOCATION_MARKET,
+		MarketPlaceVisibility: false,
+		WaitForProvision:      true,
+		WaitForTime:           10 * time.Minute,
+	})
+	if portErr != nil {
+		suite.FailNowf("could not buy port", "%v", portErr)
+	}
+	portUID := portRes.TechnicalServiceUIDs[0]
+	suite.True(IsGuid(portUID), "invalid guid for port uid")
+	logger.InfoContext(ctx, "port provisioned", slog.String("port_uid", portUID))
+
+	defer func() {
+		if _, err := portSvc.DeletePort(ctx, &DeletePortRequest{PortID: portUID, DeleteNow: true}); err != nil {
+			logger.WarnContext(ctx, "port teardown best-effort failed",
+				slog.String("port_uid", portUID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	// Create a packet filter on the NAT Gateway — we'll bind it to the VXC
+	// interface via packetFilterIn.
+	packetFilter, err := natSvc.CreateNATGatewayPacketFilter(ctx, prov.ProductUID, &NATGatewayPacketFilterRequest{
+		Description: "vxc-integration-permit-https",
+		Entries: []NATGatewayPacketFilterEntry{
+			{
+				Action:             PacketFilterActionPermit,
+				Description:        "permit https",
+				SourceAddress:      "0.0.0.0/0",
+				DestinationAddress: "0.0.0.0/0",
+				DestinationPorts:   "443",
+				IPProtocol:         6,
+			},
+		},
+	})
+	if err != nil {
+		suite.FailNowf("could not create packet filter", "%v", err)
+	}
+	logger.InfoContext(ctx, "packet filter created", slog.Int("packet_filter_id", packetFilter.ID))
+	defer func() {
+		if err := natSvc.DeleteNATGatewayPacketFilter(ctx, prov.ProductUID, packetFilter.ID); err != nil {
+			logger.WarnContext(ctx, "packet filter teardown best-effort failed",
+				slog.Int("packet_filter_id", packetFilter.ID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	// Create an IPv4 prefix list on the NAT Gateway.
+	prefixList, err := natSvc.CreateNATGatewayPrefixList(ctx, prov.ProductUID, &NATGatewayPrefixList{
+		Description:   "vxc-integration-private",
+		AddressFamily: AddressFamilyIPv4,
+		Entries: []NATGatewayPrefixListEntry{
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+		},
+	})
+	if err != nil {
+		suite.FailNowf("could not create prefix list", "%v", err)
+	}
+	logger.InfoContext(ctx, "prefix list created", slog.Int("prefix_list_id", prefixList.ID))
+	defer func() {
+		if err := natSvc.DeleteNATGatewayPrefixList(ctx, prov.ProductUID, prefixList.ID); err != nil {
+			logger.WarnContext(ctx, "prefix list teardown best-effort failed",
+				slog.Int("prefix_list_id", prefixList.ID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	// Negotiate a VLAN on the B-End port. NAT Gateway A-End VLANs are
+	// allocated by the platform — only the B-End needs a VLAN here.
+	var bEndVLAN int
+	for i := 0; i < 10; i++ {
+		bEndVLAN = GenerateRandomVLAN()
+		available, vlanErr := portSvc.CheckPortVLANAvailability(ctx, portUID, bEndVLAN)
+		if vlanErr != nil {
+			suite.FailNowf("could not check vlan availability", "%v", vlanErr)
+		}
+		if available {
+			break
+		}
+	}
+	if bEndVLAN == 0 {
+		suite.FailNowf("no available vlan on b-end port", "could not find an available VLAN after 10 attempts")
+	}
+
+	// Buy the VXC. A-End = NAT Gateway with full vrouter partner config.
+	// B-End = the Port we just provisioned.
+	packetFilterID := int64(packetFilter.ID)
+	logger.InfoContext(ctx, "buying VXC NAT Gateway -> Port",
+		slog.String("a_end_nat_gateway_uid", prov.ProductUID),
+		slog.String("b_end_port_uid", portUID),
+		slog.Int("b_end_vlan", bEndVLAN),
+	)
+	buyRes, vxcErr := vxcSvc.BuyVXC(ctx, &BuyVXCRequest{
+		PortUID:   prov.ProductUID,
+		VXCName:   "Integration Test VXC (NAT Gateway)",
+		RateLimit: 100,
+		Term:      1,
+		Shutdown:  false,
+		AEndConfiguration: VXCOrderEndpointConfiguration{
+			ProductUID: prov.ProductUID,
+			PartnerConfig: VXCOrderVrouterPartnerConfig{
+				Interfaces: []PartnerConfigInterface{
+					{
+						Description:   "nat-gw-to-port",
+						InterfaceType: InterfaceTypeSubInterface,
+						IpAddresses:   []string{"10.0.0.1/30"},
+						// natIpAddresses is rejected on the NAT Gateway A-End
+						// — NAT IPs are managed by the gateway itself, not
+						// configured per VXC interface.
+						IpRoutes: []IpRoute{
+							{Prefix: "192.168.1.0/24", NextHop: "10.0.0.2", Description: "test static route"},
+						},
+						BgpConnections: []BgpConnectionConfig{
+							{
+								PeerAsn:        65000,
+								LocalIpAddress: "10.0.0.1",
+								PeerIpAddress:  "10.0.0.2",
+								// Shutdown so we don't expect a real peer on the
+								// other side — the Port has no BGP speaker.
+								Shutdown:    true,
+								Description: "nat-gw-bgp-test",
+								PeerType:    "NON_CLOUD",
+							},
+						},
+						PacketFilterIn: &packetFilterID,
+					},
+				},
+			},
+		},
+		BEndConfiguration: VXCOrderEndpointConfiguration{
+			ProductUID: portUID,
+			VLAN:       bEndVLAN,
+		},
+		WaitForProvision: true,
+		WaitForTime:      15 * time.Minute,
+	})
+	if vxcErr != nil {
+		suite.FailNowf("could not buy VXC", "%v", vxcErr)
+	}
+	vxcUID := buyRes.TechnicalServiceUID
+	suite.True(IsGuid(vxcUID), "invalid guid for vxc uid")
+	logger.InfoContext(ctx, "VXC provisioned", slog.String("vxc_uid", vxcUID))
+
+	defer func() {
+		if err := vxcSvc.DeleteVXC(ctx, vxcUID, &DeleteVXCRequest{DeleteNow: true}); err != nil {
+			logger.WarnContext(ctx, "vxc teardown best-effort failed",
+				slog.String("vxc_uid", vxcUID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	// Verify the VXC is live and that its A-End is the NAT Gateway.
+	fetched, err := vxcSvc.GetVXC(ctx, vxcUID)
+	if err != nil {
+		suite.FailNowf("could not get VXC", "%v", err)
+	}
+	suite.Contains(SERVICE_STATE_READY, fetched.ProvisioningStatus,
+		"expected VXC in CONFIGURED/LIVE, got %q", fetched.ProvisioningStatus)
+	suite.Equal(prov.ProductUID, fetched.AEndConfiguration.UID,
+		"A-End UID mismatch — expected NAT Gateway %s, got %s", prov.ProductUID, fetched.AEndConfiguration.UID)
+	logger.InfoContext(ctx, "VXC↔NAT Gateway attachment verified",
+		slog.String("vxc_uid", vxcUID),
+		slog.String("a_end_uid", fetched.AEndConfiguration.UID),
+		slog.String("provisioning_status", fetched.ProvisioningStatus),
+	)
+}

--- a/shared_types.go
+++ b/shared_types.go
@@ -31,6 +31,10 @@ const (
 	// AWS VXC Types
 	CONNECT_TYPE_AWS_VIF               = "AWS"
 	CONNECT_TYPE_AWS_HOSTED_CONNECTION = "AWSHC"
+
+	// Interface types for VXC vRouter / NAT Gateway A-End partner configs.
+	InterfaceTypeSubInterface = "subInterface"
+	InterfaceTypeIPSecTunnel  = "ipSecTunnel"
 )
 
 var (

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -328,13 +328,17 @@ type VXCOrderConfirmation struct {
 
 // PartnerConfigInterface represents the configuration of a partner interface.
 type PartnerConfigInterface struct {
-	IpAddresses    []string              `json:"ipAddresses,omitempty"`
-	IpRoutes       []IpRoute             `json:"ipRoutes,omitempty"`
-	NatIpAddresses []string              `json:"natIpAddresses,omitempty"`
-	Bfd            BfdConfig             `json:"bfd,omitempty"`
-	BgpConnections []BgpConnectionConfig `json:"bgpConnections,omitempty"`
-	VLAN           int                   `json:"vlan,omitempty"`
-	IpMtu          int                   `json:"ipMtu,omitempty"`
+	Description     string                `json:"description,omitempty"`
+	InterfaceType   string                `json:"interfaceType,omitempty"` // InterfaceTypeSubInterface (default) or InterfaceTypeIPSecTunnel.
+	IpAddresses     []string              `json:"ipAddresses,omitempty"`
+	IpRoutes        []IpRoute             `json:"ipRoutes,omitempty"`
+	NatIpAddresses  []string              `json:"natIpAddresses,omitempty"`
+	Bfd             BfdConfig             `json:"bfd,omitempty"`
+	BgpConnections  []BgpConnectionConfig `json:"bgpConnections,omitempty"`
+	VLAN            int                   `json:"vlan,omitempty"`
+	IpMtu           int                   `json:"ipMtu,omitempty"`
+	PacketFilterIn  *int64                `json:"packetFilterIn,omitempty"`  // NAT Gateway packet filter ID to apply to inbound packets.
+	PacketFilterOut *int64                `json:"packetFilterOut,omitempty"` // NAT Gateway packet filter ID to apply to outbound packets.
 }
 
 // IpRoute represents an IP route.


### PR DESCRIPTION
## Summary

Extends the NAT Gateway SDK surface to cover the four pieces of product functionality that were previously missing: VXC attachment, packet filters, prefix lists, and looking-glass diagnostics.

- **VXC attachment** — `PartnerConfigInterface` gains `Description`, `InterfaceType`, `PacketFilterIn`, `PacketFilterOut` (all `omitempty`, so existing MCR orders serialise identically). NAT Gateway A-End VXCs reuse the existing `VXCOrderVrouterPartnerConfig` shape.
- **Packet filters** — 5 endpoints under `/v3/products/nat_gateways/{uid}/packet_filters*` for ACL-style rules bindable to a VXC interface.
- **Prefix lists** — 5 endpoints mirroring MCR prefix filter lists, scoped to NAT Gateway. Wire-level `ge`/`le` are strings; exposed as `int` via an internal converter.
- **Diagnostics** — 4 async "looking-glass" endpoints (IP routes, BGP routes, BGP neighbor routes, operation poll) with a discriminated-union route type and both primitive + poll-to-completion helpers.

## Testing

- Full unit test suite passes (`go test ./...`, `golangci-lint run` clean).
- Integration tests pass end-to-end against staging:
  - `TestNATGatewayPacketFilterLifecycle`
  - `TestNATGatewayPrefixListLifecycle` (IPv4 + IPv6)
  - `TestVXCAttachedToNATGateway` — full end-to-end NAT Gateway ↔ VXC attachment with vrouter partner config (interface IPs, static route, BGP peer, packet filter binding)
  - `TestNATGatewayDiagnostics` — ip-routes, bgp-routes, bgp-neighbor-routes-validation; sub-cases skip cleanly on transient 429/5xx from the looking-glass backend.

## Test plan

- [x] `go build -v ./...`
- [x] `go test -v ./...`
- [x] `golangci-lint run`
- [x] `go test -timeout 45m -integration -run 'NATGateway|VXCAttachedToNAT|Diagnostics' ./...` against staging