### PR TITLE
ci: add govulncheck workflow and pin toolchain to go1.26.4

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,24 @@
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0  # Pin to avoid CI drift
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26.4'  # Keep in sync with the toolchain directive in go.mod
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0  # Pin to avoid CI drift
       - name: Run govulncheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
           cache: false
       - name: Run linters
         # Pinned to a SHA whitelisted for the org — any new SHA must be

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,13 +16,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26.4'  # Keep in sync with the toolchain directive in go.mod
           cache: false
       - name: Run linters
         # Pinned to a SHA whitelisted for the org — any new SHA must be
         # whitelisted before it will run, so bumps must be allowlisted first.
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
         with:
-          version: 'v2.3.1' # Use golangci-lint v2 to match config version
+          version: 'v2.12.2' # golangci-lint v2, built with a Go new enough to target the go1.26.4 toolchain
           args: --timeout=10m
           skip-cache: true # Disable golangci-lint-action's cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.26.4'  # Keep in sync with the toolchain directive in go.mod
       - name: Run Tests
         run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
       - name: Run Tests
         run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/megaport/megaportgo
 
 go 1.21
 
+toolchain go1.26.4
+
 require (
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/stretchr/testify v1.11.1

--- a/product.go
+++ b/product.go
@@ -544,7 +544,7 @@ func isNilPriceBookRequest(req PriceBookRequest) bool {
 	}
 	v := reflect.ValueOf(req)
 	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Interface, reflect.Slice:
 		return v.IsNil()
 	default:
 		return false


### PR DESCRIPTION
Adds a `govulncheck` CI job and pins the toolchain to `go1.26.4` in `go.mod`.

Running govulncheck on the old toolchain (go1.26.1) surfaced 10 reachable stdlib vulnerabilities in the HTTP/TLS/x509/mail stack, all via `Client.Do` and `DoRequestWithClient`. Bumping to go1.26.4 clears all of them; the scan is clean with no code or dependency changes needed.

To make CI actually run on 1.26.4:
- Pin `go-version: '1.26.4'` in all three workflows (lint, test, govulncheck). setup-go's `go-version-file` reads the `go` directive (1.21), not the `toolchain` line, so it can't pick up 1.26.4 on its own, and raising the `go` directive would force the bump onto every SDK consumer.
- Bump golangci-lint to v2.12.2. v2.3.1 is built with go1.24 and refuses to lint a module targeting go1.26.4.
- The newer linter flagged a deprecated `reflect.Ptr` alias in `product.go`; switched it to `reflect.Pointer`.