### PR TITLE
ESD-1554: accept string and null dates in Time.UnmarshalJSON

### DIFF
--- a/shared_types.go
+++ b/shared_types.go
@@ -2,6 +2,9 @@ package megaport
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -52,18 +55,79 @@ var (
 	SERVICE_STATE_READY = []string{SERVICE_CONFIGURED, SERVICE_LIVE}
 )
 
-// Time is a custom time type that allows for unmarshalling of Unix timestamps.
+// Time is a custom time type for Megaport API timestamps.
 type Time struct {
 	time.Time
 }
 
-// UnmarshalJSON unmarshals a Unix timestamp into a Time type.
+// timeStringLayouts are the date string formats the Megaport API is known to
+// return across environments, tried in order.
+var timeStringLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+}
+
+// minEpochMillis and maxEpochMillis bound the range in which a quoted digit
+// string is accepted as an epoch-millisecond timestamp (2000-01-01 to
+// 2100-01-01 UTC). Outside it, a digit string is likelier a compact date
+// (e.g. "20260629" or "20260629010203") than an epoch. No date layout matches
+// a bare digit string, so such input errors rather than silently decoding to a
+// 1970-era or far-future timestamp.
+const (
+	minEpochMillis = 946684800000  // 2000-01-01T00:00:00Z
+	maxEpochMillis = 4102444800000 // 2100-01-01T00:00:00Z
+)
+
+// epochMillisToTime converts Unix epoch milliseconds to a time.Time, keeping
+// the numeric path's historical host-local zone so existing responses decode
+// exactly as before; only the new string and null forms are additive.
+func epochMillisToTime(ms int64) time.Time {
+	return time.Unix(ms/1000, 0)
+}
+
+// UnmarshalJSON parses a Megaport API timestamp. The API usually sends Unix
+// epoch milliseconds as a JSON number, but some endpoints and environments
+// send an ISO 8601 date string (or null) instead. Accepting all of these stops
+// a single string-valued date from failing the decode of an entire response.
 func (t *Time) UnmarshalJSON(b []byte) error {
-	var timestamp int64
-	err := json.Unmarshal(b, &timestamp)
-	if err != nil {
+	s := strings.TrimSpace(string(b))
+	if s == "" || s == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+
+	// Numeric form: Unix epoch milliseconds.
+	if s[0] != '"' {
+		var ms int64
+		if err := json.Unmarshal(b, &ms); err != nil {
+			return err
+		}
+		t.Time = epochMillisToTime(ms)
+		return nil
+	}
+
+	// String form: a quoted epoch or a date string.
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
 		return err
 	}
-	t.Time = time.Unix(timestamp/1000, 0) // Divide by 1000 to convert from milliseconds to seconds
-	return nil
+	str = strings.TrimSpace(str)
+	if str == "" {
+		t.Time = time.Time{}
+		return nil
+	}
+	if ms, err := strconv.ParseInt(str, 10, 64); err == nil && ms >= minEpochMillis && ms < maxEpochMillis {
+		t.Time = epochMillisToTime(ms)
+		return nil
+	}
+	for _, layout := range timeStringLayouts {
+		if parsed, err := time.Parse(layout, str); err == nil {
+			t.Time = parsed
+			return nil
+		}
+	}
+	return fmt.Errorf("megaport: cannot parse %q as a timestamp", str)
 }

