### PR TITLE
ESD-898: Add VXC telemetry

### DIFF
--- a/vxc.go
+++ b/vxc.go
@@ -1,12 +1,15 @@
 package megaport
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -33,6 +36,8 @@ type VXCService interface {
 	ListVXCResourceTags(ctx context.Context, vxcID string) (map[string]string, error)
 	// UpdateVXCResourceTags updates the resource tags for a VXC in the Megaport Products API.
 	UpdateVXCResourceTags(ctx context.Context, vxcID string, tags map[string]string) error
+	// GetVXCTelemetry returns telemetry metrics for a VXC.
+	GetVXCTelemetry(ctx context.Context, req *GetVXCTelemetryRequest) (*ServiceTelemetryResponse, error)
 }
 
 // NewVXCService creates a new instance of the VXC Service.
@@ -628,4 +633,63 @@ func shouldIncludeVXC(vxc *VXC, req *ListVXCsRequest) bool {
 	}
 
 	return true
+}
+
+// validateGetVXCTelemetryRequest validates the request parameters.
+func validateGetVXCTelemetryRequest(req *GetVXCTelemetryRequest) error {
+	if req.ProductUID == "" {
+		return ErrVXCTelemetryProductUIDRequired
+	}
+	if len(req.Types) == 0 {
+		return ErrVXCTelemetryTypesRequired
+	}
+	if req.Days != nil && (req.From != nil || req.To != nil) {
+		return ErrVXCTelemetryTimeExclusive
+	}
+	if req.Days != nil && (*req.Days < 1 || *req.Days > 180) {
+		return ErrVXCTelemetryDaysOutOfRange
+	}
+	if (req.From != nil) != (req.To != nil) {
+		return ErrVXCTelemetryFromToIncomplete
+	}
+	return nil
+}
+
+// GetVXCTelemetry returns telemetry data for a VXC product.
+func (svc *VXCServiceOp) GetVXCTelemetry(ctx context.Context, req *GetVXCTelemetryRequest) (*ServiceTelemetryResponse, error) {
+	if err := validateGetVXCTelemetryRequest(req); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/v2/product/vxc/%s/telemetry", url.PathEscape(req.ProductUID))
+
+	params := url.Values{}
+	for _, t := range req.Types {
+		params.Add("type", t)
+	}
+	if req.From != nil {
+		params.Set("from", strconv.FormatInt(req.From.UnixMilli(), 10))
+	}
+	if req.To != nil {
+		params.Set("to", strconv.FormatInt(req.To.UnixMilli(), 10))
+	}
+	if req.Days != nil {
+		params.Set("days", strconv.FormatInt(int64(*req.Days), 10))
+	}
+
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, path+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	resp, err := svc.Client.Do(ctx, clientReq, &buf)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	telemetryResp := &ServiceTelemetryResponse{}
+	if err := json.Unmarshal(buf.Bytes(), telemetryResp); err != nil {
+		return nil, err
+	}
+	return telemetryResp, nil
 }

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -1874,4 +1875,106 @@ func (suite *VXCClientTestSuite) TestListVXCsWithDifferentProductTypes() {
 	for uid, found := range expectedUIDs {
 		suite.True(found, "VXC with UID %s was not found", uid)
 	}
+}
+
+func (suite *VXCClientTestSuite) TestGetVXCTelemetry() {
+	ctx := context.Background()
+	vxcSvc := suite.client.VXCService
+	productUID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	jblob := `{
+		"serviceUid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		"type": "A_BITS",
+		"timeFrame": {"from": 1608516536000, "to": 1608603936000},
+		"data": [
+			{
+				"type": "A_BITS",
+				"subtype": "IN",
+				"samples": [[1608516536000, 125.5], [1608517536000, 130.2]],
+				"unit": {"name": "Mbps", "fullName": "Megabits per second"}
+			}
+		]
+	}`
+
+	path := fmt.Sprintf("/v2/product/vxc/%s/telemetry", productUID)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		suite.Equal("7", r.URL.Query().Get("days"))
+		suite.Equal([]string{"A_BITS"}, r.URL.Query()["type"])
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, jblob)
+	})
+
+	resp, err := vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		ProductUID: productUID,
+		Types:      []string{"A_BITS"},
+		Days:       PtrTo[int32](7),
+	})
+	suite.NoError(err)
+	suite.Equal(productUID, resp.ServiceUID)
+	suite.Equal("A_BITS", resp.Type)
+	suite.Equal(int64(1608516536000), resp.TimeFrame.From)
+	suite.Equal(int64(1608603936000), resp.TimeFrame.To)
+	suite.Len(resp.Data, 1)
+	suite.Equal("A_BITS", resp.Data[0].Type)
+	suite.Equal("IN", resp.Data[0].Subtype)
+	suite.Len(resp.Data[0].Samples, 2)
+	suite.Equal(int64(1608516536000), resp.Data[0].Samples[0].Timestamp)
+	suite.Equal(125.5, resp.Data[0].Samples[0].Value)
+	suite.Equal(int64(1608517536000), resp.Data[0].Samples[1].Timestamp)
+	suite.Equal(130.2, resp.Data[0].Samples[1].Value)
+	suite.Equal("Mbps", resp.Data[0].Unit.Name)
+	suite.Equal("Megabits per second", resp.Data[0].Unit.FullName)
+}
+
+func (suite *VXCClientTestSuite) TestGetVXCTelemetryValidation() {
+	ctx := context.Background()
+	vxcSvc := suite.client.VXCService
+
+	// Missing ProductUID
+	_, err := vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		Types: []string{"A_BITS"},
+		Days:  PtrTo[int32](7),
+	})
+	suite.ErrorIs(err, ErrVXCTelemetryProductUIDRequired)
+
+	// Missing Types
+	_, err = vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		ProductUID: "some-uid",
+		Days:       PtrTo[int32](7),
+	})
+	suite.ErrorIs(err, ErrVXCTelemetryTypesRequired)
+
+	// Days and From/To mutually exclusive
+	_, err = vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		ProductUID: "some-uid",
+		Types:      []string{"A_BITS"},
+		Days:       PtrTo[int32](7),
+		From:       PtrTo(time.UnixMilli(1608516536000)),
+	})
+	suite.ErrorIs(err, ErrVXCTelemetryTimeExclusive)
+
+	// Days out of range (too low)
+	_, err = vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		ProductUID: "some-uid",
+		Types:      []string{"A_BITS"},
+		Days:       PtrTo[int32](0),
+	})
+	suite.ErrorIs(err, ErrVXCTelemetryDaysOutOfRange)
+
+	// Days out of range (too high)
+	_, err = vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		ProductUID: "some-uid",
+		Types:      []string{"A_BITS"},
+		Days:       PtrTo[int32](181),
+	})
+	suite.ErrorIs(err, ErrVXCTelemetryDaysOutOfRange)
+
+	// Only From without To
+	_, err = vxcSvc.GetVXCTelemetry(ctx, &GetVXCTelemetryRequest{
+		ProductUID: "some-uid",
+		Types:      []string{"A_BITS"},
+		From:       PtrTo(time.UnixMilli(1608516536000)),
+	})
+	suite.ErrorIs(err, ErrVXCTelemetryFromToIncomplete)
 }

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -3,7 +3,9 @@ package megaport
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"time"
 )
 
 // Partner Providers
