### PR TITLE
ESD-1310: Fix IPsec tunnel order shape to match the API

### DIFF
--- a/shared_types.go
+++ b/shared_types.go
@@ -33,8 +33,8 @@ const (
 	CONNECT_TYPE_AWS_HOSTED_CONNECTION = "AWSHC"
 
 	// InterfaceTypeSubInterface and InterfaceTypeIPSecTunnel are the
-	// interface type values accepted by the Megaport API (camelCase —
-	// the API matches these exactly).
+	// interface type values accepted by the Megaport API. They are
+	// camelCase and the API matches them exactly.
 	InterfaceTypeSubInterface = "subInterface"
 	InterfaceTypeIPSecTunnel  = "ipSecTunnel"
 

--- a/shared_types.go
+++ b/shared_types.go
@@ -32,13 +32,11 @@ const (
 	CONNECT_TYPE_AWS_VIF               = "AWS"
 	CONNECT_TYPE_AWS_HOSTED_CONNECTION = "AWSHC"
 
-	// InterfaceTypeSubInterface and InterfaceTypeIPSecTunnel are the interface
-	// type string values accepted by the Megaport API. These are new exports
-	// introduced in this release — no previously released version of this SDK
-	// exported these constants, so there are no existing consumers to maintain
-	// backwards compatibility with.
-	InterfaceTypeSubInterface = "SUBINTERFACE"
-	InterfaceTypeIPSecTunnel  = "IPSEC_TUNNEL"
+	// InterfaceTypeSubInterface and InterfaceTypeIPSecTunnel are the
+	// interface type values accepted by the Megaport API (camelCase —
+	// the API matches these exactly).
+	InterfaceTypeSubInterface = "subInterface"
+	InterfaceTypeIPSecTunnel  = "ipSecTunnel"
 
 	// maxCostCentreLength is the maximum number of characters the API accepts for a cost centre.
 	maxCostCentreLength = 255

--- a/vxc_integration_test.go
+++ b/vxc_integration_test.go
@@ -2,7 +2,9 @@ package megaport
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -718,7 +720,9 @@ func (suite *VXCIntegrationTestSuite) TestAWSHostedConnectionBuy() {
 
 // TestMCRVXCWithIPsec provisions an MCR with the IPsec add-on, orders a VXC
 // off it whose A-End interface carries an IPsec tunnel config, verifies the
-// VXC goes live, and tears everything down.
+// tunnel is actually configured on the MCR (not just that the VXC goes
+// live — the API silently drops unknown partner config fields), and tears
+// everything down.
 func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 	vxcSvc := suite.client.VXCService
 	mcrSvc := suite.client.MCRService
@@ -799,17 +803,15 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 			PartnerConfig: VXCOrderVrouterPartnerConfig{
 				Interfaces: []PartnerConfigInterface{
 					{
-						IpAddresses: []string{"192.0.2.1/30"},
-						IpsecTunnels: []IPsecTunnelConfig{
-							{
-								Description:          "integration-test-tunnel",
-								SourceIpAddress:      "192.0.2.1",
-								DestinationIpAddress: "198.51.100.1",
-								PreSharedKey:         "integrationTestKey123",
-								StartAction:          IPsecStartActionPassive,
-								Phase1Lifetime:       &phase1,
-								Phase2Lifetime:       &phase2,
-							},
+						Description:   "integration-test-tunnel",
+						InterfaceType: InterfaceTypeIPSecTunnel,
+						IpAddresses:   []string{"192.0.2.1/30"},
+						IpSecTunnelOptions: &IPsecTunnelConfig{
+							SourceIpAddress:      "192.0.2.1",
+							DestinationIpAddress: "198.51.100.1",
+							PreSharedKey:         "integrationTestKey123",
+							Phase1Lifetime:       &phase1,
+							Phase2Lifetime:       &phase2,
 						},
 					},
 				},
@@ -842,6 +844,41 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 		slog.String("vxc_uid", vxcUid),
 		slog.String("provisioning_status", vxc.ProvisioningStatus))
 	suite.Contains(SERVICE_STATE_READY, vxc.ProvisioningStatus, "vxc with ipsec tunnel did not reach a ready provisioning status")
+
+	// A READY VXC alone is a false positive — the API silently drops
+	// unrecognised partner config fields, so read the tunnel state back
+	// from the MCR's IPsec endpoint. Raw request until ESD-1311 adds a
+	// GetMCRIPsec wrapper.
+	req, reqErr := suite.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrUid), nil)
+	if reqErr != nil {
+		suite.FailNowf("cannot build ipsec read request", "cannot build ipsec read request %v", reqErr)
+	}
+	var ipsecRes struct {
+		Data struct {
+			TotalTunnelCount    int `json:"totalTunnelCount"`
+			IpSecConfiguredVxcs []struct {
+				ProductUid string `json:"productUid"`
+				Tunnels    []struct {
+					Description          string `json:"description"`
+					SourceIpAddress      string `json:"sourceIpAddress"`
+					DestinationIpAddress string `json:"destinationIpAddress"`
+				} `json:"tunnels"`
+			} `json:"ipSecConfiguredVxcs"`
+		} `json:"data"`
+	}
+	if _, doErr := suite.client.Do(ctx, req, &ipsecRes); doErr != nil {
+		suite.FailNowf("cannot read mcr ipsec config", "cannot read mcr ipsec config %v", doErr)
+	}
+
+	suite.Equal(1, ipsecRes.Data.TotalTunnelCount, "expected exactly one configured tunnel on the mcr")
+	suite.Require().Len(ipsecRes.Data.IpSecConfiguredVxcs, 1, "expected the vxc to appear in the mcr ipsec config")
+	configuredVxc := ipsecRes.Data.IpSecConfiguredVxcs[0]
+	suite.Equal(vxcUid, configuredVxc.ProductUid)
+	suite.Require().Len(configuredVxc.Tunnels, 1)
+	tunnel := configuredVxc.Tunnels[0]
+	suite.Equal("integration-test-tunnel", tunnel.Description)
+	suite.Equal("192.0.2.1", tunnel.SourceIpAddress)
+	suite.Equal("198.51.100.1", tunnel.DestinationIpAddress)
 }
 
 // TestAWSConnectionBuyDefaults tests the AWS connection buy process with default values.

--- a/vxc_integration_test.go
+++ b/vxc_integration_test.go
@@ -806,13 +806,13 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 						Description:   "integration-test-tunnel",
 						InterfaceType: InterfaceTypeIPSecTunnel,
 						IpAddresses:   []string{"192.0.2.1/30"},
-						IpSecTunnelOptions: &IPsecTunnelConfig{
+						IpSecTunnelOptions: []IPsecTunnelConfig{{
 							SourceIpAddress:      "192.0.2.1",
 							DestinationIpAddress: "198.51.100.1",
 							PreSharedKey:         "integrationTestKey123",
 							Phase1Lifetime:       &phase1,
 							Phase2Lifetime:       &phase2,
-						},
+						}},
 					},
 				},
 			},

