### PR TITLE
ESD-1182: Remove Terminate Later option for Ports

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -99,6 +99,9 @@ var ErrInvalidYear = errors.New("invalid year, must be between 0 and 99")
 // ErrMCRCancelLaterNotAllowed is returned when attempting to schedule MCR deletion for later (only CANCEL_NOW is allowed)
 var ErrMCRCancelLaterNotAllowed = errors.New("mcr products do not support scheduled deletion (cancel later), only immediate deletion (CANCEL_NOW) is allowed")
 
+// ErrPortCancelLaterNotAllowed is returned when attempting to schedule Port deletion for later (only CANCEL_NOW is allowed)
+var ErrPortCancelLaterNotAllowed = errors.New("port products do not support scheduled deletion (cancel later), only immediate deletion (CANCEL_NOW) is allowed")
+
 // ErrMCRNotFound is returned when an MCR cannot be found (deleted or never existed).
 var ErrMCRNotFound = errors.New("mcr not found or deleted")
 

--- a/errors.go
+++ b/errors.go
@@ -131,6 +131,9 @@ var ErrDeleteVXCRequestNil = errors.New("delete VXC request cannot be nil")
 // ErrDeleteMCRRequestNil is returned when DeleteMCR is called with a nil request.
 var ErrDeleteMCRRequestNil = errors.New("delete MCR request cannot be nil")
 
