### PR TITLE
ESD-883: Move MCR ready-state polling into megaportgo SDK

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -99,6 +99,26 @@ var ErrInvalidYear = errors.New("invalid year, must be between 0 and 99")
 // ErrMCRCancelLaterNotAllowed is returned when attempting to schedule MCR deletion for later (only CANCEL_NOW is allowed)
 var ErrMCRCancelLaterNotAllowed = errors.New("mcr products do not support scheduled deletion (cancel later), only immediate deletion (CANCEL_NOW) is allowed")
 
+// ErrMCRNotFound is returned when an MCR cannot be found (deleted or never existed).
+var ErrMCRNotFound = errors.New("mcr not found or deleted")
+
+// ErrMCRDecommissioned is returned when an MCR has been decommissioned.
+var ErrMCRDecommissioned = errors.New("mcr has been decommissioned")
+
+// IsServiceNotFoundError reports whether err is a Megaport API not-found response —
+// either HTTP 404 or the non-standard HTTP 400 "Could not find a service with UID" form.
+func IsServiceNotFoundError(err error) bool {
+	apiErr, ok := err.(*ErrorResponse)
+	if !ok || apiErr.Response == nil {
+		return false
+	}
+	if apiErr.Response.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return apiErr.Response.StatusCode == http.StatusBadRequest &&
+		strings.Contains(apiErr.Message, "Could not find a service with UID")
+}
+
 // ErrTransitVXCCancelLaterNotAllowed is returned when attempting to schedule Transit VXC deletion for later (only CANCEL_NOW is allowed)
 var ErrTransitVXCCancelLaterNotAllowed = errors.New("transit vxc (megaport internet) does not support scheduled deletion (cancel later), only immediate deletion (CANCEL_NOW) is allowed")
 

--- a/mcr.go
+++ b/mcr.go
@@ -46,6 +46,10 @@ type MCRService interface {
 	UpdateMCRWithAddOn(ctx context.Context, mcrID string, req MCRAddOnRequest) error
 	// UpdateMCRIPsecAddOn updates an existing IPsec add-on on an MCR. Setting tunnelCount to 0 will disable IPsec.
 	UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error
+	// WaitForMCRReady polls until the MCR reaches a ready provisioning state.
+	// A zero timeout defaults to 5 minutes. Returns ErrMCRNotFound or ErrMCRDecommissioned
+	// if the MCR is deleted or decommissioned while polling.
+	WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error
 
 	// GetMCRPrefixFilterLists returns prefix filter lists for the specified MCR2.
 	//
@@ -657,32 +661,7 @@ func (svc *MCRServiceOp) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 	}
 
 	if req.WaitForProvision {
-		toWait := req.WaitForTime
-		if toWait == 0 {
-			toWait = 5 * time.Minute
-		}
-
-		ticker := time.NewTicker(30 * time.Second) // check on the provision status every 30 seconds
-		timer := time.NewTimer(toWait)
-		defer ticker.Stop()
-		defer timer.Stop()
-
-		for {
-			select {
-			case <-timer.C:
-				return fmt.Errorf("time expired waiting for MCR %s to be ready after add-on update", mcrID)
-			case <-ctx.Done():
-				return fmt.Errorf("context expired waiting for MCR %s to be ready after add-on update: %w", mcrID, ctx.Err())
-			case <-ticker.C:
-				mcrDetails, err := svc.GetMCR(ctx, mcrID)
-				if err != nil {
-					return err
-				}
-				if slices.Contains(SERVICE_STATE_READY, mcrDetails.ProvisioningStatus) {
-					return nil
-				}
-			}
-		}
+		return svc.WaitForMCRReady(ctx, mcrID, req.WaitForTime)
 	}
 
 	return nil
@@ -710,4 +689,51 @@ func (svc *MCRServiceOp) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 	}
 	_, err = svc.Client.Do(ctx, clientReq, nil)
 	return err
+}
+
+// WaitForMCRReady polls until the MCR identified by mcrID reaches a ready
+// provisioning state. A zero timeout defaults to 5 minutes.
+// Returns ErrMCRNotFound if the MCR is deleted while polling, or
+// ErrMCRDecommissioned if it has been decommissioned.
+func (svc *MCRServiceOp) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
+	if timeout == 0 {
+		timeout = 5 * time.Minute
+	}
+
+	check := func() (bool, error) {
+		mcr, err := svc.GetMCR(ctx, mcrID)
+		if err != nil {
+			if IsServiceNotFoundError(err) {
+				return false, ErrMCRNotFound
+			}
+			return false, err
+		}
+		if mcr.ProvisioningStatus == STATUS_DECOMMISSIONED {
+			return false, ErrMCRDecommissioned
+		}
+		return slices.Contains(SERVICE_STATE_READY, mcr.ProvisioningStatus), nil
+	}
+
+	// Immediate pre-check before starting the ticker.
+	if ready, err := check(); err != nil || ready {
+		return err
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return fmt.Errorf("time expired waiting for MCR %s to reach a ready state", mcrID)
+		case <-ticker.C:
+			if ready, err := check(); err != nil || ready {
+				return err
+			}
+		}
+	}
 }


### PR DESCRIPTION
`WaitForMCRReady`, `ErrMCRNotFound`, `ErrMCRDecommissioned`, and `IsServiceNotFoundError` have been extracted from `terraform-provider-megaport` into the SDK. The polling logic in `mcr_ipsec_addon_resource.go` operated entirely on SDK types and is useful to any consumer — the CLI will need the same behaviour when it gains IPsec add-on support.

`UpdateMCRWithAddOn`'s inline poll loop is replaced by a call to `WaitForMCRReady`, which also adds the not-found and decommissioned guards that were missing from the original loop.

## Notable changes

- `errors.go`: `ErrMCRNotFound`, `ErrMCRDecommissioned` sentinels; `IsServiceNotFoundError` encapsulates the Megaport API's non-standard 404 / bad-400 ambiguity
- `mcr.go`: `WaitForMCRReady(ctx, mcrID, timeout)` on `MCRService` — immediate pre-check then 30s ticker; `UpdateMCRWithAddOn` poll loop removed in favour of this method