### PR TITLE
ESD-1079: Add adminPassword field to Cisco and Palo Alto MVE vendor configs

### DIFF
--- a/mve_test.go
+++ b/mve_test.go
@@ -766,3 +766,29 @@ func (suite *MVEClientTestSuite) TestDeleteMVE() {
 	suite.NoError(err)
 	suite.Equal(want, got)
 }
+
+// TestCiscoConfigAdminPasswordMarshalling verifies that CiscoConfig.AdminPassword
+// round-trips through JSON serialisation under the wire-format key "adminPassword".
+// The Megaport API requires this field for Cisco FTDv MVE buy orders.
+func (suite *MVEClientTestSuite) TestCiscoConfigAdminPasswordMarshalling() {
+	cfg := CiscoConfig{
+		Vendor:        "cisco",
+		ImageID:       1,
+		ProductSize:   "SMALL",
+		AdminPassword: "s3cret-plaintext",
+	}
+
+	raw, err := json.Marshal(cfg)
+	suite.NoError(err)
+	suite.Contains(string(raw), `"adminPassword":"s3cret-plaintext"`)
+
+	var decoded CiscoConfig
+	suite.NoError(json.Unmarshal(raw, &decoded))
+	suite.Equal("s3cret-plaintext", decoded.AdminPassword)
+
+	// Empty value must be omitted from the wire payload.
+	empty := CiscoConfig{Vendor: "cisco", ImageID: 1, ProductSize: "SMALL"}
+	emptyRaw, err := json.Marshal(empty)
+	suite.NoError(err)
+	suite.NotContains(string(emptyRaw), "adminPassword")
+}

--- a/mve_test.go
+++ b/mve_test.go
@@ -792,3 +792,29 @@ func (suite *MVEClientTestSuite) TestCiscoConfigAdminPasswordMarshalling() {
 	suite.NoError(err)
 	suite.NotContains(string(emptyRaw), "adminPassword")
 }
+
+// TestPaloAltoConfigAdminPasswordMarshalling verifies that PaloAltoConfig.AdminPassword
+// round-trips through JSON serialisation under the wire-format key "adminPassword".
+// The Megaport API requires this field for Palo Alto MVE buy orders.
+func (suite *MVEClientTestSuite) TestPaloAltoConfigAdminPasswordMarshalling() {
+	cfg := PaloAltoConfig{
+		Vendor:        "palo_alto",
+		ImageID:       1,
+		ProductSize:   "SMALL",
+		AdminPassword: "s3cret-plaintext",
+	}
+
+	raw, err := json.Marshal(cfg)
+	suite.NoError(err)
+	suite.Contains(string(raw), `"adminPassword":"s3cret-plaintext"`)
+
+	var decoded PaloAltoConfig
+	suite.NoError(json.Unmarshal(raw, &decoded))
+	suite.Equal("s3cret-plaintext", decoded.AdminPassword)
+
+	// Empty value must be omitted from the wire payload.
+	empty := PaloAltoConfig{Vendor: "palo_alto", ImageID: 1, ProductSize: "SMALL"}
+	emptyRaw, err := json.Marshal(empty)
+	suite.NoError(err)
+	suite.NotContains(string(emptyRaw), "adminPassword")
+}

--- a/mve_types.go
+++ b/mve_types.go
@@ -96,6 +96,7 @@ type PaloAltoConfig struct {
 	AdminSSHPublicKey string `json:"adminSshPublicKey,omitempty"`
 	SSHPublicKey      string `json:"sshPublicKey,omitempty"`
 	AdminPasswordHash string `json:"adminPasswordHash,omitempty"`
+	AdminPassword     string `json:"adminPassword,omitempty"`
 	LicenseData       string `json:"licenseData,omitempty"`
 }
 

--- a/mve_types.go
+++ b/mve_types.go
@@ -67,6 +67,7 @@ type CiscoConfig struct {
 	ManageLocally      bool   `json:"manageLocally,omitempty"`
 	AdminSSHPublicKey  string `json:"adminSshPublicKey,omitempty"`
 	SSHPublicKey       string `json:"sshPublicKey,omitempty"`
+	AdminPassword      string `json:"adminPassword,omitempty"`
 	CloudInit          string `json:"cloudInit,omitempty"`
 	FMCIPAddress       string `json:"fmcIpAddress,omitempty"`
 	FMCRegistrationKey string `json:"fmcRegistrationKey,omitempty"`


### PR DESCRIPTION
## Summary

Adds an `AdminPassword` field to both `CiscoConfig` and `PaloAltoConfig` in `mve_types.go` so the SDK can serialise the `adminPassword` key in MVE buy-order payloads. Without this field, Cisco FTDv and Palo Alto MVEs cannot be provisioned through the SDK (or its consumers — the Terraform provider and CLI).

## Context

A Megaport SA hit the following 400 from the staging API while attempting to provision a Cisco FTDv MVE via Terraform:

```
Validation error while attempting to create MVE with name Cisco-red CoreSite VA1: POST https://api-staging.megaport.com/v3/networkdesign/validate: 400 Validation failed adminPassword is required
```

Root cause: the Megaport API requires a plaintext `adminPassword` on MVE creation for these vendors. `PaloAltoConfig` already exposed `AdminPasswordHash` (for hashed credentials) but was also missing the `adminPassword` field. Both fields are `omitempty` so existing consumers that do not set them remain wire-compatible.

## Downstream

ESD-1080 in `terraform-provider-megaport` will surface the corresponding `admin_password` resource attributes for both vendors and depend on this SDK change once merged.

## Test plan

- [x] `go build -v ./...` — clean
- [x] `go test ./...` — all unit tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Added `TestCiscoConfigAdminPasswordMarshalling` — round-trip, correct wire key, `omitempty` honoured
- [x] Added `TestPaloAltoConfigAdminPasswordMarshalling` — round-trip, correct wire key, `omitempty` honoured
- [ ] Integration tests (require API credentials — not run locally)