### PR TITLE
ESD-1029(feat): add status constants, server-side filter, and IsOrderable helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 *.so
 *.test
 *.out
+
+.worktrees/

--- a/location.go
+++ b/location.go
@@ -234,8 +234,8 @@ type RoundTripTimeResponse struct {
 
 // ListLocationsV3Options configures ListLocationsV3WithOptions.
 //
-// Statuses, when non-empty, takes precedence and is sent verbatim as
-// repeated locationStatuses query parameters. Otherwise the boolean
+// Statuses, when non-empty, takes precedence and is used as the values
+// for repeated locationStatuses query parameters. Otherwise the boolean
 // shortcuts are composed against the default allow-list of [Active]:
 //   - IncludeRestricted adds "Restricted"
 //   - IncludeDeployment adds "Deployment"

--- a/location.go
+++ b/location.go
@@ -11,11 +11,37 @@ import (
 	"github.com/lithammer/fuzzysearch/fuzzy"
 )
 
+// LocationV3 status values returned by GET /v3/locations.
+// Source: Megaport OpenAPI spec, schema "LocationStatus".
+const (
+	LocationStatusActive     = "Active"
+	LocationStatusDeployment = "Deployment"
+	LocationStatusRestricted = "Restricted"
+	LocationStatusExtended   = "Extended"
+	LocationStatusNew        = "New"
+	LocationStatusExpired    = "Expired"
+)
+
+// LocationProductKind identifies a product whose orderability can be checked
+// against a LocationV3 via IsOrderable.
+type LocationProductKind string
+
+const (
+	LocationProductPort         LocationProductKind = "PORT"
+	LocationProductMCR          LocationProductKind = "MCR"
+	LocationProductMVE          LocationProductKind = "MVE"
+	LocationProductCrossConnect LocationProductKind = "CROSS_CONNECT"
+	LocationProductNATGateway   LocationProductKind = "NAT_GATEWAY"
+)
+
 // LocationService is an interface for interfacing with the Location endpoints of the Megaport API.
 type LocationService interface {
 	// V3 API methods (RECOMMENDED for new code)
 	// ListLocationsV3 returns a list of all locations in the Megaport Locations API v3.
 	ListLocationsV3(ctx context.Context) ([]*LocationV3, error)
+	// ListLocationsV3WithOptions returns locations filtered server-side by
+	// the provided options. A nil opts is equivalent to ListLocationsV3.
+	ListLocationsV3WithOptions(ctx context.Context, opts *ListLocationsV3Options) ([]*LocationV3, error)
 	// GetLocationByIDV3 returns a location by its ID in the Megaport Locations API v3.
 	GetLocationByIDV3(ctx context.Context, locationID int) (*LocationV3, error)
 	// GetLocationByNameV3 returns a location by its name in the Megaport Locations API v3.
@@ -206,11 +232,60 @@ type RoundTripTimeResponse struct {
 // V3 API IMPLEMENTATION METHODS
 // ==========================================
 
+// ListLocationsV3Options configures ListLocationsV3WithOptions.
+//
+// Statuses, when non-empty, takes precedence and is sent verbatim as
+// repeated locationStatuses query parameters. Otherwise the boolean
+// shortcuts are composed against the default allow-list of [Active]:
+//   - IncludeRestricted adds "Restricted"
+//   - IncludeDeployment adds "Deployment"
+//
+// A nil *ListLocationsV3Options is equivalent to calling ListLocationsV3
+// (no filter sent; all statuses returned).
+type ListLocationsV3Options struct {
+	IncludeRestricted bool
+	IncludeDeployment bool
+	Statuses          []string
+}
+
+func (o *ListLocationsV3Options) resolvedStatuses() []string {
+	if len(o.Statuses) > 0 {
+		return o.Statuses
+	}
+	statuses := []string{LocationStatusActive}
+	if o.IncludeRestricted {
+		statuses = append(statuses, LocationStatusRestricted)
+	}
+	if o.IncludeDeployment {
+		statuses = append(statuses, LocationStatusDeployment)
+	}
+	return statuses
+}
+
 // ListLocationsV3 returns a list of all locations using the v3 API.
 func (svc *LocationServiceOp) ListLocationsV3(ctx context.Context) ([]*LocationV3, error) {
+	return svc.ListLocationsV3WithOptions(ctx, nil)
+}
+
+// ListLocationsV3WithOptions returns locations filtered server-side by the
+// provided options. When opts is nil, no filter is applied and the call is
+// equivalent to ListLocationsV3.
+func (svc *LocationServiceOp) ListLocationsV3WithOptions(ctx context.Context, opts *ListLocationsV3Options) ([]*LocationV3, error) {
 	path := "/v3/locations"
-	url := svc.Client.BaseURL.JoinPath(path).String()
-	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, url, nil)
+	u := svc.Client.BaseURL.JoinPath(path)
+
+	if opts != nil {
+		statuses := opts.resolvedStatuses()
+		if len(statuses) > 0 {
+			params := url.Values{}
+			for _, s := range statuses {
+				params.Add("locationStatuses", s)
+			}
+			u.RawQuery = params.Encode()
+		}
+	}
+
+	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -220,18 +295,14 @@ func (svc *LocationServiceOp) ListLocationsV3(ctx context.Context) ([]*LocationV
 	}
 	defer response.Body.Close()
 	body, fileErr := io.ReadAll(response.Body)
-
 	if fileErr != nil {
 		return nil, fileErr
 	}
 
 	locationResponse := &LocationV3Response{}
-
-	unmarshalErr := json.Unmarshal(body, locationResponse)
-	if unmarshalErr != nil {
-		return nil, unmarshalErr
+	if err := json.Unmarshal(body, locationResponse); err != nil {
+		return nil, err
 	}
-
 	return locationResponse.Data, nil
 }
 
@@ -505,6 +576,36 @@ func (l *LocationV3) GetCrossConnectType() string {
 		return *l.ProductAddOns.CrossConnect.Type
 	}
 	return ""
+}
+
+// IsStatusOrderable reports whether the location's Status permits ordering.
+// Only Active is considered orderable.
+func (l *LocationV3) IsStatusOrderable() bool {
+	return l.Status == LocationStatusActive
+}
+
+// IsOrderable reports whether the location is currently orderable for the
+// given product. A location is orderable only when its Status is Active AND
+// the product-specific availability is set. Unknown LocationProductKind
+// values return false.
+func (l *LocationV3) IsOrderable(product LocationProductKind) bool {
+	if !l.IsStatusOrderable() {
+		return false
+	}
+	switch product {
+	case LocationProductPort:
+		return len(l.GetMegaportSpeeds()) > 0
+	case LocationProductMCR:
+		return l.HasMCRSupport()
+	case LocationProductMVE:
+		return l.HasMVESupport()
+	case LocationProductCrossConnect:
+		return l.HasCrossConnectSupport()
+	case LocationProductNATGateway:
+		return l.HasNATGatewaySupport()
+	default:
+		return false
+	}
 }
 
 // GetDataCenterName returns the data center name.

--- a/location.go
+++ b/location.go
@@ -240,32 +240,13 @@ type RoundTripTimeResponse struct {
 
 // ListLocationsV3Options configures ListLocationsV3WithOptions.
 //
-// Statuses, when non-empty, takes precedence and is used as the values
-// for repeated locationStatuses query parameters. Otherwise the boolean
-// shortcuts are composed against the default allow-list of [Active]:
-//   - IncludeRestricted adds "Restricted"
-//   - IncludeDeployment adds "Deployment"
-//
-// A nil *ListLocationsV3Options is equivalent to calling ListLocationsV3
-// (no filter sent; all statuses returned).
+// Statuses filters the returned locations to the given status values, sent as
+// repeated locationStatuses query parameters. An empty Statuses — or a nil
+// *ListLocationsV3Options — sends no filter and returns all statuses, matching
+// ListLocationsV3. To request only orderable sites, pass
+// Statuses: []string{LocationStatusActive}.
 type ListLocationsV3Options struct {
-	IncludeRestricted bool
-	IncludeDeployment bool
-	Statuses          []string
-}
-
-func (o *ListLocationsV3Options) resolvedStatuses() []string {
-	if len(o.Statuses) > 0 {
-		return o.Statuses
-	}
-	statuses := []string{LocationStatusActive}
-	if o.IncludeRestricted {
-		statuses = append(statuses, LocationStatusRestricted)
-	}
-	if o.IncludeDeployment {
-		statuses = append(statuses, LocationStatusDeployment)
-	}
-	return statuses
+	Statuses []string
 }
 
 // ListLocationsV3 returns a list of all locations using the v3 API.
@@ -280,15 +261,12 @@ func (svc *LocationServiceOp) ListLocationsV3WithOptions(ctx context.Context, op
 	path := "/v3/locations"
 	u := svc.Client.BaseURL.JoinPath(path)
 
-	if opts != nil {
-		statuses := opts.resolvedStatuses()
-		if len(statuses) > 0 {
-			params := url.Values{}
-			for _, s := range statuses {
-				params.Add("locationStatuses", s)
-			}
-			u.RawQuery = params.Encode()
+	if opts != nil && len(opts.Statuses) > 0 {
+		params := url.Values{}
+		for _, s := range opts.Statuses {
+			params.Add("locationStatuses", s)
 		}
+		u.RawQuery = params.Encode()
 	}
 
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, u.String(), nil)

--- a/location_test.go
+++ b/location_test.go
@@ -1413,7 +1413,7 @@ func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_IncludeFl
 		IncludeDeployment: true,
 	})
 	suite.NoError(err)
-	suite.Equal([]string{LocationStatusActive, LocationStatusRestricted, LocationStatusDeployment}, gotStatuses)
+	suite.ElementsMatch([]string{LocationStatusActive, LocationStatusRestricted, LocationStatusDeployment}, gotStatuses)
 }
 
 func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_StatusesOverride() {
@@ -1430,7 +1430,7 @@ func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_StatusesO
 		Statuses:          []string{LocationStatusExtended, LocationStatusNew},
 	})
 	suite.NoError(err)
-	suite.Equal([]string{LocationStatusExtended, LocationStatusNew}, gotStatuses)
+	suite.ElementsMatch([]string{LocationStatusExtended, LocationStatusNew}, gotStatuses)
 }
 
 // TestListLocationsV3_NoQueryParams asserts that the original ListLocationsV3