--- a/vxc_integration_test.go
+++ b/vxc_integration_test.go
@@ -721,8 +721,8 @@ func (suite *VXCIntegrationTestSuite) TestAWSHostedConnectionBuy() {
 // TestMCRVXCWithIPsec provisions an MCR with the IPsec add-on, orders a VXC
 // off it whose A-End interface carries an IPsec tunnel config, verifies the
 // tunnel is actually configured on the MCR (not just that the VXC goes
-// live — the API silently drops unknown partner config fields), and tears
-// everything down.
+// live, since the API silently drops unknown partner config fields), and
+// tears everything down.
 func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 	vxcSvc := suite.client.VXCService
 	mcrSvc := suite.client.MCRService
@@ -810,6 +810,8 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 							SourceIpAddress:      "192.0.2.1",
 							DestinationIpAddress: "198.51.100.1",
 							PreSharedKey:         "integrationTestKey123",
+							LocalId:              "local.example.com",
+							RemoteId:             "remote.example.com",
 							Phase1Lifetime:       &phase1,
 							Phase2Lifetime:       &phase2,
 						}},
@@ -845,8 +847,8 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 		slog.String("provisioning_status", vxc.ProvisioningStatus))
 	suite.Contains(SERVICE_STATE_READY, vxc.ProvisioningStatus, "vxc with ipsec tunnel did not reach a ready provisioning status")
 