+// ErrDeletePortRequestNil is returned when DeletePort is called with a nil request.
+var ErrDeletePortRequestNil = errors.New("delete port request cannot be nil")
+
 // maintenanceStatesToString converts a slice of MaintenanceState to a slice of strings
 func maintenanceStatesToString(states []MaintenanceState) []string {
 	strs := make([]string, len(states))

--- a/port.go
+++ b/port.go
@@ -385,6 +385,9 @@ func (svc *PortServiceOp) ModifyPort(ctx context.Context, req *ModifyPortRequest
 // DeleteNow=false are rejected with ErrPortCancelLaterNotAllowed, and accepted
 // requests always call the underlying API with DeleteNow=true.
 func (svc *PortServiceOp) DeletePort(ctx context.Context, req *DeletePortRequest) (*DeletePortResponse, error) {
+	if req == nil {
+		return nil, ErrDeletePortRequestNil
+	}
 	// Enforce Port lifecycle restriction: only CANCEL_NOW is allowed
 	if !req.DeleteNow {
 		return nil, ErrPortCancelLaterNotAllowed

--- a/port.go
+++ b/port.go
@@ -25,6 +25,8 @@ type PortService interface {
 	// ModifyPort modifies a port in the Megaport Port API.
 	ModifyPort(ctx context.Context, req *ModifyPortRequest) (*ModifyPortResponse, error)
 	// DeletePort deletes a port in the Megaport Port API.
+	// Note: Port products only support immediate deletion (CANCEL_NOW). Requests
+	// with DeleteNow=false are rejected with ErrPortCancelLaterNotAllowed.
 	DeletePort(ctx context.Context, req *DeletePortRequest) (*DeletePortResponse, error)
 	// RestorePort restores a port in the Megaport Port API.
 	RestorePort(ctx context.Context, portId string) (*RestorePortResponse, error)
@@ -99,6 +101,9 @@ type ModifyPortResponse struct {
 }
 
 // DeletePortRequest represents a request to delete a port.
+//
+// DeleteNow must be true: ports only support immediate deletion (CANCEL_NOW).
+// Requests with DeleteNow=false are rejected with ErrPortCancelLaterNotAllowed.
 type DeletePortRequest struct {
 	PortID     string
 	DeleteNow  bool
@@ -376,10 +381,18 @@ func (svc *PortServiceOp) ModifyPort(ctx context.Context, req *ModifyPortRequest
 }
 
 // DeletePort deletes a port in the Megaport Port API.
+// Note: Port products only support immediate deletion (CANCEL_NOW). Requests with
+// DeleteNow=false are rejected with ErrPortCancelLaterNotAllowed, and accepted
+// requests always call the underlying API with DeleteNow=true.
 func (svc *PortServiceOp) DeletePort(ctx context.Context, req *DeletePortRequest) (*DeletePortResponse, error) {
+	// Enforce Port lifecycle restriction: only CANCEL_NOW is allowed
+	if !req.DeleteNow {
+		return nil, ErrPortCancelLaterNotAllowed
+	}
+
 	_, err := svc.Client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
 		ProductID:  req.PortID,
-		DeleteNow:  req.DeleteNow,
+		DeleteNow:  true, // Always use CANCEL_NOW for Port
 		SafeDelete: req.SafeDelete,
 	})
 	if err != nil {

--- a/port_integration_test.go
+++ b/port_integration_test.go
@@ -322,33 +322,18 @@ func (suite *PortIntegrationTestSuite) testModifyPort(c *Client, ctx context.Con
 	suite.EqualValues(newPortName, secondGetPortInfo.Name)
 }
 
-// PortScript tests the remaining lifecycle for a Port (not dependant on port-type), Go-Live, Modification,
-// and Soft/Hard Deletes.
+// testCancelPort verifies that scheduled deletion (cancel later) is rejected.
+// Port products only support immediate deletion (CANCEL_NOW); attempts to
+// schedule deletion must return ErrPortCancelLaterNotAllowed.
 func (suite *PortIntegrationTestSuite) testCancelPort(c *Client, ctx context.Context, portId string) {
-	// Soft Delete
-	suite.client.Logger.DebugContext(ctx, "Scheduling Port for deletion (30 days).", slog.String("port_id", portId))
-	resp, deleteErr := c.PortService.DeletePort(ctx, &DeletePortRequest{
+	suite.client.Logger.DebugContext(ctx, "Attempting to schedule Port for deletion (cancel later) - this should fail.", slog.String("port_id", portId))
+	_, deleteErr := c.PortService.DeletePort(ctx, &DeletePortRequest{
 		PortID:    portId,
 		DeleteNow: false,
 	})
-	if deleteErr != nil {
-		suite.FailNowf("could not cancel port", "could not cancel port %v", deleteErr)
-	}
-	suite.True(resp.IsDeleting)
-
-	portInfo, err := c.PortService.GetPort(ctx, portId)
-	if err != nil {
-		suite.FailNowf("could not find port", "could not find port %v", err)
-	}
-	suite.EqualValues(STATUS_CANCELLED, portInfo.ProvisioningStatus)
-
-	suite.client.Logger.DebugContext(ctx, "port scheduled for cancellation", slog.String("status", portInfo.ProvisioningStatus), slog.String("port_id", portId))
-	restoreResp, restoreErr := c.PortService.RestorePort(ctx, portId)
-	if restoreErr != nil {
-		suite.FailNowf("could not restore port", "could not restore port %v", restoreErr)
-	}
-	suite.True(restoreResp.IsRestored)
-
+	suite.Require().Error(deleteErr, "expected error when attempting to cancel port later")
+	suite.Require().ErrorIs(deleteErr, ErrPortCancelLaterNotAllowed, "expected ErrPortCancelLaterNotAllowed error")
+	suite.client.Logger.DebugContext(ctx, "port cancel later correctly rejected", slog.String("error", deleteErr.Error()))
 }
 
 // testDeletePort tests the deletion of a port, both hard and soft.

--- a/port_test.go
+++ b/port_test.go
@@ -466,6 +466,17 @@ func (suite *PortClientTestSuite) TestDeletePort() {
 	suite.Equal(want, got)
 }
 
+// TestDeletePortCancelLaterNotAllowed verifies that DeletePort rejects DeleteNow=false.
+func (suite *PortClientTestSuite) TestDeletePortCancelLaterNotAllowed() {
+	ctx := context.Background()
+	req := &DeletePortRequest{
+		PortID:    "36b3f68e-2f54-4331-bf94-f8984449365f",
+		DeleteNow: false,
+	}
+	_, err := suite.client.PortService.DeletePort(ctx, req)
+	suite.ErrorIs(err, ErrPortCancelLaterNotAllowed)
+}
+
 // TestRestorePort tests the RestorePort method
 func (suite *PortClientTestSuite) TestRestorePort() {
 	ctx := context.Background()

--- a/port_test.go
+++ b/port_test.go
@@ -477,6 +477,13 @@ func (suite *PortClientTestSuite) TestDeletePortCancelLaterNotAllowed() {
 	suite.ErrorIs(err, ErrPortCancelLaterNotAllowed)
 }
 
+// TestDeletePortNilRequest verifies that DeletePort rejects a nil request.
+func (suite *PortClientTestSuite) TestDeletePortNilRequest() {
+	ctx := context.Background()
+	_, err := suite.client.PortService.DeletePort(ctx, nil)
+	suite.ErrorIs(err, ErrDeletePortRequestNil)
+}
+
 // TestRestorePort tests the RestorePort method
 func (suite *PortClientTestSuite) TestRestorePort() {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Reject `DeletePort` requests with `DeleteNow=false` and return a new `ErrPortCancelLaterNotAllowed` sentinel
- Always forward `CANCEL_NOW` to the products API on accepted requests
- Update doc comments on the `DeletePort` interface method and `DeletePortRequest` struct to document the constraint
- Replace the soft-delete + restore round-trip in `testCancelPort` with an assertion that scheduled deletion is rejected

Mirrors the approach used for MCR / Transit VXC delayed-cancellation removal (PR #117).

## Behavioral break

This is a behavioural breaking change for SDK consumers calling `DeletePort` with `DeleteNow: false` — they will now receive `ErrPortCancelLaterNotAllowed` instead of a scheduled cancellation. Source-compatible: the `DeleteNow` field on `DeletePortRequest` is retained. Follow-up PRs will be needed in `megaport-cli` and `terraform-provider-megaport` to bump the SDK dependency.

`RestorePort` is intentionally left in place — existing ports that were already scheduled for cancellation under the old behaviour still need a path to be restored. It can be deprecated in a follow-up once backend confirms no port can reach the CANCELLED-but-not-decommissioned state.

## Test plan

- [x] `GOWORK=off go test ./...` — all unit tests pass, including the new `TestDeletePortCancelLaterNotAllowed`
- [x] `GOWORK=off golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go vet ./...` — clean
- [ ] Integration tests on staging — `testCancelPort` now asserts the new error path; `testDeletePort` still exercises the `CANCEL_NOW` happy path

Linked Jira: ESD-1182 (parent ENG-27615)