--- a/location_test.go
+++ b/location_test.go
@@ -1366,3 +1366,174 @@ func (suite *LocationClientTestSuite) TestGetRoundTripTimesEmptySet() {
 	suite.NoError(err)
 	suite.Equal(want, got)
 }
+
+// emptyV3Body is a minimal but valid /v3/locations response used by the
+// query-param assertion tests below.
+const emptyV3Body = `{"message":"ok","terms":"","data":[]}`
+
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_NilOptions() {
+	ctx := context.Background()
+	locSvc := suite.client.LocationService
+	var gotRawQuery string
+	suite.mux.HandleFunc("/v3/locations", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		gotRawQuery = r.URL.RawQuery
+		fmt.Fprint(w, emptyV3Body)
+	})
+	_, err := locSvc.ListLocationsV3WithOptions(ctx, nil)
+	suite.NoError(err)
+	suite.Equal("", gotRawQuery)
+}
+
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_DefaultActiveOnly() {
+	ctx := context.Background()
+	locSvc := suite.client.LocationService
+	var gotStatuses []string
+	suite.mux.HandleFunc("/v3/locations", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		gotStatuses = r.URL.Query()["locationStatuses"]
+		fmt.Fprint(w, emptyV3Body)
+	})
+	_, err := locSvc.ListLocationsV3WithOptions(ctx, &ListLocationsV3Options{})
+	suite.NoError(err)
+	suite.Equal([]string{LocationStatusActive}, gotStatuses)
+}
+
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_IncludeFlags() {
+	ctx := context.Background()
+	locSvc := suite.client.LocationService
+	var gotStatuses []string
+	suite.mux.HandleFunc("/v3/locations", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		gotStatuses = r.URL.Query()["locationStatuses"]
+		fmt.Fprint(w, emptyV3Body)
+	})
+	_, err := locSvc.ListLocationsV3WithOptions(ctx, &ListLocationsV3Options{
+		IncludeRestricted: true,
+		IncludeDeployment: true,
+	})
+	suite.NoError(err)
+	suite.Equal([]string{LocationStatusActive, LocationStatusRestricted, LocationStatusDeployment}, gotStatuses)
+}
+
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_StatusesOverride() {
+	ctx := context.Background()
+	locSvc := suite.client.LocationService
+	var gotStatuses []string
+	suite.mux.HandleFunc("/v3/locations", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		gotStatuses = r.URL.Query()["locationStatuses"]
+		fmt.Fprint(w, emptyV3Body)
+	})
+	_, err := locSvc.ListLocationsV3WithOptions(ctx, &ListLocationsV3Options{
+		IncludeRestricted: true, // ignored — Statuses takes precedence
+		Statuses:          []string{LocationStatusExtended, LocationStatusNew},
+	})
+	suite.NoError(err)
+	suite.Equal([]string{LocationStatusExtended, LocationStatusNew}, gotStatuses)
+}
+
+// TestListLocationsV3_NoQueryParams asserts that the original ListLocationsV3
+// (no opts) issues an unfiltered request — protecting backwards compatibility
+// for callers that have not migrated to the options form.
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3_NoQueryParams() {
+	ctx := context.Background()
+	locSvc := suite.client.LocationService
+	var gotRawQuery string
+	suite.mux.HandleFunc("/v3/locations", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		gotRawQuery = r.URL.RawQuery
+		fmt.Fprint(w, emptyV3Body)
+	})
+	_, err := locSvc.ListLocationsV3(ctx)
+	suite.NoError(err)
+	suite.Equal("", gotRawQuery)
+}
+
+// TestLocationV3IsStatusOrderable validates that only "Active" passes the
+// status gate, across all six documented statuses.
+func (suite *LocationV3ClientTestSuite) TestLocationV3IsStatusOrderable() {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{LocationStatusActive, true},
+		{LocationStatusDeployment, false},
+		{LocationStatusRestricted, false},
+		{LocationStatusExtended, false},
+		{LocationStatusNew, false},
+		{LocationStatusExpired, false},
+	}
+	for _, tc := range cases {
+		suite.Run(tc.status, func() {
+			loc := &LocationV3{Status: tc.status}
+			suite.Equal(tc.want, loc.IsStatusOrderable())
+		})
+	}
+}
+
+// TestLocationV3IsOrderable covers the orderability matrix, including the
+// exact regression from ESD-1029: a Restricted site with crossConnect.available
+// must report not-orderable for cross connects.
+func (suite *LocationV3ClientTestSuite) TestLocationV3IsOrderable() {
+	mveCores := 8
+	fullActive := func() *LocationV3 {
+		return &LocationV3{
+			Status: LocationStatusActive,
+			DiversityZones: &LocationV3DiversityZones{
+				Red: &LocationV3DiversityZone{
+					McrSpeedMbps:        []int{1000, 10000},
+					MegaportSpeedMbps:   []int{1000, 10000, 100000},
+					MveAvailable:        true,
+					MveMaxCpuCoreCount:  &mveCores,
+					NATGatewaySpeedMbps: []int{500},
+				},
+			},
+			ProductAddOns: &LocationV3ProductAddOns{
+				CrossConnect: &LocationV3CrossConnect{Available: true},
+			},
+		}
+	}
+
+	// Site-1299-shaped fixture: Restricted + crossConnect unavailable.
+	site1299 := &LocationV3{
+		ID:     1299,
+		Name:   "EdgeConneX Atlanta ATL02",
+		Status: LocationStatusRestricted,
+		ProductAddOns: &LocationV3ProductAddOns{
+			CrossConnect: &LocationV3CrossConnect{Available: false},
+		},
+	}
+
+	// Active + crossConnect.available=false (Active site that can't cross-connect).
+	activeNoXC := fullActive()
+	activeNoXC.ProductAddOns.CrossConnect.Available = false
+
+	cases := []struct {
+		name    string
+		loc     *LocationV3
+		product LocationProductKind
+		want    bool
+	}{
+		{"active full / port", fullActive(), LocationProductPort, true},
+		{"active full / mcr", fullActive(), LocationProductMCR, true},
+		{"active full / mve", fullActive(), LocationProductMVE, true},
+		{"active full / cross connect", fullActive(), LocationProductCrossConnect, true},
+		{"active full / nat gateway", fullActive(), LocationProductNATGateway, true},
+		{"active full / unknown kind", fullActive(), LocationProductKind("UNKNOWN"), false},
+
+		{"active without cross connect / cross connect", activeNoXC, LocationProductCrossConnect, false},
+
+		// site 1299 regression — every product kind must be non-orderable.
+		{"site 1299 restricted / port", site1299, LocationProductPort, false},
+		{"site 1299 restricted / mcr", site1299, LocationProductMCR, false},
+		{"site 1299 restricted / mve", site1299, LocationProductMVE, false},
+		{"site 1299 restricted / cross connect", site1299, LocationProductCrossConnect, false},
+		{"site 1299 restricted / nat gateway", site1299, LocationProductNATGateway, false},
+	}
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			suite.Equal(tc.want, tc.loc.IsOrderable(tc.product))
+		})
+	}
+}