-	// A READY VXC alone is a false positive — the API silently drops
-	// unrecognised partner config fields, so read the tunnel state back
+	// A READY VXC alone is a false positive: the API silently drops
+	// unrecognized partner config fields, so read the tunnel state back
 	// from the MCR's IPsec endpoint. Raw request until ESD-1311 adds a
 	// GetMCRIPsec wrapper.
 	req, reqErr := suite.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrUid), nil)
@@ -862,6 +864,8 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 					Description          string `json:"description"`
 					SourceIpAddress      string `json:"sourceIpAddress"`
 					DestinationIpAddress string `json:"destinationIpAddress"`
+					LocalId              string `json:"localId"`
+					RemoteId             string `json:"remoteId"`
 				} `json:"tunnels"`
 			} `json:"ipSecConfiguredVxcs"`
 		} `json:"data"`
@@ -879,6 +883,8 @@ func (suite *VXCIntegrationTestSuite) TestMCRVXCWithIPsec() {
 	suite.Equal("integration-test-tunnel", tunnel.Description)
 	suite.Equal("192.0.2.1", tunnel.SourceIpAddress)
 	suite.Equal("198.51.100.1", tunnel.DestinationIpAddress)
+	suite.Equal("local.example.com", tunnel.LocalId)
+	suite.Equal("remote.example.com", tunnel.RemoteId)
 }
 
 // TestAWSConnectionBuyDefaults tests the AWS connection buy process with default values.

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -1423,23 +1423,25 @@ func (suite *VXCClientTestSuite) TestDecomissionedVXCMarshal() {
 }
 
 // TestMCRVXCWithIPsecTunnel verifies that an IPsec tunnel attached to an
-// MCR VXC A-End interface serialises to the wire format documented at
-// https://docs.megaport.com/mcr/ipsec-mcr/.
+// MCR VXC A-End interface serialises to the shape the API parses: a single
+// ipSecTunnelOptions object per interface with interfaceType "ipSecTunnel".
 func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 	phase1 := 28800
 	phase2 := 3600
