### PR TITLE
ESD-1546: Close response body on Do error returns

### DIFF
--- a/client.go
+++ b/client.go
@@ -414,6 +414,14 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
+	// Close the body on every error return below so we don't leak the
+	// connection. On success the caller owns the body.
+	success := false
+	defer func() {
+		if !success {
+			_ = resp.Body.Close()
+		}
+	}()
 	if c.onRequestCompleted != nil {
 		c.onRequestCompleted(req, resp)
 	}
@@ -466,6 +474,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 		}
 	}
 
+	success = true
 	return resp, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -439,10 +439,10 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 	tmpDisable := ctx.Value(disableResponseBodyLogging) != nil
 	if c.LogResponseBody && !tmpDisable {
 		b, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
 		if err != nil {
 			return nil, err
 		}
+		_ = resp.Body.Close()
 
 		// Create new reader for the later code
 		respBody = io.NopCloser(bytes.NewReader(b))
@@ -476,6 +476,17 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 
 	success = true
 	return resp, nil
+}
+
+// doDiscard runs Do for callers that ignore the response payload, draining
+// and closing the body so the connection is not leaked.
+func (c *Client) doDiscard(ctx context.Context, req *http.Request) error {
+	resp, err := c.Do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.Body.Close()
 }
 
 type AuthInfo struct {

--- a/client.go
+++ b/client.go
@@ -502,7 +502,10 @@ func (c *Client) doDiscard(ctx context.Context, req *http.Request) error {
 		return err
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
-	return resp.Body.Close()
+	// A close error here means the connection was already broken, not that the
+	// request failed, so it must not turn a completed mutation into an error.
+	_ = resp.Body.Close()
+	return nil
 }
 
 type AuthInfo struct {

--- a/client_close_test.go
+++ b/client_close_test.go
@@ -1,0 +1,56 @@
+package megaport
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+type closeCountingBody struct {
+	*strings.Reader
+	closes *int32
+}
+
+func (b closeCountingBody) Close() error {
+	atomic.AddInt32(b.closes, 1)
+	return nil
+}
+
+// Do must close the response body on its error-return paths, otherwise the
+// underlying connection leaks.
+func TestDoClosesBodyOnError(t *testing.T) {
+	var closes int32
+
+	c, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	u, _ := url.Parse("https://example.test")
+	c.BaseURL = u
+	c.HTTPClient = &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       closeCountingBody{Reader: strings.NewReader(`{"message":"bad request"}`), closes: &closes},
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+
+	req, err := c.NewRequest(ctx, http.MethodGet, "/x", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if _, err := c.Do(ctx, req, nil); err == nil {
+		t.Fatal("expected Do to return an error for a 400 response")
+	}
+	if got := atomic.LoadInt32(&closes); got < 1 {
+		t.Fatalf("response body not closed on error return (Close called %d times)", got)
+	}
+}

--- a/client_close_test.go
+++ b/client_close_test.go
@@ -1,6 +1,7 @@
 package megaport
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -52,5 +53,76 @@ func TestDoClosesBodyOnError(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&closes); got < 1 {
 		t.Fatalf("response body not closed on error return (Close called %d times)", got)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestDoClosesBodyOnCopyError(t *testing.T) {
+	var closes int32
+
+	c, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	u, _ := url.Parse("https://example.test")
+	c.BaseURL = u
+	c.HTTPClient = &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       closeCountingBody{Reader: strings.NewReader(`some body`), closes: &closes},
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+
+	req, err := c.NewRequest(ctx, http.MethodGet, "/x", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if _, err := c.Do(ctx, req, failingWriter{}); err == nil {
+		t.Fatal("expected Do to return an error when io.Copy fails")
+	}
+	if got := atomic.LoadInt32(&closes); got != 1 {
+		t.Fatalf("response body not closed exactly once on error return (Close called %d times)", got)
+	}
+}
+
+func TestDoClosesBodyOnDecodeError(t *testing.T) {
+	var closes int32
+
+	c, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	u, _ := url.Parse("https://example.test")
+	c.BaseURL = u
+	c.HTTPClient = &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       closeCountingBody{Reader: strings.NewReader(`not json`), closes: &closes},
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+
+	req, err := c.NewRequest(ctx, http.MethodGet, "/x", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var target struct {
+		Message string `json:"message"`
+	}
+	if _, err := c.Do(ctx, req, &target); err == nil {
+		t.Fatal("expected Do to return an error for malformed JSON")
+	}
+	if got := atomic.LoadInt32(&closes); got != 1 {
+		t.Fatalf("response body not closed exactly once on error return (Close called %d times)", got)
 	}
 }

--- a/client_close_test.go
+++ b/client_close_test.go
@@ -1,7 +1,9 @@
 package megaport
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -53,6 +55,41 @@ func TestDoClosesBodyOnError(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&closes); got < 1 {
 		t.Fatalf("response body not closed on error return (Close called %d times)", got)
+	}
+}
+
+type errCloseBody struct {
+	*strings.Reader
+}
+
+func (errCloseBody) Close() error { return errors.New("close failed") }
+
+// A close error means the connection was already broken, not that the request
+// failed. doDiscard backs mutations whose response payload is ignored, so it
+// must not report one as a failed mutation.
+func TestDoDiscardIgnoresCloseError(t *testing.T) {
+	c, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	u, _ := url.Parse("https://example.test")
+	c.BaseURL = u
+	c.HTTPClient = &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       errCloseBody{Reader: strings.NewReader(`{"message":"deleted"}`)},
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+
+	req, err := c.NewRequest(ctx, http.MethodDelete, "/x", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if err := c.doDiscard(ctx, req); err != nil {
+		t.Fatalf("doDiscard surfaced a close error for a successful request: %v", err)
 	}
 }
 
@@ -121,6 +158,44 @@ func TestDoClosesBodyOnDecodeError(t *testing.T) {
 	}
 	if _, err := c.Do(ctx, req, &target); err == nil {
 		t.Fatal("expected Do to return an error for malformed JSON")
+	}
+	if got := atomic.LoadInt32(&closes); got != 1 {
+		t.Fatalf("response body not closed exactly once on error return (Close called %d times)", got)
+	}
+}
+
+// With response-body logging on, Do closes the body itself and swaps in a
+// replacement reader, so the deferred close lands on the replacement. The
+// original body must still be closed exactly once.
+func TestDoClosesBodyOnErrorWithResponseLogging(t *testing.T) {
+	var closes int32
+
+	logCapture := &bytes.Buffer{}
+	c, err := New(nil,
+		WithLogResponseBody(),
+		WithLogHandler(NewLevelFilterHandler(slog.LevelDebug, slog.NewJSONHandler(logCapture, nil))),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	u, _ := url.Parse("https://example.test")
+	c.BaseURL = u
+	c.HTTPClient = &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       closeCountingBody{Reader: strings.NewReader(`{"message":"bad request"}`), closes: &closes},
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+
+	req, err := c.NewRequest(ctx, http.MethodGet, "/x", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if _, err := c.Do(ctx, req, nil); err == nil {
+		t.Fatal("expected Do to return an error for a 400 response")
 	}
 	if got := atomic.LoadInt32(&closes); got != 1 {
 		t.Fatalf("response body not closed exactly once on error return (Close called %d times)", got)

--- a/mcr.go
+++ b/mcr.go
@@ -565,7 +565,7 @@ func (svc *MCRServiceOp) DeleteMCRPrefixFilterList(ctx context.Context, mcrID st
 	if err != nil {
 		return nil, err
 	}
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	if err != nil {
 		return nil, err
 	}
@@ -581,7 +581,7 @@ func (svc *MCRServiceOp) ModifyMCRPrefixFilterList(ctx context.Context, mcrID st
 	if err != nil {
 		return nil, err
 	}
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +669,7 @@ func (svc *MCRServiceOp) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 		if err != nil {
 			return err
 		}
-		_, err = svc.Client.Do(ctx, clientReq, nil)
+		err = svc.Client.doDiscard(ctx, clientReq)
 		if err != nil {
 			return err
 		}
@@ -704,7 +704,7 @@ func (svc *MCRServiceOp) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 	if err != nil {
 		return err
 	}
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	return err
 }
 

--- a/product.go
+++ b/product.go
@@ -277,7 +277,7 @@ func (svc *ProductServiceOp) ModifyProduct(ctx context.Context, req *ModifyProdu
 		return nil, err
 	}
 
-	if _, err := svc.Client.Do(ctx, httpReq, nil); err != nil {
+	if err := svc.Client.doDiscard(ctx, httpReq); err != nil {
 		return nil, err
 	}
 	return &ModifyProductResponse{IsUpdated: true}, nil
@@ -313,7 +313,7 @@ func (svc *ProductServiceOp) DeleteProduct(ctx context.Context, req *DeleteProdu
 		return nil, err
 	}
 
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (svc *ProductServiceOp) RestoreProduct(ctx context.Context, productId strin
 	if err != nil {
 		return nil, err
 	}
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (svc *ProductServiceOp) ManageProductLock(ctx context.Context, req *ManageP
 		return nil, err
 	}
 
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (svc *ProductServiceOp) ValidateProductOrder(ctx context.Context, requestBo
 		return err
 	}
 
-	_, resErr := svc.Client.Do(ctx, req, nil)
+	resErr := svc.Client.doDiscard(ctx, req)
 	if resErr != nil {
 		return resErr
 	}
@@ -419,7 +419,7 @@ func (svc *ProductServiceOp) UpdateProductResourceTags(ctx context.Context, prod
 		return err
 	}
 
-	_, err = svc.Client.Do(ctx, clientReq, nil)
+	err = svc.Client.doDiscard(ctx, clientReq)
 	if err != nil {
 		return err
 	}

--- a/service_keys.go
+++ b/service_keys.go
@@ -286,7 +286,7 @@ func (svc *ServiceKeyServiceOp) UpdateServiceKey(ctx context.Context, req *Updat
 	if err != nil {
 		return nil, err
 	}
-	_, resErr := svc.Client.Do(ctx, clientReq, nil)
+	resErr := svc.Client.doDiscard(ctx, clientReq)
 	if resErr != nil {
 		return nil, resErr
 	}


### PR DESCRIPTION
`Client.Do` returned on its error paths (failed `CheckResponse`, or a copy / decode error) without closing `resp.Body`, leaking the underlying connection.

Adds a deferred close guarded by a `success` flag so the body is released on every error return. On success the caller still owns the body, so behavior there is unchanged.

`doDiscard`, which backs the mutations whose response payload is ignored, no longer returns the body-close error. A close failure means the connection was already broken, not that the request failed, so it must not turn a completed mutation into a reported failure.

Includes regression tests that assert the body is closed when `Do` returns an error, that the original body is still closed exactly once when response-body logging swaps in a replacement reader, and that `doDiscard` ignores a close error. The first and last fail without the fix.