--- a/shared_types.go
+++ b/shared_types.go
@@ -64,7 +64,6 @@ type Time struct {
 // return across environments, tried in order.
 var timeStringLayouts = []string{
 	time.RFC3339Nano,
-	time.RFC3339,
 	// Colonless numeric offset (e.g. "+0000"), the form Jackson-based
 	// backends emit; RFC3339 layouts only match "+00:00".
 	"2006-01-02T15:04:05.999999999Z0700",

--- a/shared_types.go
+++ b/shared_types.go
@@ -65,6 +65,9 @@ type Time struct {
 var timeStringLayouts = []string{
 	time.RFC3339Nano,
 	time.RFC3339,
+	// Colonless numeric offset (e.g. "+0000"), the form Jackson-based
+	// backends emit; RFC3339 layouts only match "+00:00".
+	"2006-01-02T15:04:05.999999999Z0700",
 	"2006-01-02T15:04:05",
 	"2006-01-02 15:04:05",
 	"2006-01-02",

--- a/shared_types_test.go
+++ b/shared_types_test.go
@@ -1,0 +1,118 @@
+package megaport
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Time
+		zero    bool
+		wantErr bool
+	}{
+		{name: "epoch milliseconds number", input: `1700000000000`, want: time.Unix(1700000000, 0)},
+		{name: "zero number", input: `0`, want: time.Unix(0, 0)},
+		{name: "epoch milliseconds string", input: `"1700000000000"`, want: time.Unix(1700000000, 0)},
+		{name: "rfc3339 string", input: `"2026-06-29T01:02:03Z"`, want: time.Date(2026, 6, 29, 1, 2, 3, 0, time.UTC)},
+		{name: "rfc3339 with offset", input: `"2026-06-29T01:02:03+10:00"`, want: time.Date(2026, 6, 29, 1, 2, 3, 0, time.FixedZone("", 10*3600))},
+		{name: "date only string", input: `"2026-06-29"`, want: time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC)},
+		{name: "null", input: `null`, zero: true},
+		{name: "empty string", input: `""`, zero: true},
+		{name: "unparseable string", input: `"not-a-date"`, wantErr: true},
+		{name: "compact digit string is not treated as epoch", input: `"20260629"`, wantErr: true},
+		{name: "compact datetime string is not treated as epoch", input: `"20260629010203"`, wantErr: true},
+		{name: "quoted epoch at min bound", input: `"946684800000"`, want: time.Unix(946684800, 0)},
+		{name: "quoted epoch just below min bound errors", input: `"946684799999"`, wantErr: true},
+		{name: "quoted epoch just below max bound", input: `"4102444799999"`, want: time.Unix(4102444799, 0)},
+		{name: "quoted epoch at max bound errors", input: `"4102444800000"`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Time
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.zero {
+				assert.True(t, got.IsZero(), "expected zero time, got %s", got)
+				return
+			}
+			assert.True(t, got.Equal(tt.want), "got %s, want %s", got, tt.want)
+		})
+	}
+}
+
+// A string-valued date must not fail decoding of the whole struct, which was
+// the original fragility (the unmarshaller only accepted numbers). Covers both
+// a pointer field (e.g. Port.CreateDate) and a value field (UserActivity), and
+// pins the null handling for each.
+func TestTimeUnmarshalInStruct(t *testing.T) {
+	type ptrField struct {
+		Name       string `json:"name"`
+		CreateDate *Time  `json:"createDate"`
+	}
+	type valueField struct {
+		CreateDate Time `json:"createDate"`
+	}
+
+	t.Run("pointer field with string date", func(t *testing.T) {
+		var p ptrField
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"port-1","createDate":"2026-06-29T00:00:00Z"}`), &p))
+		assert.Equal(t, "port-1", p.Name)
+		require.NotNil(t, p.CreateDate)
+		assert.Equal(t, 2026, p.CreateDate.Year())
+	})
+
+	t.Run("pointer field null stays nil", func(t *testing.T) {
+		var p ptrField
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"port-1","createDate":null}`), &p))
+		assert.Nil(t, p.CreateDate)
+	})
+
+	t.Run("value field with string date", func(t *testing.T) {
+		var v valueField
+		require.NoError(t, json.Unmarshal([]byte(`{"createDate":"2026-06-29T00:00:00Z"}`), &v))
+		assert.Equal(t, 2026, v.CreateDate.Year())
+	})
+
+	// Deliberate change: null on a value Time field now yields the Go zero
+	// time (IsZero), where older code decoded null to the 1970 epoch.
+	t.Run("value field null is zero time", func(t *testing.T) {
+		var v valueField
+		require.NoError(t, json.Unmarshal([]byte(`{"createDate":null}`), &v))
+		assert.True(t, v.CreateDate.IsZero())
+	})
+}
+
+// Decoding must not normalize zones: epoch inputs keep the host-local zone of
+// the historical numeric path, and string inputs keep the zone they were
+// written in. Guards against re-introducing UTC normalization, which would
+// churn downstream consumers that format these times into stored state.
+func TestTimeUnmarshalPreservesZone(t *testing.T) {
+	decode := func(in string) Time {
+		var got Time
+		require.NoError(t, json.Unmarshal([]byte(in), &got))
+		return got
+	}
+
+	// Epoch, as a number and as a quoted string, stays host-local (time.Unix).
+	assert.Equal(t, time.Local, decode(`1700000000000`).Location())
+	assert.Equal(t, time.Local, decode(`"1700000000000"`).Location())
+
+	// Zulu and date-only strings parse as UTC.
+	assert.Equal(t, time.UTC, decode(`"2026-06-29T01:02:03Z"`).Location())
+	assert.Equal(t, time.UTC, decode(`"2026-06-29"`).Location())
+
+	// An explicit offset is preserved, not converted to UTC.
+	_, offset := decode(`"2026-06-29T01:02:03+10:00"`).Zone()
+	assert.Equal(t, 10*3600, offset)
+}