+	passive := false
 	iface := PartnerConfigInterface{
-		IpAddresses: []string{"192.0.2.1/30"},
-		IpsecTunnels: []IPsecTunnelConfig{
-			{
-				Description:          "tunnel-a",
-				SourceIpAddress:      "192.0.2.1",
-				DestinationIpAddress: "198.51.100.1",
-				PreSharedKey:         "notARealKey12345",
-				StartAction:          IPsecStartActionPassive,
-				Phase1Lifetime:       &phase1,
-				Phase2Lifetime:       &phase2,
-			},
+		Description:   "tunnel-a",
+		InterfaceType: InterfaceTypeIPSecTunnel,
+		IpAddresses:   []string{"192.0.2.1/30"},
+		IpSecTunnelOptions: &IPsecTunnelConfig{
+			SourceIpAddress:      "192.0.2.1",
+			DestinationIpAddress: "198.51.100.1",
+			PreSharedKey:         "notARealKey12345",
+			Passive:              &passive,
+			LocalId:              "local.example.com",
+			RemoteId:             "remote.example.com",
+			Phase1Lifetime:       &phase1,
+			Phase2Lifetime:       &phase2,
 		},
 	}
 	cfg := VXCOrderVrouterPartnerConfig{Interfaces: []PartnerConfigInterface{iface}}
@@ -1448,41 +1450,49 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 	suite.NoError(err)
 
 	var got struct {
-		Interfaces []struct {
-			IpsecTunnels []map[string]any `json:"ipsecTunnels"`
-		} `json:"interfaces"`
+		Interfaces []map[string]any `json:"interfaces"`
 	}
 	suite.NoError(json.Unmarshal(raw, &got))
 	suite.Require().Len(got.Interfaces, 1)
-	suite.Require().Len(got.Interfaces[0].IpsecTunnels, 1)
 
-	tunnel := got.Interfaces[0].IpsecTunnels[0]
-	suite.Equal("tunnel-a", tunnel["description"])
+	gotIface := got.Interfaces[0]
+	suite.Equal("ipSecTunnel", gotIface["interfaceType"])
+	suite.Equal("tunnel-a", gotIface["description"])
+	_, hasLegacyKey := gotIface["ipsecTunnels"]
+	suite.False(hasLegacyKey, "legacy ipsecTunnels array must not be serialised")
+
+	tunnel, ok := gotIface["ipSecTunnelOptions"].(map[string]any)
+	suite.Require().True(ok, "expected ipSecTunnelOptions object")
 	suite.Equal("192.0.2.1", tunnel["sourceIpAddress"])
 	suite.Equal("198.51.100.1", tunnel["destinationIpAddress"])
 	suite.Equal("notARealKey12345", tunnel["preSharedKey"])
-	suite.Equal("passive", tunnel["startAction"])
+	suite.Equal(false, tunnel["passive"])
+	suite.Equal("local.example.com", tunnel["localId"])
+	suite.Equal("remote.example.com", tunnel["remoteId"])
 	suite.EqualValues(28800, tunnel["phase1Lifetime"])
 	suite.EqualValues(3600, tunnel["phase2Lifetime"])
+	_, hasStartAction := tunnel["startAction"]
+	suite.False(hasStartAction, "startAction is not an API field")
 
-	// Unset optional fields must be omitted from the wire payload.
+	// Unset optional fields must be omitted so the API defaults apply
+	// (notably passive, which the API defaults to true).
 	minimal := PartnerConfigInterface{
-		IpsecTunnels: []IPsecTunnelConfig{{
+		InterfaceType: InterfaceTypeIPSecTunnel,
+		IpSecTunnelOptions: &IPsecTunnelConfig{
 			SourceIpAddress:      "192.0.2.2",
 			DestinationIpAddress: "198.51.100.2",
 			PreSharedKey:         "anotherKey12345",
-		}},
+		},
 	}
 	raw, err = json.Marshal(minimal)
 	suite.NoError(err)
 	var minimalGot struct {
-		IpsecTunnels []map[string]any `json:"ipsecTunnels"`
+		IpSecTunnelOptions map[string]any `json:"ipSecTunnelOptions"`
 	}
 	suite.NoError(json.Unmarshal(raw, &minimalGot))
-	suite.Require().Len(minimalGot.IpsecTunnels, 1)
-	minimalTunnel := minimalGot.IpsecTunnels[0]
-	for _, key := range []string{"startAction", "phase1Lifetime", "phase2Lifetime", "description"} {
-		_, ok := minimalTunnel[key]
+	suite.Require().NotNil(minimalGot.IpSecTunnelOptions)
+	for _, key := range []string{"passive", "localId", "remoteId", "phase1Lifetime", "phase2Lifetime"} {
+		_, ok := minimalGot.IpSecTunnelOptions[key]
 		suite.False(ok, "expected key %q to be absent", key)
 	}
 }

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -1423,8 +1423,8 @@ func (suite *VXCClientTestSuite) TestDecomissionedVXCMarshal() {
 }
 
 // TestMCRVXCWithIPsecTunnel verifies that an IPsec tunnel attached to an
-// MCR VXC A-End interface serialises to the shape the API parses: a single
-// ipSecTunnelOptions object per interface with interfaceType "ipSecTunnel".
+// MCR VXC A-End interface serialises to the shape the API parses: an
+// ipSecTunnelOptions array on an interface with interfaceType "ipSecTunnel".
 func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 	phase1 := 28800
 	phase2 := 3600
@@ -1433,7 +1433,7 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 		Description:   "tunnel-a",
 		InterfaceType: InterfaceTypeIPSecTunnel,
 		IpAddresses:   []string{"192.0.2.1/30"},
-		IpSecTunnelOptions: &IPsecTunnelConfig{
+		IpSecTunnelOptions: []IPsecTunnelConfig{{
 			SourceIpAddress:      "192.0.2.1",
 			DestinationIpAddress: "198.51.100.1",
 			PreSharedKey:         "notARealKey12345",
@@ -1442,7 +1442,7 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 			RemoteId:             "remote.example.com",
 			Phase1Lifetime:       &phase1,
 			Phase2Lifetime:       &phase2,
-		},
+		}},
 	}
 	cfg := VXCOrderVrouterPartnerConfig{Interfaces: []PartnerConfigInterface{iface}}
 