--- a/location_test.go
+++ b/location_test.go
@@ -1443,21 +1443,24 @@ func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_NilOption
 	suite.Equal("", gotRawQuery)
 }
 
-func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_DefaultActiveOnly() {
+// TestListLocationsV3WithOptions_EmptyNoFilter guards the fix for the
+// nil-vs-zero-value footgun: an empty options struct must behave like nil
+// (no filter, all statuses), not default to Active-only.
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_EmptyNoFilter() {
 	ctx := context.Background()
 	locSvc := suite.client.LocationService
-	var gotStatuses []string
+	var gotRawQuery string
 	suite.mux.HandleFunc("/v3/locations", func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodGet)
-		gotStatuses = r.URL.Query()["locationStatuses"]
+		gotRawQuery = r.URL.RawQuery
 		fmt.Fprint(w, emptyV3Body)
 	})
 	_, err := locSvc.ListLocationsV3WithOptions(ctx, &ListLocationsV3Options{})
 	suite.NoError(err)
-	suite.Equal([]string{LocationStatusActive}, gotStatuses)
+	suite.Equal("", gotRawQuery)
 }
 
-func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_IncludeFlags() {
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_Statuses() {
 	ctx := context.Background()
 	locSvc := suite.client.LocationService
 	var gotStatuses []string
@@ -1467,14 +1470,15 @@ func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_IncludeFl
 		fmt.Fprint(w, emptyV3Body)
 	})
 	_, err := locSvc.ListLocationsV3WithOptions(ctx, &ListLocationsV3Options{
-		IncludeRestricted: true,
-		IncludeDeployment: true,
+		Statuses: []string{LocationStatusActive, LocationStatusRestricted, LocationStatusDeployment},
 	})
 	suite.NoError(err)
 	suite.ElementsMatch([]string{LocationStatusActive, LocationStatusRestricted, LocationStatusDeployment}, gotStatuses)
 }
 
