### PR TITLE
ESD-1551: add marketplace visibility to the MCR buy request

### DIFF
--- a/mcr.go
+++ b/mcr.go
@@ -79,8 +79,11 @@ type BuyMCRRequest struct {
 	MCRAsn        int
 	CostCentre    string
 	PromoCode     string
-	ResourceTags  map[string]string `json:"resourceTags,omitempty"`
-	AddOns        []MCRAddOn        `json:"addOns,omitempty"`
+	// MarketplaceVisibility is sent only when non-nil. Leaving it nil omits the
+	// field so the API applies its own default, rather than forcing false.
+	MarketplaceVisibility *bool
+	ResourceTags          map[string]string `json:"resourceTags,omitempty"`
+	AddOns                []MCRAddOn        `json:"addOns,omitempty"`
 
 	WaitForProvision bool          // Wait until the MCR provisions before returning
 	WaitForTime      time.Duration // How long to wait for the MCR to provision if WaitForProvision is true (default is 5 minutes; must be at least 30 seconds for the poller to fire)
@@ -277,6 +280,8 @@ func createMCROrder(req *BuyMCRRequest) []MCROrder {
 		PromoCode:    req.PromoCode,
 		ResourceTags: toProductResourceTags(req.ResourceTags),
 		Config:       MCROrderConfig{},
+
+		MarketplaceVisibility: req.MarketplaceVisibility,
 	}
 
 	if req.CostCentre != "" {

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -42,12 +42,13 @@ func (suite *MCRClientTestSuite) TestBuyMCR() {
 	productUid := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	want := &BuyMCRResponse{TechnicalServiceUID: productUid}
 	req := &BuyMCRRequest{
-		LocationID:    1,
-		Name:          "test-mcr",
-		Term:          1,
-		PortSpeed:     1000,
-		MCRAsn:        0,
-		DiversityZone: "red",
+		LocationID:            1,
+		Name:                  "test-mcr",
+		Term:                  1,
+		PortSpeed:             1000,
+		MCRAsn:                0,
+		DiversityZone:         "red",
+		MarketplaceVisibility: PtrTo(false),
 	}
 	jblob := `{
 			"message": "test-message",
@@ -68,6 +69,7 @@ func (suite *MCRClientTestSuite) TestBuyMCR() {
 				DiversityZone: "red",
 				ASN:           0,
 			},
+			MarketplaceVisibility: PtrTo(false),
 		},
 	}
 	suite.mux.HandleFunc("/v4/networkdesign/buy", func(w http.ResponseWriter, r *http.Request) {
@@ -90,11 +92,34 @@ func (suite *MCRClientTestSuite) TestBuyMCR() {
 		suite.Equal(wantOrder.LocationID, gotOrder.LocationID)
 		suite.Equal(wantOrder.Type, gotOrder.Type)
 		suite.Equal(wantOrder.Config, gotOrder.Config)
+		suite.Equal(wantOrder.MarketplaceVisibility, gotOrder.MarketplaceVisibility)
 		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	got, err := mcrSvc.BuyMCR(ctx, req)
 	suite.NoError(err)
 	suite.Equal(want, got)
+}
+
+// TestCreateMCROrderMarketplaceVisibility asserts the marshaled MCROrder carries
+// marketplaceVisibility when set, and omits it (preserving the API default) when
+// the request leaves it nil.
+func (suite *MCRClientTestSuite) TestCreateMCROrderMarketplaceVisibility() {
+	visible := suite.marshalMCROrder(&BuyMCRRequest{MarketplaceVisibility: PtrTo(true)})
+	suite.Contains(visible, `"marketplaceVisibility":true`)
+
+	hidden := suite.marshalMCROrder(&BuyMCRRequest{MarketplaceVisibility: PtrTo(false)})
+	suite.Contains(hidden, `"marketplaceVisibility":false`)
+
+	unset := suite.marshalMCROrder(&BuyMCRRequest{})
+	suite.NotContains(unset, "marketplaceVisibility")
+}
+
+func (suite *MCRClientTestSuite) marshalMCROrder(req *BuyMCRRequest) string {
+	orders := createMCROrder(req)
+	suite.Require().Len(orders, 1)
+	b, err := json.Marshal(orders[0])
+	suite.Require().NoError(err)
+	return string(b)
 }
 
 // TestGetMCR tests the GetMCR method.

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -4,15 +4,16 @@ import "strconv"
 
 // MCROrder represents a request to buy an MCR from the Megaport Products API.
 type MCROrder struct {
-	LocationID int            `json:"locationId"`
-	Name       string         `json:"productName"`
-	Term       int            `json:"term"`
-	Type       string         `json:"productType"`
-	PortSpeed  int            `json:"portSpeed"`
-	CostCentre string         `json:"costCentre"`
-	PromoCode  string         `json:"promoCode,omitempty"`
-	Config     MCROrderConfig `json:"config"`
-	AddOns     []MCRAddOn     `json:"addOns,omitempty"`
+	LocationID            int            `json:"locationId"`
+	Name                  string         `json:"productName"`
+	Term                  int            `json:"term"`
+	Type                  string         `json:"productType"`
+	PortSpeed             int            `json:"portSpeed"`
+	CostCentre            string         `json:"costCentre"`
+	PromoCode             string         `json:"promoCode,omitempty"`
+	MarketplaceVisibility *bool          `json:"marketplaceVisibility,omitempty"`
+	Config                MCROrderConfig `json:"config"`
+	AddOns                []MCRAddOn     `json:"addOns,omitempty"`
 
 	ResourceTags []ResourceTag `json:"resourceTags,omitempty"`
 }


### PR DESCRIPTION
The SDK couldn't set marketplace visibility when ordering an MCR. `BuyMCRRequest` had no field for it and `createMCROrder` never sent one, so the buy payload omitted `marketplaceVisibility` even though the order API accepts it (port and MVE buy already send it). This unblocks the CLI (and later Terraform) setting MCR marketplace visibility at order time.

- Add `MarketplaceVisibility *bool` to `BuyMCRRequest` and to the `MCROrder` wire struct (`marketplaceVisibility,omitempty`).
- Wire it through `createMCROrder`, which `ValidateMCROrder` also uses, so validate carries it too.
- Tests assert the marshaled order includes the key when set (true/false) and omits it when unset.

**On the type:** `*bool` with `omitempty`, not the plain `bool` that `BuyPortRequest` uses. A nil pointer omits the key, so existing callers keep the API default instead of being silently flipped to `false`. This also matches the `Modify*Request` convention already in the SDK.

**Follow-up:** `BuyMVERequest` has the same gap (no `MarketplaceVisibility`, `createMVEOrder` doesn't wire it) despite the MVE response struct carrying the field. Worth a separate ticket.