### PR TITLE
ESD-1357 Stop logging credentials and auth tokens.

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,12 @@ import (
 
 type Environment string
 
+type disableResponseBodyLoggingKey string
+
+const (
+	disableResponseBodyLogging disableResponseBodyLoggingKey = "disable_response_body_logging"
+)
+
 const (
 	EnvironmentStaging     Environment = "https://api-staging.megaport.com/"
 	EnvironmentProduction  Environment = "https://api.megaport.com/"
@@ -333,7 +339,7 @@ func WithTokenURL(tokenURL string) ClientOpt {
 // NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
-func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body any) (*http.Request, error) {
 	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
@@ -402,7 +408,7 @@ func (c *Client) SetOnRequestCompleted(rc RequestCompletionCallback) {
 // Do sends an API request and returns the API response. The API response is JSON decoded and stored in the value
 // pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
 // the raw response will be written to v, without attempting to decode it.
-func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*http.Response, error) {
+func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Response, error) {
 	reqStart := time.Now()
 	resp, err := DoRequestWithClient(ctx, c.HTTPClient, req)
 	if err != nil {
@@ -422,18 +428,20 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 		slog.String("method", req.Method),
 		slog.String("trace_id", resp.Header.Get(headerTraceId))}
 
-	if c.LogResponseBody {
+	tmpDisable := ctx.Value(disableResponseBodyLogging) != nil
+	if c.LogResponseBody && !tmpDisable {
 		b, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, err
 		}
 
-		// Base64 encode the response body
-		encodedBody := base64.StdEncoding.EncodeToString(b)
-
 		// Create new reader for the later code
 		respBody = io.NopCloser(bytes.NewReader(b))
+		resp.Body = respBody
 
+		// Base64 encode the response body
+		encodedBody := base64.StdEncoding.EncodeToString(b)
 		attrs = append(attrs, slog.String("response_body_base_64", encodedBody))
 	}
 
@@ -506,8 +514,6 @@ func (c *Client) Authorize(ctx context.Context) (*AuthInfo, error) {
 		return &AuthInfo{AccessToken: token}, nil
 	}
 
-	c.Logger.DebugContext(ctx, "authorizing client using access key and secret key", slog.String("access_key", c.AccessKey))
-
 	// Shortcut if we've already authenticated.
 	if time.Now().Before(c.tokenExpiry) {
 		return &AuthInfo{Expiration: c.tokenExpiry, AccessToken: c.accessToken}, nil
@@ -556,8 +562,10 @@ func (c *Client) Authorize(ctx context.Context) (*AuthInfo, error) {
 	clientReq.Header.Set("Authorization", "Basic "+authHeader)
 
 	// Create an HTTP client and send the request
-	c.Logger.DebugContext(ctx, "login request", slog.String("token_url", tokenURL), slog.String("authorization_header", clientReq.Header.Get("Authorization")), slog.String("content_type", clientReq.Header.Get("Content_Type")))
-	resp, err := c.Do(ctx, clientReq, nil)
+	c.Logger.DebugContext(ctx, "login request", slog.String("token_url", tokenURL), slog.String("content_type", clientReq.Header.Get("Content-Type")))
+	// Temporarily disable response body logging to prevent sensitive information being leaked.
+	tmpContext := context.WithValue(ctx, disableResponseBodyLogging, true)
+	resp, err := c.Do(tmpContext, clientReq, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -224,6 +225,71 @@ func (suite *ClientTestSuite) TestDo() {
 	expected := &foo{"a"}
 	if !reflect.DeepEqual(body, expected) {
 		suite.FailNowf("", "Response body = %v, expected %v", *body, expected)
+	}
+}
+
+type myLogHandler struct {
+	m                     *sync.Mutex
+	messagesAndAttributes []string
+}
+
+func (mlh *myLogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (mlh *myLogHandler) Handle(ctx context.Context, r slog.Record) error {
+	mlh.m.Lock()
+	defer mlh.m.Unlock()
+
+	mlh.messagesAndAttributes = append(mlh.messagesAndAttributes, r.Message)
+	r.Attrs(
+		func(a slog.Attr) bool {
+			mlh.messagesAndAttributes = append(mlh.messagesAndAttributes, a.String())
+			return true
+		},
+	)
+
+	return nil
+}
+
+func (mlh *myLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return mlh
+}
+
+func (mlh *myLogHandler) WithGroup(name string) slog.Handler { return mlh }
+
+func (suite *ClientTestSuite) TestLogging() {
+	// Authorize() calls Do() which in turn logs response body if this functionality is enabled.
+	// Here we create custom slog handler to capture what's being logged
+	// and verify that response body isn't logged for auth request specifically.
+
+	customToken := "deadc0de"
+	responseBody := fmt.Sprintf(`{"access_token":"%s","token_type":"Bearer","expires_in":3600}`, customToken)
+
+	lh := &myLogHandler{
+		m:                     &sync.Mutex{},
+		messagesAndAttributes: make([]string, 0),
+	}
+
+	c, err := New(nil,
+		WithBaseURL(suite.server.URL),
+		WithCredentials("test-key", "test-secret"),
+		WithTokenURL(suite.server.URL+"/oauth2/token"),
+		WithLogResponseBody(),
+		WithLogHandler(lh),
+	)
+	suite.Require().NoError(err)
+
+	suite.mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, responseBody)
+	})
+
+	authInfo, err := c.Authorize(context.Background())
+	suite.Require().NoError(err)
+	suite.Equal(customToken, authInfo.AccessToken)
+
+	for _, msg := range lh.messagesAndAttributes {
+		haveResponseBody := strings.Contains(msg, "response_body_base_64")
+		suite.Require().False(haveResponseBody)
 	}
 }
 


### PR DESCRIPTION
## Description

Fixed a few instances where auth tokens and secrets were logged directly.
Also, enabling response body logging no longer applies to authorisation request to prevent sensitive information leakage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

