### PR TITLE
ESD-1325: Add WithTokenURL client option for custom OAuth token endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -532,7 +532,7 @@ func (c *Client) Authorize(ctx context.Context) (*AuthInfo, error) {
 			tokenURL = "https://auth-m2m.megaport.com/oauth2/token"
 		case "api-staging.megaport.com":
 			tokenURL = "https://auth-m2m-staging.megaport.com/oauth2/token"
-		case "":
+		case "api-mpone-dev.megaport.com":
 			tokenURL = "https://auth-m2m-mpone-dev.megaport.com/oauth2/token"
 		default:
 			return nil, errors.New("unknown API environment")

--- a/client.go
+++ b/client.go
@@ -100,6 +100,7 @@ type Client struct {
 
 	accessToken string    // Access Token for client
 	tokenExpiry time.Time // Token Expiration
+	tokenURL    string    // Optional override for the OAuth token endpoint
 
 	LogResponseBody bool // Log Response Body of HTTP Requests
 
@@ -320,6 +321,15 @@ func WithTokenProvider(tp TokenProvider) ClientOpt {
 	}
 }
 
+// WithTokenURL overrides the OAuth token endpoint used by Authorize. When set, the host-based
+// environment switch is bypassed entirely, allowing non-standard base URLs (e.g. localhost) to authenticate.
+func WithTokenURL(tokenURL string) ClientOpt {
+	return func(c *Client) error {
+		c.tokenURL = tokenURL
+		return nil
+	}
+}
+
 // NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
@@ -515,17 +525,18 @@ func (c *Client) Authorize(ctx context.Context) (*AuthInfo, error) {
 	authHeader := base64.StdEncoding.EncodeToString([]byte(c.AccessKey + ":" + c.SecretKey))
 
 	// Set the URL for the token endpoint
-	var tokenURL string
-
-	switch c.BaseURL.Host {
-	case "api.megaport.com":
-		tokenURL = "https://auth-m2m.megaport.com/oauth2/token"
-	case "api-staging.megaport.com":
-		tokenURL = "https://auth-m2m-staging.megaport.com/oauth2/token"
-	case "":
-		tokenURL = "https://auth-m2m-mpone-dev.megaport.com/oauth2/token"
-	default:
-		return nil, errors.New("unknown API environment")
+	tokenURL := c.tokenURL
+	if tokenURL == "" {
+		switch c.BaseURL.Host {
+		case "api.megaport.com":
+			tokenURL = "https://auth-m2m.megaport.com/oauth2/token"
+		case "api-staging.megaport.com":
+			tokenURL = "https://auth-m2m-staging.megaport.com/oauth2/token"
+		case "":
+			tokenURL = "https://auth-m2m-mpone-dev.megaport.com/oauth2/token"
+		default:
+			return nil, errors.New("unknown API environment")
+		}
 	}
 
 	// Create form data for the request body

--- a/client_test.go
+++ b/client_test.go
@@ -485,6 +485,28 @@ func (suite *ClientTestSuite) TestAuthorize_tokenProviderError() {
 	suite.Contains(err.Error(), "failed to get token from provider")
 }
 
+// TestAuthorize_withTokenURL tests that WithTokenURL bypasses the host switch and reaches the custom endpoint.
+func (suite *ClientTestSuite) TestAuthorize_withTokenURL() {
+	var tokenEndpointHit bool
+	suite.mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenEndpointHit = true
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"custom-token","token_type":"Bearer","expires_in":3600}`)
+	})
+
+	c, err := New(nil,
+		WithBaseURL(suite.server.URL),
+		WithCredentials("test-key", "test-secret"),
+		WithTokenURL(suite.server.URL+"/oauth2/token"),
+	)
+	suite.Require().NoError(err)
+
+	authInfo, err := c.Authorize(ctx)
+	suite.Require().NoError(err)
+	suite.True(tokenEndpointHit, "custom token endpoint should have been called")
+	suite.Equal("custom-token", authInfo.AccessToken)
+}
+
 // TestDo_withTokenProvider tests a full request cycle using TokenProvider.
 func (suite *ClientTestSuite) TestDo_withTokenProvider() {
 	type response struct {


### PR DESCRIPTION
`Client.Authorize` previously hard-coded the OAuth token URL by matching `BaseURL.Host` against three known values, returning an error for any other host. This blocked the `--base-url` flag (ESD-1325) from working against local dev servers or megatest environments.

Adds a `WithTokenURL(string)` client option that overrides the token endpoint. When set, `Authorize` uses the supplied URL directly and skips the host switch entirely. Existing behaviour for the three known hosts is unchanged.

- Add `tokenURL` field to `Client`
- Add `WithTokenURL` client option
- Update `Authorize` to check `c.tokenURL` before the environment switch
- Unit test: client with `WithBaseURL("http://localhost")` + `WithTokenURL` hits the custom endpoint and returns a token