### PR TITLE
ESD-1291: Add nil-request guards to SDK services

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -134,6 +134,72 @@ var ErrDeleteMCRRequestNil = errors.New("delete MCR request cannot be nil")
 // ErrDeletePortRequestNil is returned when DeletePort is called with a nil request.
 var ErrDeletePortRequestNil = errors.New("delete port request cannot be nil")
 
+// ErrBuyIXRequestNil is returned when BuyIX or ValidateIXOrder is called with a nil request.
+var ErrBuyIXRequestNil = errors.New("buy IX request cannot be nil")
+
+// ErrUpdateIXRequestNil is returned when UpdateIX is called with a nil request.
+var ErrUpdateIXRequestNil = errors.New("update IX request cannot be nil")
+
+// ErrDeleteIXRequestNil is returned when DeleteIX is called with a nil request.
+var ErrDeleteIXRequestNil = errors.New("delete IX request cannot be nil")
+
+// ErrBuyMCRRequestNil is returned when BuyMCR or ValidateMCROrder is called with a nil request.
+var ErrBuyMCRRequestNil = errors.New("buy MCR request cannot be nil")
+
+// ErrCreateMCRPrefixFilterListRequestNil is returned when CreatePrefixFilterList is called with a nil request.
+var ErrCreateMCRPrefixFilterListRequestNil = errors.New("create MCR prefix filter list request cannot be nil")
+
+// ErrModifyMCRRequestNil is returned when ModifyMCR is called with a nil request.
+var ErrModifyMCRRequestNil = errors.New("modify MCR request cannot be nil")
+
+// ErrBuyMVERequestNil is returned when BuyMVE or ValidateMVEOrder is called with a nil request.
+var ErrBuyMVERequestNil = errors.New("buy MVE request cannot be nil")
+
+// ErrModifyMVERequestNil is returned when ModifyMVE is called with a nil request.
+var ErrModifyMVERequestNil = errors.New("modify MVE request cannot be nil")
+
+// ErrDeleteMVERequestNil is returned when DeleteMVE is called with a nil request.
+var ErrDeleteMVERequestNil = errors.New("delete MVE request cannot be nil")
+
+// ErrBuyVXCRequestNil is returned when BuyVXC or ValidateVXCOrder is called with a nil request.
+var ErrBuyVXCRequestNil = errors.New("buy VXC request cannot be nil")
+
+// ErrUpdateVXCRequestNil is returned when UpdateVXC is called with a nil request.
+var ErrUpdateVXCRequestNil = errors.New("update VXC request cannot be nil")
+
+// ErrLookupPartnerPortsRequestNil is returned when LookupPartnerPorts is called with a nil request.
+var ErrLookupPartnerPortsRequestNil = errors.New("lookup partner ports request cannot be nil")
+
+// ErrListPartnerPortsRequestNil is returned when ListPartnerPorts is called with a nil request.
+var ErrListPartnerPortsRequestNil = errors.New("list partner ports request cannot be nil")
+
+// ErrBuyPortRequestNil is returned when BuyPort or ValidatePortOrder is called with a nil request.
+var ErrBuyPortRequestNil = errors.New("buy port request cannot be nil")
+
+// ErrModifyPortRequestNil is returned when ModifyPort is called with a nil request.
+var ErrModifyPortRequestNil = errors.New("modify port request cannot be nil")
+
+// ErrModifyProductRequestNil is returned when ModifyProduct is called with a nil request.
+var ErrModifyProductRequestNil = errors.New("modify product request cannot be nil")
+
+// ErrDeleteProductRequestNil is returned when DeleteProduct is called with a nil request.
+var ErrDeleteProductRequestNil = errors.New("delete product request cannot be nil")
+
+// ErrManageProductLockRequestNil is returned when ManageProductLock is called with a nil request.
+var ErrManageProductLockRequestNil = errors.New("manage product lock request cannot be nil")
+
+// ErrCreateServiceKeyRequestNil is returned when CreateServiceKey is called with a nil request.
+var ErrCreateServiceKeyRequestNil = errors.New("create service key request cannot be nil")
+
+// ErrUpdateServiceKeyRequestNil is returned when UpdateServiceKey is called with a nil request.
+var ErrUpdateServiceKeyRequestNil = errors.New("update service key request cannot be nil")
+
+// ErrCreateUserRequestNil is returned when CreateUser is called with a nil request.
+var ErrCreateUserRequestNil = errors.New("create user request cannot be nil")
+
+// ErrUpdateUserRequestNil is returned when UpdateUser is called with a nil request.
+var ErrUpdateUserRequestNil = errors.New("update user request cannot be nil")
+
 // maintenanceStatesToString converts a slice of MaintenanceState to a slice of strings
 func maintenanceStatesToString(states []MaintenanceState) []string {
 	strs := make([]string, len(states))

--- a/ix.go
+++ b/ix.go
@@ -177,6 +177,9 @@ func (svc *IXServiceOp) BuyIX(ctx context.Context, req *BuyIXRequest) (*BuyIXRes
 
 // ValidateIXOrder validates an Internet Exchange order without submitting it
 func (svc *IXServiceOp) ValidateIXOrder(ctx context.Context, req *BuyIXRequest) error {
+	if req == nil {
+		return ErrBuyIXRequestNil
+	}
 	ixOrder := ConvertBuyIXRequestToIXOrder(*req)
 
 	return svc.Client.ProductService.ValidateProductOrder(ctx, ixOrder)
@@ -215,6 +218,9 @@ func (svc *IXServiceOp) GetIX(ctx context.Context, id string) (*IX, error) {
 
 // UpdateIX updates an existing Internet Exchange
 func (svc *IXServiceOp) UpdateIX(ctx context.Context, id string, req *UpdateIXRequest) (*IX, error) {
+	if req == nil {
+		return nil, ErrUpdateIXRequestNil
+	}
 	// Validate inputs
 	if req.CostCentre != nil && len(*req.CostCentre) > 255 {
 		return nil, ErrCostCentreTooLong
@@ -322,6 +328,9 @@ func (svc *IXServiceOp) UpdateIX(ctx context.Context, id string, req *UpdateIXRe
 
 // DeleteIX deletes an Internet Exchange
 func (svc *IXServiceOp) DeleteIX(ctx context.Context, id string, req *DeleteIXRequest) error {
+	if req == nil {
+		return ErrDeleteIXRequestNil
+	}
 	_, err := svc.Client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
 		ProductID: id,
 		DeleteNow: req.DeleteNow,

--- a/ix_test.go
+++ b/ix_test.go
@@ -786,3 +786,24 @@ func (suite *IXClientTestSuite) TestListIXsDeduplication() {
 		suite.Equal(65101, result[0].ASN, "Expected correct IX ASN")
 	}
 }
+
+// TestIXNilRequestGuards verifies that the IX service methods reject a nil
+// request with a sentinel error instead of panicking.
+func (suite *IXClientTestSuite) TestIXNilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"BuyIX", func() error { _, err := suite.client.IXService.BuyIX(ctx, nil); return err }, ErrBuyIXRequestNil},
+		{"ValidateIXOrder", func() error { return suite.client.IXService.ValidateIXOrder(ctx, nil) }, ErrBuyIXRequestNil},
+		{"UpdateIX", func() error { _, err := suite.client.IXService.UpdateIX(ctx, "id", nil); return err }, ErrUpdateIXRequestNil},
+		{"DeleteIX", func() error { return suite.client.IXService.DeleteIX(ctx, "id", nil) }, ErrDeleteIXRequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}

--- a/mcr.go
+++ b/mcr.go
@@ -227,6 +227,9 @@ func (svc *MCRServiceOp) BuyMCR(ctx context.Context, req *BuyMCRRequest) (*BuyMC
 
 // validateBuyMCRRequest validates the BuyMCRRequest for a valid term and port speed.
 func validateBuyMCRRequest(order *BuyMCRRequest) error {
+	if order == nil {
+		return ErrBuyMCRRequestNil
+	}
 	if !slices.Contains(VALID_CONTRACT_TERMS, order.Term) {
 		return ErrInvalidTerm
 	}
@@ -324,6 +327,9 @@ func (svc *MCRServiceOp) ValidateMCROrder(ctx context.Context, req *BuyMCRReques
 
 // ListMCRs lists all MCRs in the Megaport API.
 func (svc *MCRServiceOp) ListMCRs(ctx context.Context, req *ListMCRsRequest) ([]*MCR, error) {
+	if req == nil {
+		req = &ListMCRsRequest{}
+	}
 	allProducts, err := svc.Client.ProductService.ListProducts(ctx)
 	if err != nil {
 		return nil, err
@@ -381,6 +387,9 @@ func (svc *MCRServiceOp) GetMCR(ctx context.Context, mcrId string) (*MCR, error)
 
 // CreatePrefixFilterList creates a Prefix Filter List on an MCR from the Megaport MCR API.
 func (svc *MCRServiceOp) CreatePrefixFilterList(ctx context.Context, req *CreateMCRPrefixFilterListRequest) (*CreateMCRPrefixFilterListResponse, error) {
+	if req == nil {
+		return nil, ErrCreateMCRPrefixFilterListRequestNil
+	}
 	url := "/v2/product/mcr2/" + req.MCRID + "/prefixList"
 
 	clientReq, err := svc.Client.NewRequest(ctx, "POST", url, req.PrefixFilterList)
@@ -490,6 +499,9 @@ func (svc *MCRServiceOp) GetMCRPrefixFilterList(ctx context.Context, mcrID strin
 
 // ModifyMCR modifies an MCR in the Megaport MCR API.
 func (svc *MCRServiceOp) ModifyMCR(ctx context.Context, req *ModifyMCRRequest) (*ModifyMCRResponse, error) {
+	if req == nil {
+		return nil, ErrModifyMCRRequestNil
+	}
 	if len(req.CostCentre) > 255 {
 		return nil, ErrCostCentreTooLong
 	}

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -911,3 +911,39 @@ func (suite *MCRClientTestSuite) TestUpdateMCRIPsecAddOnInvalidTunnelCount() {
 	suite.Error(err)
 	suite.Equal(ErrInvalidIPsecTunnelCount, err)
 }
+
+// TestMCRNilRequestGuards verifies that the required-request MCR methods reject
+// a nil request with a sentinel error instead of panicking.
+func (suite *MCRClientTestSuite) TestMCRNilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"BuyMCR", func() error { _, err := suite.client.MCRService.BuyMCR(ctx, nil); return err }, ErrBuyMCRRequestNil},
+		{"ValidateMCROrder", func() error { return suite.client.MCRService.ValidateMCROrder(ctx, nil) }, ErrBuyMCRRequestNil},
+		{"CreatePrefixFilterList", func() error {
+			_, err := suite.client.MCRService.CreatePrefixFilterList(ctx, nil)
+			return err
+		}, ErrCreateMCRPrefixFilterListRequestNil},
+		{"ModifyMCR", func() error { _, err := suite.client.MCRService.ModifyMCR(ctx, nil); return err }, ErrModifyMCRRequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}
+
+// TestListMCRsNilRequest verifies that ListMCRs treats a nil request as "no filter".
+func (suite *MCRClientTestSuite) TestListMCRsNilRequest() {
+	ctx := context.Background()
+	suite.mux.HandleFunc("/v2/products", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, `{"message":"OK","data":[]}`)
+	})
+	mcrs, err := suite.client.MCRService.ListMCRs(ctx, nil)
+	suite.NoError(err)
+	suite.NotNil(mcrs)
+}

--- a/mve.go
+++ b/mve.go
@@ -198,6 +198,9 @@ func createMVEOrder(req *BuyMVERequest) []*MVEOrderConfig {
 
 // ListMVEs lists all MVEs in the Megaport API.
 func (svc *MVEServiceOp) ListMVEs(ctx context.Context, req *ListMVEsRequest) ([]*MVE, error) {
+	if req == nil {
+		req = &ListMVEsRequest{}
+	}
 	allProducts, err := svc.Client.ProductService.ListProducts(ctx)
 	if err != nil {
 		return nil, err
@@ -251,6 +254,9 @@ func (svc *MVEServiceOp) GetMVE(ctx context.Context, mveId string) (*MVE, error)
 
 // ModifyMVE modifies an MVE in the Megaport MVE API.
 func (svc *MVEServiceOp) ModifyMVE(ctx context.Context, req *ModifyMVERequest) (*ModifyMVEResponse, error) {
+	if req == nil {
+		return nil, ErrModifyMVERequestNil
+	}
 	modifyProductReq := &ModifyProductRequest{
 		ProductID:             req.MVEID,
 		ProductType:           PRODUCT_MVE,
@@ -310,6 +316,9 @@ func (svc *MVEServiceOp) ModifyMVE(ctx context.Context, req *ModifyMVERequest) (
 
 // DeleteMVE deletes an MVE in the Megaport MVE API.
 func (svc *MVEServiceOp) DeleteMVE(ctx context.Context, req *DeleteMVERequest) (*DeleteMVEResponse, error) {
+	if req == nil {
+		return nil, ErrDeleteMVERequestNil
+	}
 	_, err := svc.Client.ProductService.DeleteProduct(ctx, &DeleteProductRequest{
 		ProductID:  req.MVEID,
 		DeleteNow:  true,
@@ -388,6 +397,9 @@ func (svc *MVEServiceOp) ListAvailableMVESizes(ctx context.Context) ([]*MVESize,
 
 // validateBuyMVERequest validates a BuyMVERequest for proper term length.
 func validateBuyMVERequest(req *BuyMVERequest) error {
+	if req == nil {
+		return ErrBuyMVERequestNil
+	}
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		return ErrInvalidTerm
 	}

--- a/mve_test.go
+++ b/mve_test.go
@@ -818,3 +818,36 @@ func (suite *MVEClientTestSuite) TestPaloAltoConfigAdminPasswordMarshalling() {
 	suite.NoError(err)
 	suite.NotContains(string(emptyRaw), "adminPassword")
 }
+
+// TestMVENilRequestGuards verifies that the required-request MVE methods reject
+// a nil request with a sentinel error instead of panicking.
+func (suite *MVEClientTestSuite) TestMVENilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"BuyMVE", func() error { _, err := suite.client.MVEService.BuyMVE(ctx, nil); return err }, ErrBuyMVERequestNil},
+		{"ValidateMVEOrder", func() error { return suite.client.MVEService.ValidateMVEOrder(ctx, nil) }, ErrBuyMVERequestNil},
+		{"ModifyMVE", func() error { _, err := suite.client.MVEService.ModifyMVE(ctx, nil); return err }, ErrModifyMVERequestNil},
+		{"DeleteMVE", func() error { _, err := suite.client.MVEService.DeleteMVE(ctx, nil); return err }, ErrDeleteMVERequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}
+
+// TestListMVEsNilRequest verifies that ListMVEs treats a nil request as "no filter".
+func (suite *MVEClientTestSuite) TestListMVEsNilRequest() {
+	ctx := context.Background()
+	suite.mux.HandleFunc("/v2/products", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, `{"message":"OK","data":[]}`)
+	})
+	mves, err := suite.client.MVEService.ListMVEs(ctx, nil)
+	suite.NoError(err)
+	suite.NotNil(mves)
+}

--- a/port.go
+++ b/port.go
@@ -147,6 +147,9 @@ type UnlockPortResponse struct {
 
 // BuyPort buys a port from the Megaport Port API.
 func (svc *PortServiceOp) BuyPort(ctx context.Context, req *BuyPortRequest) (*BuyPortResponse, error) {
+	if req == nil {
+		return nil, ErrBuyPortRequestNil
+	}
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		return nil, ErrInvalidTerm
 	}
@@ -238,6 +241,9 @@ func createPortOrder(req *BuyPortRequest) []PortOrder {
 }
 
 func (svc *PortServiceOp) ValidatePortOrder(ctx context.Context, req *BuyPortRequest) error {
+	if req == nil {
+		return ErrBuyPortRequestNil
+	}
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		// Validate that term is one of the allowed values
 		return ErrInvalidTerm
@@ -323,6 +329,9 @@ func (svc *PortServiceOp) GetPort(ctx context.Context, portId string) (*Port, er
 
 // ModifyPort modifies a port in the Megaport Port API.
 func (svc *PortServiceOp) ModifyPort(ctx context.Context, req *ModifyPortRequest) (*ModifyPortResponse, error) {
+	if req == nil {
+		return nil, ErrModifyPortRequestNil
+	}
 	if len(req.CostCentre) > 255 {
 		return nil, ErrCostCentreTooLong
 	}

--- a/port_test.go
+++ b/port_test.go
@@ -604,3 +604,23 @@ func (suite *PortClientTestSuite) TestUnlockPort() {
 	suite.NoError(err)
 	suite.Equal(want, got)
 }
+
+// TestPortNilRequestGuards verifies that the required-request Port methods reject
+// a nil request with a sentinel error instead of panicking.
+func (suite *PortClientTestSuite) TestPortNilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"BuyPort", func() error { _, err := suite.client.PortService.BuyPort(ctx, nil); return err }, ErrBuyPortRequestNil},
+		{"ValidatePortOrder", func() error { return suite.client.PortService.ValidatePortOrder(ctx, nil) }, ErrBuyPortRequestNil},
+		{"ModifyPort", func() error { _, err := suite.client.PortService.ModifyPort(ctx, nil); return err }, ErrModifyPortRequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}

--- a/product.go
+++ b/product.go
@@ -253,6 +253,9 @@ func (svc *ProductServiceOp) ListProducts(ctx context.Context) ([]Product, error
 
 // ModifyProduct modifies a product in the Megaport Products API. The available fields to modify are Name, Cost Centre, and Marketplace Visibility.
 func (svc *ProductServiceOp) ModifyProduct(ctx context.Context, req *ModifyProductRequest) (*ModifyProductResponse, error) {
+	if req == nil {
+		return nil, ErrModifyProductRequestNil
+	}
 	if req.ProductType == PRODUCT_MEGAPORT || req.ProductType == PRODUCT_MCR || req.ProductType == PRODUCT_MVE {
 		path := fmt.Sprintf("/v2/product/%s/%s", req.ProductType, req.ProductID)
 		url := svc.Client.BaseURL.JoinPath(path).String()
@@ -275,6 +278,9 @@ func (svc *ProductServiceOp) ModifyProduct(ctx context.Context, req *ModifyProdu
 
 // DeleteProduct is responsible for either scheduling a product for deletion "CANCEL" or deleting a product immediately "CANCEL_NOW" in the Megaport Products API.
 func (svc *ProductServiceOp) DeleteProduct(ctx context.Context, req *DeleteProductRequest) (*DeleteProductResponse, error) {
+	if req == nil {
+		return nil, ErrDeleteProductRequestNil
+	}
 	var action string
 
 	if req.DeleteNow {
@@ -325,6 +331,9 @@ func (svc *ProductServiceOp) RestoreProduct(ctx context.Context, productId strin
 
 // ManageProductLock is responsible for locking or unlocking a product in the Megaport Products API.
 func (svc *ProductServiceOp) ManageProductLock(ctx context.Context, req *ManageProductLockRequest) (*ManageProductLockResponse, error) {
+	if req == nil {
+		return nil, ErrManageProductLockRequestNil
+	}
 	verb := "POST"
 
 	if !req.ShouldLock {

--- a/product_test.go
+++ b/product_test.go
@@ -680,3 +680,26 @@ func (suite *ProductClientTestSuite) TestListProductResourceTags() {
 	suite.NoError(err)
 	suite.EqualValues(testProductResourceTags, res)
 }
+
+// TestProductNilRequestGuards verifies that the required-request Product methods
+// reject a nil request with a sentinel error instead of panicking.
+func (suite *ProductClientTestSuite) TestProductNilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"ModifyProduct", func() error { _, err := suite.client.ProductService.ModifyProduct(ctx, nil); return err }, ErrModifyProductRequestNil},
+		{"DeleteProduct", func() error { _, err := suite.client.ProductService.DeleteProduct(ctx, nil); return err }, ErrDeleteProductRequestNil},
+		{"ManageProductLock", func() error {
+			_, err := suite.client.ProductService.ManageProductLock(ctx, nil)
+			return err
+		}, ErrManageProductLockRequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}

--- a/service_keys.go
+++ b/service_keys.go
@@ -144,6 +144,9 @@ type UpdateServiceKeyResponse struct {
 
 // CreateServiceKey creates a service key in the Megaport Service Key API.
 func (svc *ServiceKeyServiceOp) CreateServiceKey(ctx context.Context, req *CreateServiceKeyRequest) (*CreateServiceKeyResponse, error) {
+	if req == nil {
+		return nil, ErrCreateServiceKeyRequestNil
+	}
 	if req.ProductID != 0 && req.ProductUID != "" {
 		return nil, errors.New("ProductID and ProductUID cannot both be set")
 	}
@@ -184,6 +187,9 @@ func (svc *ServiceKeyServiceOp) CreateServiceKey(ctx context.Context, req *Creat
 }
 
 func (svc *ServiceKeyServiceOp) ListServiceKeys(ctx context.Context, req *ListServiceKeysRequest) (*ListServiceKeysResponse, error) {
+	if req == nil {
+		req = &ListServiceKeysRequest{}
+	}
 	path := "/v2/service/key"
 	params := url.Values{}
 	if req.ProductUID != nil {
@@ -262,6 +268,9 @@ func (svc *ServiceKeyServiceOp) GetServiceKey(ctx context.Context, keyId string)
 }
 
 func (svc *ServiceKeyServiceOp) UpdateServiceKey(ctx context.Context, req *UpdateServiceKeyRequest) (*UpdateServiceKeyResponse, error) {
+	if req == nil {
+		return nil, ErrUpdateServiceKeyRequestNil
+	}
 	if req.ProductID != 0 && req.ProductUID != "" {
 		return nil, errors.New("ProductID and ProductUID cannot both be set")
 	}

--- a/service_keys_test.go
+++ b/service_keys_test.go
@@ -16,7 +16,7 @@ type ServiceKeyClientTestSuite struct {
 	ClientTestSuite
 }
 
-func TestServiceClientTestSuite(t *testing.T) {
+func TestServiceKeyClientTestSuite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, new(ServiceKeyClientTestSuite))
 }

--- a/service_keys_test.go
+++ b/service_keys_test.go
@@ -185,6 +185,7 @@ func (suite *ServiceKeyClientTestSuite) TestListServiceKeys() {
 	}}
 	suite.mux.HandleFunc("/v2/service/key", func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodGet)
+		suite.Equal(productUid, r.URL.Query().Get("productIdOrUid"))
 		fmt.Fprint(w, jblob)
 	})
 	listRes, err := suite.client.ServiceKeyService.ListServiceKeys(ctx, listReq)

--- a/service_keys_test.go
+++ b/service_keys_test.go
@@ -18,7 +18,7 @@ type ServiceKeyClientTestSuite struct {
 
 func TestServiceClientTestSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(PortClientTestSuite))
+	suite.Run(t, new(ServiceKeyClientTestSuite))
 }
 
 func (suite *ServiceKeyClientTestSuite) SetupTest() {
@@ -164,32 +164,26 @@ func (suite *ServiceKeyClientTestSuite) TestListServiceKeys() {
       }`
 	want := &ListServiceKeysResponse{ServiceKeys: []*ServiceKey{
 		{
-			Key: "d1269fa6-dde7-49d2-b643-0a9d3cc7bedd",
-			// CreateDate:  &Time{Time: GetTime(1527815582306)},
-			// CompanyID:   1153,
-			// CompanyUID:  "160208ae-01e4-4cb9-8d57-03a197be47a8",
-			// CompanyName: "Megaport Lab",
-			// Description: "pmgsk",
-			// ProductID:   19347,
-			// ProductUID:  "69ddf381-06ae-4150-9690-a46c8323d2d5",
-			// ProductName: "PMG1",
-			// VLAN:        300,
-			// MaxSpeed:    10,
-			// PreApproved: false,
-			// SingleUse:   true,
-			// LastUsed:    nil,
-			// Active:      true,
-			// ValidFor: &ValidFor{
-			// 	StartTime: &Time{
-			// 		Time: GetTime(1527815662405),
-			// 	},
-			// 	EndTime: &Time{
-			// 		Time: GetTime(1528725600000),
-			// 	},
-			// },
+			Key:         "d1269fa6-dde7-49d2-b643-0a9d3cc7bedd",
+			CreateDate:  &Time{Time: GetTime(1527815582306)},
+			CompanyID:   1153,
+			CompanyUID:  "160208ae-01e4-4cb9-8d57-03a197be47a8",
+			CompanyName: "Megaport Lab",
+			Description: "pmgsk",
+			ProductID:   19347,
+			ProductUID:  "69ddf381-06ae-4150-9690-a46c8323d2d5",
+			ProductName: "PMG1",
+			VLAN:        300,
+			MaxSpeed:    10,
+			SingleUse:   true,
+			Active:      true,
+			ValidFor: &ValidFor{
+				StartTime: &Time{Time: GetTime(1527815662405)},
+				EndTime:   &Time{Time: GetTime(1528725600000)},
+			},
 		},
 	}}
-	suite.mux.HandleFunc(fmt.Sprintf("/v2/service/key?productidOrUid=%s", productUid), func(w http.ResponseWriter, r *http.Request) {
+	suite.mux.HandleFunc("/v2/service/key", func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodGet)
 		fmt.Fprint(w, jblob)
 	})
@@ -282,4 +276,39 @@ func (suite *ServiceKeyClientTestSuite) TestUpdateServiceKey() {
 	})
 	_, err := suite.client.ServiceKeyService.UpdateServiceKey(ctx, updateReq)
 	suite.NoError(err)
+}
+
+// TestServiceKeyNilRequestGuards verifies that the required-request service-key
+// methods reject a nil request with a sentinel error instead of panicking.
+func (suite *ServiceKeyClientTestSuite) TestServiceKeyNilRequestGuards() {
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"CreateServiceKey", func() error {
+			_, err := suite.client.ServiceKeyService.CreateServiceKey(ctx, nil)
+			return err
+		}, ErrCreateServiceKeyRequestNil},
+		{"UpdateServiceKey", func() error {
+			_, err := suite.client.ServiceKeyService.UpdateServiceKey(ctx, nil)
+			return err
+		}, ErrUpdateServiceKeyRequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}
+
+// TestListServiceKeysNilRequest verifies that ListServiceKeys treats a nil request as "no filter".
+func (suite *ServiceKeyClientTestSuite) TestListServiceKeysNilRequest() {
+	suite.mux.HandleFunc("/v2/service/key", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, `{"message":"OK","data":[]}`)
+	})
+	res, err := suite.client.ServiceKeyService.ListServiceKeys(ctx, nil)
+	suite.NoError(err)
+	suite.NotNil(res)
 }

--- a/user_management.go
+++ b/user_management.go
@@ -214,6 +214,9 @@ type GetUserActivityRequest struct {
 
 // CreateUser creates a new user in the Megaport system.
 func (svc *UserManagementServiceOp) CreateUser(ctx context.Context, req *CreateUserRequest) (*CreateUserResponse, error) {
+	if req == nil {
+		return nil, ErrCreateUserRequestNil
+	}
 	// Validate the request according to API requirements
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)
@@ -344,6 +347,9 @@ func (svc *UserManagementServiceOp) ListCompanyUsers(ctx context.Context) ([]*Us
 }
 
 func (svc *UserManagementServiceOp) UpdateUser(ctx context.Context, employeeID int, req *UpdateUserRequest) error {
+	if req == nil {
+		return ErrUpdateUserRequestNil
+	}
 	// Validate the request according to API requirements
 	if err := req.Validate(); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
@@ -448,6 +454,9 @@ func (svc *UserManagementServiceOp) DeleteUser(ctx context.Context, employeeID i
 // GetUserActivity retrieves a log of user activity in the Megaport Portal.
 // It can be filtered by person ID/UID and/or company ID/UID using the request parameters.
 func (svc *UserManagementServiceOp) GetUserActivity(ctx context.Context, req *GetUserActivityRequest) ([]*UserActivity, error) {
+	if req == nil {
+		req = &GetUserActivityRequest{}
+	}
 	path := "/v3/activity"
 
 	// Append query parameters if provided using proper URL encoding

--- a/user_management_test.go
+++ b/user_management_test.go
@@ -261,3 +261,42 @@ func (suite *UserManagementClientTestSuite) TestGetUserActivity() {
 	suite.Equal("User logged in", activities[0].Description)
 	suite.Equal("Login", activities[0].Name)
 }
+
+// TestUserManagementNilRequestGuards verifies required-request methods reject a nil request.
+func (suite *UserManagementClientTestSuite) TestUserManagementNilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name    string
+		call    func() error
+		wantErr error
+	}{
+		{
+			name:    "CreateUser",
+			call:    func() error { _, err := suite.client.UserManagementService.CreateUser(ctx, nil); return err },
+			wantErr: ErrCreateUserRequestNil,
+		},
+		{
+			name:    "UpdateUser",
+			call:    func() error { return suite.client.UserManagementService.UpdateUser(ctx, 9012, nil) },
+			wantErr: ErrUpdateUserRequestNil,
+		},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.wantErr)
+		})
+	}
+}
+
+// TestGetUserActivityNilRequest verifies a nil request is treated as no filter.
+func (suite *UserManagementClientTestSuite) TestGetUserActivityNilRequest() {
+	ctx := context.Background()
+	suite.mux.HandleFunc("/v3/activity", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, `[]`)
+	})
+
+	activities, err := suite.client.UserManagementService.GetUserActivity(ctx, nil)
+	suite.NoError(err)
+	suite.Empty(activities)
+}

--- a/vxc.go
+++ b/vxc.go
@@ -528,7 +528,7 @@ func (svc *VXCServiceOp) LookupPartnerPorts(ctx context.Context, req *LookupPart
 	return nil, ErrNoAvailableVxcPorts
 }
 
-// LookupPartnerPorts looks up available partner ports in the Megaport VXC API.
+// ListPartnerPorts lists available partner ports in the Megaport VXC API.
 func (svc *VXCServiceOp) ListPartnerPorts(ctx context.Context, req *ListPartnerPortsRequest) (*ListPartnerPortsResponse, error) {
 	if req == nil {
 		return nil, ErrListPartnerPortsRequestNil

--- a/vxc.go
+++ b/vxc.go
@@ -157,6 +157,9 @@ type ListVXCsRequest struct {
 
 // BuyVXC buys a VXC from the Megaport VXC API.
 func (svc *VXCServiceOp) BuyVXC(ctx context.Context, req *BuyVXCRequest) (*BuyVXCResponse, error) {
+	if req == nil {
+		return nil, ErrBuyVXCRequestNil
+	}
 	if !slices.Contains(VALID_CONTRACT_TERMS, req.Term) {
 		return nil, ErrInvalidTerm
 	}
@@ -289,6 +292,9 @@ func createVXCOrder(req *BuyVXCRequest) []VXCOrder {
 
 // ValidateVXCOrder validates a VXC order in the Megaport VXC API.
 func (svc *VXCServiceOp) ValidateVXCOrder(ctx context.Context, req *BuyVXCRequest) error {
+	if req == nil {
+		return ErrBuyVXCRequestNil
+	}
 	buyOrder := createVXCOrder(req)
 
 	return svc.Client.ProductService.ValidateProductOrder(ctx, buyOrder)
@@ -352,6 +358,9 @@ func (svc *VXCServiceOp) DeleteVXC(ctx context.Context, id string, req *DeleteVX
 
 // UpdateVXC updates a VXC in the Megaport VXC API.
 func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVXCRequest) (*VXC, error) {
+	if req == nil {
+		return nil, ErrUpdateVXCRequestNil
+	}
 	if req.Term != nil && !slices.Contains(VALID_CONTRACT_TERMS, *req.Term) {
 		return nil, ErrInvalidTerm
 	}
@@ -474,6 +483,9 @@ func (svc *VXCServiceOp) UpdateVXC(ctx context.Context, id string, req *UpdateVX
 
 // LookupPartnerPorts looks up available partner ports in the Megaport VXC API.
 func (svc *VXCServiceOp) LookupPartnerPorts(ctx context.Context, req *LookupPartnerPortsRequest) (*LookupPartnerPortsResponse, error) {
+	if req == nil {
+		return nil, ErrLookupPartnerPortsRequestNil
+	}
 	lookupUrl := "/v2/secure/" + strings.ToLower(req.Partner) + "/" + req.Key
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, lookupUrl, nil)
 	if err != nil {
@@ -518,6 +530,9 @@ func (svc *VXCServiceOp) LookupPartnerPorts(ctx context.Context, req *LookupPart
 
 // LookupPartnerPorts looks up available partner ports in the Megaport VXC API.
 func (svc *VXCServiceOp) ListPartnerPorts(ctx context.Context, req *ListPartnerPortsRequest) (*ListPartnerPortsResponse, error) {
+	if req == nil {
+		return nil, ErrListPartnerPortsRequestNil
+	}
 	lookupUrl := "/v2/secure/" + strings.ToLower(req.Partner) + "/" + req.Key
 	clientReq, err := svc.Client.NewRequest(ctx, http.MethodGet, lookupUrl, nil)
 	if err != nil {

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -1940,3 +1940,31 @@ func (suite *VXCClientTestSuite) TestListVXCsWithDifferentProductTypes() {
 		suite.True(found, "VXC with UID %s was not found", uid)
 	}
 }
+
+// TestVXCNilRequestGuards verifies that the required-request VXC methods reject
+// a nil request with a sentinel error instead of panicking.
+func (suite *VXCClientTestSuite) TestVXCNilRequestGuards() {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		call func() error
+		want error
+	}{
+		{"BuyVXC", func() error { _, err := suite.client.VXCService.BuyVXC(ctx, nil); return err }, ErrBuyVXCRequestNil},
+		{"ValidateVXCOrder", func() error { return suite.client.VXCService.ValidateVXCOrder(ctx, nil) }, ErrBuyVXCRequestNil},
+		{"UpdateVXC", func() error { _, err := suite.client.VXCService.UpdateVXC(ctx, "id", nil); return err }, ErrUpdateVXCRequestNil},
+		{"LookupPartnerPorts", func() error {
+			_, err := suite.client.VXCService.LookupPartnerPorts(ctx, nil)
+			return err
+		}, ErrLookupPartnerPortsRequestNil},
+		{"ListPartnerPorts", func() error {
+			_, err := suite.client.VXCService.ListPartnerPorts(ctx, nil)
+			return err
+		}, ErrListPartnerPortsRequestNil},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.ErrorIs(tt.call(), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Several exported service methods would panic if called with a nil request pointer, since they dereference `req` straight away. This adds a guard at the top of each one.

Where nil legitimately means "no filter" (the list methods) we coalesce to an empty request. Everywhere else we return a new `Err…RequestNil` sentinel. Signatures are unchanged, so megaport-cli and terraform-provider-megaport are unaffected.

- Add `Err…RequestNil` sentinels for the guarded methods.
- Coalesce-to-empty: `ListMCRs`, `ListMVEs`, `ListServiceKeys`, `GetUserActivity`.
- Return-sentinel: the IX, MCR, MVE, VXC, port, product, service key, and user methods that require a request. Guards on shared Buy*/Validate* helpers cover both entry points.
- Table-driven tests pass nil to each method (error for required, empty/no-panic for list).

While adding the service-key tests I found the `ServiceKeyClientTestSuite` runner was pointing at `PortClientTestSuite`, so the whole suite never ran. Fixed the runner and the dormant `ListServiceKeys` test it exposed (wrong mock path, stale expectation).