### PR TITLE
ESD-1311: Add GetMCRIPsec method

### DIFF
--- a/client.go
+++ b/client.go
@@ -421,8 +421,9 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 		// Base64 encode the response body
 		encodedBody := base64.StdEncoding.EncodeToString(b)
 
-		// Create new reader for the later code
+		// Reset the body so later decode paths and callers can re-read it
 		respBody = io.NopCloser(bytes.NewReader(b))
+		resp.Body = respBody
 
 		attrs = append(attrs, slog.String("response_body_base_64", encodedBody))
 	}

--- a/client.go
+++ b/client.go
@@ -413,9 +413,12 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 		slog.String("trace_id", resp.Header.Get(headerTraceId))}
 
 	if c.LogResponseBody {
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
+		b, readErr := io.ReadAll(resp.Body)
+		// Close the original network body once it has been drained; the
+		// caller only sees the in-memory replacement below.
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
 		}
 
 		// Base64 encode the response body

--- a/client.go
+++ b/client.go
@@ -446,15 +446,13 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 
 	tmpDisable := ctx.Value(disableResponseBodyLogging) != nil
 	if c.LogResponseBody && !tmpDisable {
-		b, readErr := io.ReadAll(resp.Body)
-		// Close the original network body once it has been drained; the
-		// caller only sees the in-memory replacement below.
+		b, err := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		if readErr != nil {
-			return nil, readErr
+		if err != nil {
+			return nil, err
 		}
 
-		// Reset the body so later decode paths and callers can re-read it
+		// Create new reader for the later code
 		respBody = io.NopCloser(bytes.NewReader(b))
 		resp.Body = respBody
 

--- a/errors.go
+++ b/errors.go
@@ -111,6 +111,9 @@ var ErrMCRNotFound = errors.New("mcr not found or deleted")
 // ErrMCRDecommissioned is returned when an MCR has been decommissioned.
 var ErrMCRDecommissioned = errors.New("mcr has been decommissioned")
 
+// ErrMCRIPsecNoData is returned when GetMCRIPsec gets a successful response with no data payload.
+var ErrMCRIPsecNoData = errors.New("mcr ipsec response contained no data")
+
 // IsServiceNotFoundError reports whether err is a Megaport API not-found response —
 // either HTTP 404 or the non-standard HTTP 400 "Could not find a service with UID" form.
 func IsServiceNotFoundError(err error) bool {

--- a/mcr.go
+++ b/mcr.go
@@ -46,6 +46,9 @@ type MCRService interface {
 	UpdateMCRWithAddOn(ctx context.Context, mcrID string, req MCRAddOnRequest) error
 	// UpdateMCRIPsecAddOn updates an existing IPsec add-on on an MCR. Setting tunnelCount to 0 will disable IPsec.
 	UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error
+	// GetMCRIPsec returns the IPsec tunnel configuration for an MCR. The response
+	// never includes the pre-shared key or phase lifetimes.
+	GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPsecConfiguration, error)
 	// WaitForMCRReady polls until the MCR reaches a ready provisioning state.
 	// A zero timeout defaults to 5 minutes. Returns ErrMCRNotFound or ErrMCRDecommissioned
 	// if the MCR is deleted or decommissioned while polling.
@@ -706,6 +709,38 @@ func (svc *MCRServiceOp) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 	}
 	_, err = svc.Client.Do(ctx, clientReq, nil)
 	return err
+}
+
+// GetMCRIPsec returns the IPsec tunnel configuration for an MCR.
+// GET /v3/products/mcrs/{productUid}/ipsec
+// The response never includes the pre-shared key or phase lifetimes — those
+// cannot be read back after ordering.
+func (svc *MCRServiceOp) GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPsecConfiguration, error) {
+	url := "/v3/products/mcrs/" + mcrID + "/ipsec"
+
+	clientReq, err := svc.Client.NewRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := svc.Client.Do(ctx, clientReq, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, fileErr := io.ReadAll(response.Body)
+	if fileErr != nil {
+		return nil, fileErr
+	}
+
+	ipsecRes := &mcrIPsecResponse{}
+	unmarshalErr := json.Unmarshal(body, ipsecRes)
+	if unmarshalErr != nil {
+		return nil, unmarshalErr
+	}
+
+	return ipsecRes.Data, nil
 }
 
 // WaitForMCRReady polls until the MCR identified by mcrID reaches a ready

--- a/mcr.go
+++ b/mcr.go
@@ -713,7 +713,7 @@ func (svc *MCRServiceOp) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 
 // GetMCRIPsec returns the IPsec tunnel configuration for an MCR.
 // GET /v3/products/mcrs/{productUid}/ipsec
-// The response never includes the pre-shared key or phase lifetimes — those
+// The response never includes the pre-shared key or phase lifetimes: those
 // cannot be read back after ordering.
 func (svc *MCRServiceOp) GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPsecConfiguration, error) {
 	url := "/v3/products/mcrs/" + mcrID + "/ipsec"

--- a/mcr.go
+++ b/mcr.go
@@ -740,6 +740,10 @@ func (svc *MCRServiceOp) GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPs
 		return nil, unmarshalErr
 	}
 
