### PR TITLE
feat(mcr): add WaitForProvision support to MCRAddOnRequest

### DIFF
--- a/mcr.go
+++ b/mcr.go
@@ -79,7 +79,7 @@ type BuyMCRRequest struct {
 	AddOns        []MCRAddOn        `json:"addOns,omitempty"`
 
 	WaitForProvision bool          // Wait until the MCR provisions before returning
-	WaitForTime      time.Duration // How long to wait for the MCR to provision if WaitForProvision is true (default is 5 minutes)
+	WaitForTime      time.Duration // How long to wait for the MCR to provision if WaitForProvision is true (default is 5 minutes; must be at least 30 seconds for the poller to fire)
 }
 
 // BuyMCRResponse represents a response from buying an MCR
@@ -113,7 +113,7 @@ type ModifyMCRRequest struct {
 	ContractTermMonths    *int
 
 	WaitForUpdate bool          // Wait until the MCR updates before returning
-	WaitForTime   time.Duration // How long to wait for the MCR to update if WaitForUpdate is true (default is 5 minutes)
+	WaitForTime   time.Duration // How long to wait for the MCR to update if WaitForUpdate is true (default is 5 minutes; must be at least 30 seconds for the poller to fire)
 }
 
 // ModifyMCRResponse represents a response from modifying an MCR