-func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_StatusesOverride() {
+// TestListLocationsV3WithOptions_ActiveOnly documents how callers request only
+// Active locations now that there is no implicit default.
+func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_ActiveOnly() {
 	ctx := context.Background()
 	locSvc := suite.client.LocationService
 	var gotStatuses []string
@@ -1484,11 +1488,10 @@ func (suite *LocationV3ClientTestSuite) TestListLocationsV3WithOptions_StatusesO
 		fmt.Fprint(w, emptyV3Body)
 	})
 	_, err := locSvc.ListLocationsV3WithOptions(ctx, &ListLocationsV3Options{
-		IncludeRestricted: true, // ignored — Statuses takes precedence
-		Statuses:          []string{LocationStatusExtended, LocationStatusNew},
+		Statuses: []string{LocationStatusActive},
 	})
 	suite.NoError(err)
-	suite.ElementsMatch([]string{LocationStatusExtended, LocationStatusNew}, gotStatuses)
+	suite.Equal([]string{LocationStatusActive}, gotStatuses)
 }
 
 // TestListLocationsV3_NoQueryParams asserts that the original ListLocationsV3


### PR DESCRIPTION
Adds typed location-status constants, server-side status filtering on `/v3/locations`, and an `IsOrderable(LocationProductKind)` helper on `*LocationV3` that composes the existing per-product `Has…Support()` methods.