+	if ipsecRes.Data == nil {
+		return nil, fmt.Errorf("%w (trace_id %q)", ErrMCRIPsecNoData, response.Header.Get(headerTraceId))
+	}
+
 	return ipsecRes.Data, nil
 }
 

--- a/mcr.go
+++ b/mcr.go
@@ -47,8 +47,7 @@ type MCRService interface {
 	UpdateMCRWithAddOn(ctx context.Context, mcrID string, req MCRAddOnRequest) error
 	// UpdateMCRIPsecAddOn updates an existing IPsec add-on on an MCR. Setting tunnelCount to 0 will disable IPsec.
 	UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error
-	// GetMCRIPsec returns the IPsec tunnel configuration for an MCR. The response
-	// never includes the pre-shared key or phase lifetimes.
+	// GetMCRIPsec returns the IPsec tunnel configuration for an MCR.
 	GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPsecConfiguration, error)
 	// WaitForMCRReady polls until the MCR reaches a ready provisioning state.
 	// A zero timeout defaults to 5 minutes. Returns ErrMCRNotFound or ErrMCRDecommissioned
@@ -719,8 +718,6 @@ func (svc *MCRServiceOp) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 
 // GetMCRIPsec returns the IPsec tunnel configuration for an MCR.
 // GET /v3/products/mcrs/{productUid}/ipsec