@@ -1461,8 +1461,11 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 	_, hasLegacyKey := gotIface["ipsecTunnels"]
 	suite.False(hasLegacyKey, "legacy ipsecTunnels array must not be serialised")
 
-	tunnel, ok := gotIface["ipSecTunnelOptions"].(map[string]any)
-	suite.Require().True(ok, "expected ipSecTunnelOptions object")
+	tunnels, ok := gotIface["ipSecTunnelOptions"].([]any)
+	suite.Require().True(ok, "expected ipSecTunnelOptions to serialise as a JSON array")
+	suite.Require().Len(tunnels, 1)
+	tunnel, ok := tunnels[0].(map[string]any)
+	suite.Require().True(ok, "expected each ipSecTunnelOptions element to be an object")
 	suite.Equal("192.0.2.1", tunnel["sourceIpAddress"])
 	suite.Equal("198.51.100.1", tunnel["destinationIpAddress"])
 	suite.Equal("notARealKey12345", tunnel["preSharedKey"])
@@ -1478,21 +1481,21 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 	// (notably passive, which the API defaults to true).
 	minimal := PartnerConfigInterface{
 		InterfaceType: InterfaceTypeIPSecTunnel,
-		IpSecTunnelOptions: &IPsecTunnelConfig{
+		IpSecTunnelOptions: []IPsecTunnelConfig{{
 			SourceIpAddress:      "192.0.2.2",
 			DestinationIpAddress: "198.51.100.2",
 			PreSharedKey:         "anotherKey12345",
-		},
+		}},
 	}
 	raw, err = json.Marshal(minimal)
 	suite.NoError(err)
 	var minimalGot struct {
-		IpSecTunnelOptions map[string]any `json:"ipSecTunnelOptions"`
+		IpSecTunnelOptions []map[string]any `json:"ipSecTunnelOptions"`
 	}
 	suite.NoError(json.Unmarshal(raw, &minimalGot))
-	suite.Require().NotNil(minimalGot.IpSecTunnelOptions)
+	suite.Require().Len(minimalGot.IpSecTunnelOptions, 1)
 	for _, key := range []string{"passive", "localId", "remoteId", "phase1Lifetime", "phase2Lifetime"} {
-		_, ok := minimalGot.IpSecTunnelOptions[key]
+		_, ok := minimalGot.IpSecTunnelOptions[0][key]
 		suite.False(ok, "expected key %q to be absent", key)
 	}
 }

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -1498,6 +1498,25 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 		_, ok := minimalGot.IpSecTunnelOptions[0][key]
 		suite.False(ok, "expected key %q to be absent", key)
 	}