**Why:** a customer recently pulled site 1299 (EdgeConneX Atlanta ATL02 — `Status: "Restricted"`, `crossConnect.available: false`) into Terraform, and the failure only surfaced as a generic API error at provision time. `loc.IsOrderable(LocationProductCrossConnect)` now returns `false` for that exact shape.

### Findings vs. the ticket

The ticket made three claims that disagree with the live OpenAPI; reconciled here:

| Claim | Reality | Resolution |
|---|---|---|
| 3 statuses (Active/Restricted/Deployment) | API enum has **6**: also Extended, New, Expired | Define all 6 constants |
| `productAddOns` carries port/MCR/MVE/IX/cross-connect | Only `crossConnect` is in `productAddOns`; port/MCR/MVE/NAT-gateway live in `diversityZones`; **IX is not exposed at all** | `LocationProductKind` covers Port/MCR/MVE/CrossConnect/NATGateway; IX dropped |
| Filter client-side after fetch | API supports `?locationStatuses=…` (repeated) | Filter server-side |

### Decisions

- Only `Active` is treated as orderable (strict — matches the ticket).
- `ListLocationsV3(ctx)` is unchanged: it delegates to `ListLocationsV3WithOptions(ctx, nil)` and sends no query string (regression-tested).
- An explicit `Statuses []string` overrides the `IncludeRestricted` / `IncludeDeployment` shortcuts.

### Compatibility

`ListLocationsV3` and the `LocationV3` struct are unchanged; only new methods are added, so `megaport-cli` and `terraform-provider-megaport` need no migration. One caveat: adding `ListLocationsV3WithOptions` to the `LocationService` interface breaks any third-party fake that implements the full interface — consistent with how `FilterLocationsByNATGatewaySpeedV3` was added.

Ticket: ESD-1029