@@ -808,3 +810,27 @@ func (c *CSPConnection) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+// GetVXCTelemetryRequest represents a request to get telemetry data for a VXC.
+type GetVXCTelemetryRequest struct {
+	ProductUID string     // required
+	Types      []string   // required; valid values: A_BITS, B_BITS, A_PACKETS, B_PACKETS
+	From       *time.Time // mutually exclusive with Days
+	To         *time.Time // mutually exclusive with Days
+	Days       *int32     // 1-180; mutually exclusive with From/To
+}
+
+// ErrVXCTelemetryProductUIDRequired is returned when a ProductUID is not provided.
+var ErrVXCTelemetryProductUIDRequired = errors.New("product UID is required")
+
+// ErrVXCTelemetryTypesRequired is returned when no telemetry types are provided.
+var ErrVXCTelemetryTypesRequired = errors.New("at least one telemetry type is required")
+
+// ErrVXCTelemetryTimeExclusive is returned when both Days and From/To are provided.
+var ErrVXCTelemetryTimeExclusive = errors.New("days and from/to are mutually exclusive")
+
+// ErrVXCTelemetryDaysOutOfRange is returned when Days is not between 1 and 180.
+var ErrVXCTelemetryDaysOutOfRange = errors.New("days must be between 1 and 180")
+
+// ErrVXCTelemetryFromToIncomplete is returned when only one of From/To is provided.
+var ErrVXCTelemetryFromToIncomplete = errors.New("both from and to must be provided together")


### PR DESCRIPTION
Adds `GetVXCTelemetry` to `VXCService`, backed by `GET /v2/product/vxc/{productUid}/telemetry`. Supports A_BITS, B_BITS, A_PACKETS, and B_PACKETS metric types with optional time-range filtering (days or from/to).

Part of ESD-889.