+
+	// The API accepts multiple tunnels per interface, so the field must
+	// serialise every element of the slice (not collapse to one object).
+	multi := PartnerConfigInterface{
+		InterfaceType: InterfaceTypeIPSecTunnel,
+		IpSecTunnelOptions: []IPsecTunnelConfig{
+			{SourceIpAddress: "192.0.2.3", DestinationIpAddress: "198.51.100.3", PreSharedKey: "firstKey12345678"},
+			{SourceIpAddress: "192.0.2.4", DestinationIpAddress: "198.51.100.4", PreSharedKey: "secondKey1234567"},
+		},
+	}
+	raw, err = json.Marshal(multi)
+	suite.NoError(err)
+	var multiGot struct {
+		IpSecTunnelOptions []map[string]any `json:"ipSecTunnelOptions"`
+	}
+	suite.NoError(json.Unmarshal(raw, &multiGot))
+	suite.Require().Len(multiGot.IpSecTunnelOptions, 2)
+	suite.Equal("192.0.2.3", multiGot.IpSecTunnelOptions[0]["sourceIpAddress"])
+	suite.Equal("192.0.2.4", multiGot.IpSecTunnelOptions[1]["sourceIpAddress"])
 }
 
 // TestListVXCs tests the ListVXCs method with various filters

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -330,37 +330,34 @@ type VXCOrderConfirmation struct {
 
 // PartnerConfigInterface represents the configuration of a partner interface.
 type PartnerConfigInterface struct {
-	Description     string                `json:"description,omitempty"`
-	InterfaceType   string                `json:"interfaceType,omitempty"` // InterfaceTypeSubInterface (default) or InterfaceTypeIPSecTunnel.
-	IpAddresses     []string              `json:"ipAddresses,omitempty"`
-	IpRoutes        []IpRoute             `json:"ipRoutes,omitempty"`
-	NatIpAddresses  []string              `json:"natIpAddresses,omitempty"`
-	Bfd             BfdConfig             `json:"bfd,omitempty"`
-	BgpConnections  []BgpConnectionConfig `json:"bgpConnections,omitempty"`
-	VLAN            int                   `json:"vlan,omitempty"`
-	IpMtu           int                   `json:"ipMtu,omitempty"`
-	PacketFilterIn  *int64                `json:"packetFilterIn,omitempty"`  // NAT Gateway packet filter ID to apply to inbound packets.
-	PacketFilterOut *int64                `json:"packetFilterOut,omitempty"` // NAT Gateway packet filter ID to apply to outbound packets.
-	IpsecTunnels    []IPsecTunnelConfig   `json:"ipsecTunnels,omitempty"`
+	Description        string                `json:"description,omitempty"`
+	InterfaceType      string                `json:"interfaceType,omitempty"` // InterfaceTypeSubInterface (default) or InterfaceTypeIPSecTunnel.
+	IpAddresses        []string              `json:"ipAddresses,omitempty"`
+	IpRoutes           []IpRoute             `json:"ipRoutes,omitempty"`
+	NatIpAddresses     []string              `json:"natIpAddresses,omitempty"`
+	Bfd                BfdConfig             `json:"bfd,omitempty"`
+	BgpConnections     []BgpConnectionConfig `json:"bgpConnections,omitempty"`
+	VLAN               int                   `json:"vlan,omitempty"`
+	IpMtu              int                   `json:"ipMtu,omitempty"`
+	PacketFilterIn     *int64                `json:"packetFilterIn,omitempty"`     // NAT Gateway packet filter ID to apply to inbound packets.
+	PacketFilterOut    *int64                `json:"packetFilterOut,omitempty"`    // NAT Gateway packet filter ID to apply to outbound packets.
+	IpSecTunnelOptions *IPsecTunnelConfig    `json:"ipSecTunnelOptions,omitempty"` // Requires InterfaceType to be InterfaceTypeIPSecTunnel.
 }
 
-// IPsec start action values used by IPsecTunnelConfig.StartAction.
-const (
-	IPsecStartActionActive  = "active"
-	IPsecStartActionPassive = "passive"
-)
-
-// IPsecTunnelConfig represents an IPsec tunnel interface attached to a VXC
-// A-End interface on an MCR. See https://docs.megaport.com/mcr/ipsec-mcr/.
-// The MCR must have an IPsec add-on provisioned (see MCRAddOnIPsecConfig).
+// IPsecTunnelConfig represents the IPsec tunnel options for a VXC A-End
+// interface on an MCR (one tunnel per interface). See
+// https://docs.megaport.com/mcr/ipsec-mcr/. The MCR must have an IPsec
+// add-on provisioned (see MCRAddOnIPsecConfig). The tunnel takes its
+// description from the enclosing PartnerConfigInterface.Description.
 type IPsecTunnelConfig struct {
-	Description          string `json:"description,omitempty"`
 	SourceIpAddress      string `json:"sourceIpAddress"`
 	DestinationIpAddress string `json:"destinationIpAddress"`
 	PreSharedKey         string `json:"preSharedKey"`
-	StartAction          string `json:"startAction,omitempty"`    // IPsecStartActionActive or IPsecStartActionPassive
-	Phase1Lifetime       *int   `json:"phase1Lifetime,omitempty"` // seconds, 300-604800, API default 28800
-	Phase2Lifetime       *int   `json:"phase2Lifetime,omitempty"` // seconds, 300-604800, must be < Phase1Lifetime, API default 3600
+	Passive              *bool  `json:"passive,omitempty"`        // nil applies the API default (true)
+	LocalId              string `json:"localId,omitempty"`        // IKE local identifier override, for peers behind NAT
+	RemoteId             string `json:"remoteId,omitempty"`       // IKE remote identifier override, for peers behind NAT
+	Phase1Lifetime       *int   `json:"phase1Lifetime,omitempty"` // seconds, 3600-604800, API default 28800
+	Phase2Lifetime       *int   `json:"phase2Lifetime,omitempty"` // seconds, 600-86400, must be < Phase1Lifetime, API default 3600
 }
 
 // IpRoute represents an IP route.

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -341,13 +341,14 @@ type PartnerConfigInterface struct {
 	IpMtu              int                   `json:"ipMtu,omitempty"`
 	PacketFilterIn     *int64                `json:"packetFilterIn,omitempty"`     // NAT Gateway packet filter ID to apply to inbound packets.
 	PacketFilterOut    *int64                `json:"packetFilterOut,omitempty"`    // NAT Gateway packet filter ID to apply to outbound packets.
-	IpSecTunnelOptions *IPsecTunnelConfig    `json:"ipSecTunnelOptions,omitempty"` // Requires InterfaceType to be InterfaceTypeIPSecTunnel.
+	IpSecTunnelOptions []IPsecTunnelConfig   `json:"ipSecTunnelOptions,omitempty"` // Requires InterfaceType to be InterfaceTypeIPSecTunnel.
 }
 
-// IPsecTunnelConfig represents the IPsec tunnel options for a VXC A-End
-// interface on an MCR (one tunnel per interface). See
+// IPsecTunnelConfig represents a single IPsec tunnel on a VXC A-End
+// interface on an MCR. An interface carries a list of these
+// (PartnerConfigInterface.IpSecTunnelOptions). See
 // https://docs.megaport.com/mcr/ipsec-mcr/. The MCR must have an IPsec
-// add-on provisioned (see MCRAddOnIPsecConfig). The tunnel takes its
+// add-on provisioned (see MCRAddOnIPsecConfig). Tunnels take their
 // description from the enclosing PartnerConfigInterface.Description.
 type IPsecTunnelConfig struct {
 	SourceIpAddress      string `json:"sourceIpAddress"`


### PR DESCRIPTION
The IPsec tunnel config added in #140 didn't match the shape the API parses. Unrecognized partner config fields are silently dropped, so the VXC ordered fine but no tunnel was configured.

- Send `ipSecTunnelOptions` as an array of tunnels per interface (the API accepts multiple), replacing the wrongly-named/shaped `ipsecTunnels`
- Replace `startAction` with `passive` (`*bool`, nil = API default of true); `startAction` is not an API field
- Add `localId` / `remoteId` (IKE identifier overrides for peers behind NAT)
- Correct the interface-type constants to the camelCase values the API matches: `InterfaceTypeIPSecTunnel` -> `"ipSecTunnel"`, `InterfaceTypeSubInterface` -> `"subInterface"`
- Drop `Description` from the tunnel config; the API takes the tunnel description from the interface-level `description`
- Integration test now reads `GET /v3/products/mcrs/{uid}/ipsec` back and asserts the tunnel exists, instead of only checking the VXC reaches READY (a false positive when fields are dropped). Raw request until ESD-1311 adds `GetMCRIPsec`. Unit test covers the multi-tunnel case.

**Breaking change (v1 public API).** The old shape never worked, but it shipped as exported API from v1.12.0 through the current v1.13.1, so this must be released as a breaking change. Removed: `IpsecTunnels`, `StartAction`, `Description`, and the `IPsecStartActionActive` / `IPsecStartActionPassive` constants. Changed values: `InterfaceTypeSubInterface` (`"SUBINTERFACE"` -> `"subInterface"`) and `InterfaceTypeIPSecTunnel` (`"IPSEC_TUNNEL"` -> `"ipSecTunnel"`).