@@ -150,6 +150,9 @@ type DeleteMCRPrefixFilterListResponse struct {
 
 type MCRAddOnRequest struct {
 	AddOn MCRAddOn
+
+	WaitForProvision bool          // Wait until the MCR reaches a ready state before returning
+	WaitForTime      time.Duration // How long to wait if WaitForProvision is true (default is 5 minutes; must be at least 30 seconds for the poller to fire)
 }
 
 // BuyMCR purchases an MCR from the Megaport MCR API.
@@ -195,7 +198,7 @@ func (svc *MCRServiceOp) BuyMCR(ctx context.Context, req *BuyMCRRequest) (*BuyMC
 			case <-timer.C:
 				return nil, fmt.Errorf("time expired waiting for MCR %s to provision", toReturn.TechnicalServiceUID)
 			case <-ctx.Done():
-				return nil, fmt.Errorf("context expired waiting for MCR %s to provision", toReturn.TechnicalServiceUID)
+				return nil, fmt.Errorf("context expired waiting for MCR %s to provision: %w", toReturn.TechnicalServiceUID, ctx.Err())
 			case <-ticker.C:
 				mcrDetails, err := svc.GetMCR(ctx, toReturn.TechnicalServiceUID)
 				if err != nil {
@@ -517,7 +520,7 @@ func (svc *MCRServiceOp) ModifyMCR(ctx context.Context, req *ModifyMCRRequest) (
 			case <-timer.C:
 				return nil, fmt.Errorf("time expired waiting for MCR %s to update", req.MCRID)
 			case <-ctx.Done():
-				return nil, fmt.Errorf("context expired waiting for MCR %s to update", req.MCRID)
+				return nil, fmt.Errorf("context expired waiting for MCR %s to update: %w", req.MCRID, ctx.Err())
 			case <-ticker.C:
 				mcrDetails, err := svc.GetMCR(ctx, req.MCRID)
 				if err != nil {
@@ -646,10 +649,43 @@ func (svc *MCRServiceOp) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 			return err
 		}
 		_, err = svc.Client.Do(ctx, clientReq, nil)
-		return err
+		if err != nil {
+			return err
+		}
 	default:
 		return ErrInvalidAddOnType
 	}
+
+	if req.WaitForProvision {
+		toWait := req.WaitForTime
+		if toWait == 0 {
+			toWait = 5 * time.Minute
+		}
+
+		ticker := time.NewTicker(30 * time.Second) // check on the provision status every 30 seconds
+		timer := time.NewTimer(toWait)
+		defer ticker.Stop()
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-timer.C:
+				return fmt.Errorf("time expired waiting for MCR %s to be ready after add-on update", mcrID)
+			case <-ctx.Done():
+				return fmt.Errorf("context expired waiting for MCR %s to be ready after add-on update: %w", mcrID, ctx.Err())
+			case <-ticker.C:
+				mcrDetails, err := svc.GetMCR(ctx, mcrID)
+				if err != nil {
+					return err
+				}
+				if slices.Contains(SERVICE_STATE_READY, mcrDetails.ProvisioningStatus) {
+					return nil
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // UpdateMCRIPsecAddOn updates an existing IPsec add-on on an MCR.

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -763,6 +764,62 @@ func (suite *MCRClientTestSuite) TestBuyMCRWithIPsecValidation() {
 	got, err := mcrSvc.BuyMCR(ctx, reqValid)
 	suite.NoError(err)
 	suite.Equal(productUid, got.TechnicalServiceUID)
+}
+
+// TestUpdateMCRWithAddOn tests that UpdateMCRWithAddOn posts the correct payload without waiting.
+func (suite *MCRClientTestSuite) TestUpdateMCRWithAddOn() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrID := "36b3f68e-2f54-4331-bf94-f8984449365f"
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/product/%s/addon", mcrID), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPost)
+
+		v := make(map[string]interface{})
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			suite.FailNowf("could not decode json", "could not decode json %v", err)
+		}
+		suite.Equal(AddOnTypeIPsec, v["addOnType"])
+		suite.Equal(float64(10), v["tunnelCount"])
+
+		fmt.Fprint(w, `{"message":"ok"}`)
+	})
+
+	err := mcrSvc.UpdateMCRWithAddOn(ctx, mcrID, MCRAddOnRequest{
+		AddOn: &MCRAddOnIPsecConfig{
+			AddOnType:   AddOnTypeIPsec,
+			TunnelCount: 10,
+		},
+	})
+	suite.NoError(err)
+}
+
+// TestUpdateMCRWithAddOnWaitTimeout tests that WaitForProvision returns an error on timeout.
+func (suite *MCRClientTestSuite) TestUpdateMCRWithAddOnWaitTimeout() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrID := "36b3f68e-2f54-4331-bf94-f8984449365f"
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/product/%s/addon", mcrID), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPost)
+		fmt.Fprint(w, `{"message":"ok"}`)
+	})
+	suite.mux.HandleFunc(fmt.Sprintf("/v2/product/%s", mcrID), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprintf(w, `{"data":{"productUid":%q,"provisioningStatus":"CONFIGURING"}}`, mcrID)
+	})
+
+	err := mcrSvc.UpdateMCRWithAddOn(ctx, mcrID, MCRAddOnRequest{
+		AddOn: &MCRAddOnIPsecConfig{
+			AddOnType:   AddOnTypeIPsec,
+			TunnelCount: 10,
+		},
+		WaitForProvision: true,
+		WaitForTime:      100 * time.Millisecond,
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "time expired")
 }
 
 // TestUpdateMCRIPsecAddOn tests the UpdateMCRIPsecAddOn method


### PR DESCRIPTION
Add `WaitForProvision` and `WaitForTime` fields to `MCRAddOnRequest`, matching the contract already present on `BuyMCRRequest` and `ModifyMCRRequest`. `UpdateMCRWithAddOn` now polls every 30 s until the MCR enters a ready state or the timeout expires (default 5 minutes).

This closes a consistency gap identified during review of the Terraform provider's `megaport_mcr_ipsec_addon` resource ([terraform-provider-megaport#343](https://github.com/megaport/terraform-provider-megaport/pull/343)), which had to implement its own `waitForMCRReady` poll loop because `UpdateMCRWithAddOn` had no built-in wait. With this change the provider can pass `WaitForProvision: true` and remove the duplicated loop, matching the pattern used by every other resource in the provider.

Also fixes the `ctx.Done()` error path in `BuyMCR` and `ModifyMCR` to wrap `ctx.Err()` with `%w`, enabling callers to use `errors.Is(err, context.Canceled)` / `errors.Is(err, context.DeadlineExceeded)` for programmatic handling.