-// The response never includes the pre-shared key or phase lifetimes: those
-// cannot be read back after ordering.
 func (svc *MCRServiceOp) GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPsecConfiguration, error) {
 	path := "/v3/products/mcrs/" + url.PathEscape(mcrID) + "/ipsec"
 

--- a/mcr.go
+++ b/mcr.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -716,9 +717,9 @@ func (svc *MCRServiceOp) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 // The response never includes the pre-shared key or phase lifetimes: those
 // cannot be read back after ordering.
 func (svc *MCRServiceOp) GetMCRIPsec(ctx context.Context, mcrID string) (*MCRIPsecConfiguration, error) {
-	url := "/v3/products/mcrs/" + mcrID + "/ipsec"
+	path := "/v3/products/mcrs/" + url.PathEscape(mcrID) + "/ipsec"
 
-	clientReq, err := svc.Client.NewRequest(ctx, "GET", url, nil)
+	clientReq, err := svc.Client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -595,7 +595,7 @@ func (suite *MCRIntegrationTestSuite) TestMCRWithIPsecAddOn() {
 	}
 	suite.EqualValues("MCR with IPsec", mcr.Name)
 
-	// Read back IPsec state — no VXCs yet, so no configured tunnels
+	// Read back IPsec state: no VXCs yet, so no configured tunnels
 	logger.InfoContext(ctx, "Getting MCR IPsec configuration", slog.String("mcr_id", mcrId))
 	ipsec, ipsecErr := mcrSvc.GetMCRIPsec(ctx, mcrId)
 	if ipsecErr != nil {

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -604,7 +604,6 @@ func (suite *MCRIntegrationTestSuite) TestMCRWithIPsecAddOn() {
 	suite.NotNil(ipsec)
 	suite.Empty(ipsec.IPsecConfiguredVXCs)
 	suite.EqualValues(0, ipsec.TotalTunnelCount)
-	suite.Positive(ipsec.MaxTunnelCountLimit)
 
 	// Delete MCR
 	logger.InfoContext(ctx, "Deleting MCR now", slog.String("mcr_id", mcrId))

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -595,6 +595,17 @@ func (suite *MCRIntegrationTestSuite) TestMCRWithIPsecAddOn() {
 	}
 	suite.EqualValues("MCR with IPsec", mcr.Name)
 
+	// Read back IPsec state — no VXCs yet, so no configured tunnels
+	logger.InfoContext(ctx, "Getting MCR IPsec configuration", slog.String("mcr_id", mcrId))
+	ipsec, ipsecErr := mcrSvc.GetMCRIPsec(ctx, mcrId)
+	if ipsecErr != nil {
+		suite.FailNowf("could not get mcr ipsec", "could not get mcr ipsec %v", ipsecErr)
+	}
+	suite.NotNil(ipsec)
+	suite.Empty(ipsec.IPsecConfiguredVXCs)
+	suite.EqualValues(0, ipsec.TotalTunnelCount)
+	suite.Positive(ipsec.MaxTunnelCountLimit)
+
 	// Delete MCR
 	logger.InfoContext(ctx, "Deleting MCR now", slog.String("mcr_id", mcrId))
 	hardDeleteRes, deleteErr := mcrSvc.DeleteMCR(ctx, &DeleteMCRRequest{

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -189,12 +189,10 @@ func (suite *MCRClientTestSuite) TestGetMCR() {
 	suite.Equal(want, got)
 }
 
-// TestGetMCRIPsec tests the GetMCRIPsec method.
-func (suite *MCRClientTestSuite) TestGetMCRIPsec() {
-	ctx := context.Background()
-	mcrSvc := suite.client.MCRService
-	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
-	want := &MCRIPsecConfiguration{
+// mcrIPsecFixture returns a populated IPsec response body and the configuration
+// it should decode into, shared by tests that need a non-trivial payload.
+func mcrIPsecFixture() (jblob string, want *MCRIPsecConfiguration) {
+	want = &MCRIPsecConfiguration{
 		IPsecConfiguredVXCs: []IPsecConfiguredVXC{
 			{
 				Name:       "VXC-12345",
@@ -218,7 +216,7 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsec() {
 		TotalTunnelCount:    2,
 		MaxTunnelCountLimit: 10,
 	}
-	jblob := `{
+	jblob = `{
 		"message": "test-message",
 		"terms": "This data is subject to the Acceptable Use Policy https://www.megaport.com/legal/acceptable-use-policy",
 		"data": {
@@ -246,6 +244,15 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsec() {
 			"maxTunnelCountLimit": 10
 		}
 	}`
+	return jblob, want
+}
+
+// TestGetMCRIPsec tests the GetMCRIPsec method.
+func (suite *MCRClientTestSuite) TestGetMCRIPsec() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	jblob, want := mcrIPsecFixture()
 	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodGet)
 		fmt.Fprint(w, jblob)
@@ -280,30 +287,23 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsecNoVXCs() {
 	suite.Equal(10, got.MaxTunnelCountLimit)
 }
 
-// TestGetMCRIPsecWithLogResponseBody ensures the response body survives the
-// LogResponseBody debug path in Client.Do and can still be read by the caller.
+// TestGetMCRIPsecWithLogResponseBody ensures the full response body survives the
+// LogResponseBody debug path in Client.Do and decodes intact for the caller.
+// It uses the populated fixture so a truncated or corrupted body would change the
+// decoded result, not just the trailing field.
 func (suite *MCRClientTestSuite) TestGetMCRIPsecWithLogResponseBody() {
 	ctx := context.Background()
 	suite.client.LogResponseBody = true
 	mcrSvc := suite.client.MCRService
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
-	jblob := `{
-		"message": "test-message",
-		"terms": "test-terms",
-		"data": {
-			"ipSecConfiguredVxcs": [],
-			"totalTunnelCount": 0,
-			"maxTunnelCountLimit": 10
-		}
-	}`
+	jblob, want := mcrIPsecFixture()
 	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodGet)
 		fmt.Fprint(w, jblob)
 	})
 	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
 	suite.NoError(err)
-	suite.NotNil(got)
-	suite.Equal(10, got.MaxTunnelCountLimit)
+	suite.Equal(want, got)
 }
 
 // TestGetMCRIPsecNotFound tests error handling when the MCR does not exist.
@@ -318,6 +318,7 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsecNotFound() {
 	})
 	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
 	suite.Error(err)
+	suite.True(IsServiceNotFoundError(err))
 	suite.Nil(got)
 }
 

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -189,6 +189,97 @@ func (suite *MCRClientTestSuite) TestGetMCR() {
 	suite.Equal(want, got)
 }
 
+// TestGetMCRIPsec tests the GetMCRIPsec method.
+func (suite *MCRClientTestSuite) TestGetMCRIPsec() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	want := &MCRIPsecConfiguration{
+		IPsecConfiguredVXCs: []IPsecConfiguredVXC{
+			{
+				Name:       "VXC-12345",
+				ProductUID: "123e4567-e89b-12d3-a456-426614174000",
+				Tunnels: []IPsecTunnel{
+					{
+						Description:          "Primary IPsec tunnel",
+						SourceIpAddress:      "192.168.1.2",
+						DestinationIpAddress: "192.200.1.2",
+						LocalID:              "local-peer-id",
+						RemoteID:             "remote-peer-id",
+						VLAN:                 100,
+					},
+					{
+						SourceIpAddress:      "192.168.1.6",
+						DestinationIpAddress: "192.200.1.6",
+					},
+				},
+			},
+		},
+		TotalTunnelCount:    2,
+		MaxTunnelCountLimit: 10,
+	}
+	jblob := `{
+		"message": "test-message",
+		"terms": "This data is subject to the Acceptable Use Policy https://www.megaport.com/legal/acceptable-use-policy",
+		"data": {
+			"ipSecConfiguredVxcs": [
+				{
+					"name": "VXC-12345",
+					"productUid": "123e4567-e89b-12d3-a456-426614174000",
+					"tunnels": [
+						{
+							"description": "Primary IPsec tunnel",
+							"sourceIpAddress": "192.168.1.2",
+							"destinationIpAddress": "192.200.1.2",
+							"localId": "local-peer-id",
+							"remoteId": "remote-peer-id",
+							"vlan": 100
+						},
+						{
+							"sourceIpAddress": "192.168.1.6",
+							"destinationIpAddress": "192.200.1.6"
+						}
+					]
+				}
+			],
+			"totalTunnelCount": 2,
+			"maxTunnelCountLimit": 10
+		}
+	}`
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, jblob)
+	})
+	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
+	suite.NoError(err)
+	suite.Equal(want, got)
+}
+
+// TestGetMCRIPsecNoVXCs tests GetMCRIPsec when no VXCs have IPsec tunnels configured.
+func (suite *MCRClientTestSuite) TestGetMCRIPsecNoVXCs() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	jblob := `{
+		"message": "test-message",
+		"terms": "test-terms",
+		"data": {
+			"ipSecConfiguredVxcs": [],
+			"totalTunnelCount": 0,
+			"maxTunnelCountLimit": 10
+		}
+	}`
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, jblob)
+	})
+	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
+	suite.NoError(err)
+	suite.Empty(got.IPsecConfiguredVXCs)
+	suite.Equal(0, got.TotalTunnelCount)
+	suite.Equal(10, got.MaxTunnelCountLimit)
+}
+
 // TestCreatePrefixFilterList tests the CreatePrefixFilterList method.
 func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -321,6 +321,21 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsecNotFound() {
 	suite.Nil(got)
 }
 
+// TestGetMCRIPsecNoData ensures a 2xx response without a data payload returns
+// ErrMCRIPsecNoData rather than a nil configuration that callers would panic on.
+func (suite *MCRClientTestSuite) TestGetMCRIPsecNoData() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, `{"message": "test-message", "terms": "test-terms"}`)
+	})
+	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
+	suite.ErrorIs(err, ErrMCRIPsecNoData)
+	suite.Nil(got)
+}
+
 // TestCreatePrefixFilterList tests the CreatePrefixFilterList method.
 func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -280,6 +280,20 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsecNoVXCs() {
 	suite.Equal(10, got.MaxTunnelCountLimit)
 }
 
+// TestGetMCRIPsecNotFound tests error handling when the MCR does not exist.
+func (suite *MCRClientTestSuite) TestGetMCRIPsecNotFound() {
+	ctx := context.Background()
+	mcrSvc := suite.client.MCRService
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message": "MCR not found", "data": ""}`)
+	})
+	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
+	suite.Error(err)
+	suite.Nil(got)
+}
+
 // TestCreatePrefixFilterList tests the CreatePrefixFilterList method.
 func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -280,12 +280,39 @@ func (suite *MCRClientTestSuite) TestGetMCRIPsecNoVXCs() {
 	suite.Equal(10, got.MaxTunnelCountLimit)
 }
 
+// TestGetMCRIPsecWithLogResponseBody ensures the response body survives the
+// LogResponseBody debug path in Client.Do and can still be read by the caller.
+func (suite *MCRClientTestSuite) TestGetMCRIPsecWithLogResponseBody() {
+	ctx := context.Background()
+	suite.client.LogResponseBody = true
+	mcrSvc := suite.client.MCRService
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	jblob := `{
+		"message": "test-message",
+		"terms": "test-terms",
+		"data": {
+			"ipSecConfiguredVxcs": [],
+			"totalTunnelCount": 0,
+			"maxTunnelCountLimit": 10
+		}
+	}`
+	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, jblob)
+	})
+	got, err := mcrSvc.GetMCRIPsec(ctx, mcrId)
+	suite.NoError(err)
+	suite.NotNil(got)
+	suite.Equal(10, got.MaxTunnelCountLimit)
+}
+
 // TestGetMCRIPsecNotFound tests error handling when the MCR does not exist.
 func (suite *MCRClientTestSuite) TestGetMCRIPsecNotFound() {
 	ctx := context.Background()
 	mcrSvc := suite.client.MCRService
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	suite.mux.HandleFunc(fmt.Sprintf("/v3/products/mcrs/%s/ipsec", mcrId), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"message": "MCR not found", "data": ""}`)
 	})

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -179,7 +179,7 @@ type mcrResponse struct {
 type MCRIPsecConfiguration struct {
 	IPsecConfiguredVXCs []IPsecConfiguredVXC `json:"ipSecConfiguredVxcs"`
 	TotalTunnelCount    int                  `json:"totalTunnelCount"`
-	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"`
+	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"` // 0 if the API omits it; the platform default limit is currently 10
 }
 
 // IPsecConfiguredVXC is a VXC on an MCR with configured IPsec tunnels.
@@ -197,7 +197,7 @@ type IPsecTunnel struct {
 	DestinationIpAddress string `json:"destinationIpAddress"`
 	LocalID              string `json:"localId,omitempty"`
 	RemoteID             string `json:"remoteId,omitempty"`
-	VLAN                 int    `json:"vlan,omitempty"`
+	VLAN                 int    `json:"vlan"`
 }
 
 // mcrIPsecResponse represents a response from the Megaport MCR API after querying an MCR's IPsec configuration.

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -174,6 +174,40 @@ type mcrResponse struct {
 	Data    *MCR   `json:"data"`
 }
 
+// MCRIPsecConfiguration is the IPsec tunnel state for an MCR. The API never
+// returns the pre-shared key or phase lifetimes, so they are absent here.
+type MCRIPsecConfiguration struct {
+	IPsecConfiguredVXCs []IPsecConfiguredVXC `json:"ipSecConfiguredVxcs"`
+	TotalTunnelCount    int                  `json:"totalTunnelCount"`
+	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"`
+}
+
+// IPsecConfiguredVXC is a VXC on an MCR with configured IPsec tunnels.
+type IPsecConfiguredVXC struct {
+	Name       string        `json:"name"`
+	ProductUID string        `json:"productUid"`
+	Tunnels    []IPsecTunnel `json:"tunnels"`
+}
+
+// IPsecTunnel is a configured IPsec tunnel as read back from the API.
+// Unlike IPsecTunnelConfig, it carries no pre-shared key or phase lifetimes.
+type IPsecTunnel struct {
+	Description          string `json:"description,omitempty"`
+	SourceIpAddress      string `json:"sourceIpAddress"`
+	DestinationIpAddress string `json:"destinationIpAddress"`
+	LocalID              string `json:"localId,omitempty"`
+	RemoteID             string `json:"remoteId,omitempty"`
+	VLAN                 int    `json:"vlan,omitempty"`
+}
+
+// mcrIPsecResponse represents a response from the Megaport MCR API after querying an MCR's IPsec configuration.
+// Used internally for JSON unmarshalling.
+type mcrIPsecResponse struct {
+	Message string                 `json:"message"`
+	Terms   string                 `json:"terms"`
+	Data    *MCRIPsecConfiguration `json:"data"`
+}
+
 // PrefixFilterList represents a prefix filter list associated with an MCR.
 type PrefixFilterList struct {
 	Id            int    `json:"id"`

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -179,7 +179,7 @@ type mcrResponse struct {
 type MCRIPsecConfiguration struct {
 	IPsecConfiguredVXCs []IPsecConfiguredVXC `json:"ipSecConfiguredVxcs"`
 	TotalTunnelCount    int                  `json:"totalTunnelCount"`
-	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"` // 0 if the API omits it; the platform default limit is currently 10
+	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"` // 0 if the API omits it
 }
 
 // IPsecConfiguredVXC is a VXC on an MCR with configured IPsec tunnels.

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -175,8 +175,7 @@ type mcrResponse struct {
 	Data    *MCR   `json:"data"`
 }
 
-// MCRIPsecConfiguration is the IPsec tunnel state for an MCR. The API never
-// returns the pre-shared key or phase lifetimes, so they are absent here.
+// MCRIPsecConfiguration is the IPsec tunnel state for an MCR.
 type MCRIPsecConfiguration struct {
 	IPsecConfiguredVXCs []IPsecConfiguredVXC `json:"ipSecConfiguredVxcs"`
 	TotalTunnelCount    int                  `json:"totalTunnelCount"`

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -179,7 +179,7 @@ type mcrResponse struct {
 type MCRIPsecConfiguration struct {
 	IPsecConfiguredVXCs []IPsecConfiguredVXC `json:"ipSecConfiguredVxcs"`
 	TotalTunnelCount    int                  `json:"totalTunnelCount"`
-	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"` // 0 if the API omits it
+	MaxTunnelCountLimit int                  `json:"maxTunnelCountLimit"` // 0 when the API omits it; the effective limit then defaults to 10
 }
 
 // IPsecConfiguredVXC is a VXC on an MCR with configured IPsec tunnels.


### PR DESCRIPTION
Adds `MCRService.GetMCRIPsec` wrapping `GET /v3/products/mcrs/{uid}/ipsec` — the only way to read IPsec tunnel state back after ordering, which the Terraform provider needs for Read/import/drift detection.

- New types `MCRIPsecConfiguration`, `IPsecConfiguredVXC`, `IPsecTunnel` per the spec
- Doc comments note the PSK and phase lifetimes are never returned
- Unit tests with mocked responses; `TestMCRWithIPsecAddOn` integration test now reads back IPsec state

Jira: [ESD-1311](https://megaportcloud.atlassian.net/browse/ESD-1311)

[ESD-1311]: https://megaportcloud.atlassian.net/browse/ESD-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