--- a/shared_types_test.go
+++ b/shared_types_test.go
@@ -22,6 +22,8 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 		{name: "epoch milliseconds string", input: `"1700000000000"`, want: time.Unix(1700000000, 0)},
 		{name: "rfc3339 string", input: `"2026-06-29T01:02:03Z"`, want: time.Date(2026, 6, 29, 1, 2, 3, 0, time.UTC)},
 		{name: "rfc3339 with offset", input: `"2026-06-29T01:02:03+10:00"`, want: time.Date(2026, 6, 29, 1, 2, 3, 0, time.FixedZone("", 10*3600))},
+		{name: "colonless offset with millis", input: `"2026-06-29T01:02:03.000+0000"`, want: time.Date(2026, 6, 29, 1, 2, 3, 0, time.UTC)},
+		{name: "colonless offset without millis", input: `"2026-06-29T01:02:03+1000"`, want: time.Date(2026, 6, 29, 1, 2, 3, 0, time.FixedZone("", 10*3600))},
 		{name: "date only string", input: `"2026-06-29"`, want: time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC)},
 		{name: "null", input: `null`, zero: true},
 		{name: "empty string", input: `""`, zero: true},

--- a/shared_types_test.go
+++ b/shared_types_test.go
@@ -71,7 +71,7 @@ func TestTimeUnmarshalInStruct(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(`{"name":"port-1","createDate":"2026-06-29T00:00:00Z"}`), &p))
 		assert.Equal(t, "port-1", p.Name)
 		require.NotNil(t, p.CreateDate)
-		assert.Equal(t, 2026, p.CreateDate.Year())
+		assert.True(t, p.CreateDate.Equal(time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC)))
 	})
 
 	t.Run("pointer field null stays nil", func(t *testing.T) {
@@ -83,7 +83,7 @@ func TestTimeUnmarshalInStruct(t *testing.T) {
 	t.Run("value field with string date", func(t *testing.T) {
 		var v valueField
 		require.NoError(t, json.Unmarshal([]byte(`{"createDate":"2026-06-29T00:00:00Z"}`), &v))
-		assert.Equal(t, 2026, v.CreateDate.Year())
+		assert.True(t, v.CreateDate.Equal(time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC)))
 	})
 
 	// Deliberate change: null on a value Time field now yields the Go zero


### PR DESCRIPTION
## Description

`Time.UnmarshalJSON` only decoded JSON numbers (Unix epoch milliseconds). Any date value that arrived as a string made the unmarshal error out, and that error failed the decode of the whole response, surfacing to users as an empty resource list. The `Time` type backs date fields on ports, VXCs, MCRs, MVEs, IXs, service keys, and locations, so this affects every list/get path.

Note: the spec is not uniform here. The product DTOs declare these dates as non-nullable epoch-millisecond integers, so for ports, VXCs, MCRs, MVEs and service keys this is defensive broadening rather than a documented mismatch. But `MegaportLocation.liveDate`, behind `GET /v2/locations`, is a documented `date-time` string that the SDK decodes into `Location.LiveDate *Time`, so at least one mapping would have failed on the old numeric-only path. That the v2 location methods are deprecated is probably why nobody hit it. Either way this costs nothing on the unchanged numeric path.

The unmarshaller now also accepts:

- RFC3339 / ISO 8601 date strings, with or without offset, plus date-only
- a quoted numeric epoch (e.g. `"1700000000000"`)
- `null` / empty, mapped to the zero time

The plain numeric epoch path is unchanged, so existing responses decode exactly as before (same timezone, same precision). A single string-valued date can no longer empty a list. A quoted digit string outside the year 2000-2100 epoch-millisecond window is treated as a date rather than an epoch, so a compact date like `20260629` or `20260629010203` can't silently decode to a 1970-era or far-future timestamp. Truly unparseable values still return an error.

Adds table-driven tests for each input form plus struct-level regression tests covering null on both pointer and value `Time` fields.

No CHANGELOG entry: the file is organized by released version with no Unreleased section, so entries are added at release time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Contributor Agreement

[I have read and accept the CLA]
