### PR TITLE
ESD-1096: support modifying MCR ASN via ModifyMCR

### DIFF
--- a/mcr.go
+++ b/mcr.go
@@ -115,6 +115,10 @@ type ModifyMCRRequest struct {
 	CostCentre            string
 	MarketplaceVisibility *bool
 	ContractTermMonths    *int
+	// MCRAsn updates the MCR's BGP ASN in place when non-nil. The Megaport
+	// platform supports modifying ASN on a configured/live MCR; setting this
+	// avoids the destroy-and-recreate that callers would otherwise need.
+	MCRAsn *int
 
 	WaitForUpdate bool          // Wait until the MCR updates before returning
 	WaitForTime   time.Duration // How long to wait for the MCR to update if WaitForUpdate is true (default is 5 minutes; must be at least 30 seconds for the poller to fire)
@@ -495,6 +499,7 @@ func (svc *MCRServiceOp) ModifyMCR(ctx context.Context, req *ModifyMCRRequest) (
 		Name:                  req.Name,
 		CostCentre:            req.CostCentre,
 		MarketplaceVisibility: req.MarketplaceVisibility,
+		ASN:                   req.MCRAsn,
 	}
 	if req.ContractTermMonths != nil {
 		modifyReq.ContractTermMonths = *req.ContractTermMonths

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -412,6 +412,7 @@ func (suite *MCRClientTestSuite) TestModifyMCR() {
 		Name:                  "test-mcr-updated",
 		CostCentre:            "US",
 		MarketplaceVisibility: PtrTo(false),
+		MCRAsn:                PtrTo(64512),
 	}
 	jblobGet := `{
     "message": "Product [36b3f68e-2f54-4331-bf94-f8984449365f] has been updated",
@@ -504,6 +505,7 @@ func (suite *MCRClientTestSuite) TestModifyMCR() {
 		Name:                  req.Name,
 		CostCentre:            req.CostCentre,
 		MarketplaceVisibility: req.MarketplaceVisibility,
+		ASN:                   req.MCRAsn,
 	}
 	path := fmt.Sprintf("/v2/product/%s/%s", PRODUCT_MCR, productUid)
 	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {

--- a/product.go
+++ b/product.go
@@ -54,6 +54,9 @@ type ModifyProductRequest struct {
 	CostCentre            string `json:"costCentre"`
 	MarketplaceVisibility *bool  `json:"marketplaceVisibility,omitempty"`
 	ContractTermMonths    int    `json:"term,omitempty"`
+	// ASN is currently only meaningful for MCR products. Sent as-is to the
+	// PUT /v2/product/mcr2/{productUid} endpoint when non-nil.
+	ASN *int `json:"asn,omitempty"`
 }
 
 // ModifyProductResponse represents a response from the Megaport Products API after modifying a product.


### PR DESCRIPTION
## Summary

The Megaport API (`PUT /v2/product/mcr2/{productUid}`, `ServiceUpdateRequest`) accepts an `asn` field, allowing the BGP ASN of a configured/live MCR to be updated in place. The SDK did not expose it, so consumers (notably terraform-provider-megaport) were forced to destroy and recreate the MCR to change its ASN.

This change wires ASN through `ModifyMCR`:

- `ModifyProductRequest` gains `ASN *int` with `json:"asn,omitempty"` so callers that don't set it preserve current behavior on the wire.
- `ModifyMCRRequest` gains `MCRAsn *int`, passed through to `ModifyProductRequest.ASN` in `MCRServiceOp.ModifyMCR`.

## Test plan

- [x] `TestModifyMCR` extended to assert `ASN` is sent on the PUT body.
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` — 0 issues.

## Consumer

terraform-provider-megaport ESD-1094 will bump to this version and drop the `RequiresReplace` plan modifier on `megaport_mcr.asn`, plus wire the ASN into its `Update` path.

Resolves https://github.com/megaport/terraform-provider-megaport/issues/369