### PR TITLE
ESD-1555: add marketplace visibility to the MVE buy request

### DIFF
--- a/mve.go
+++ b/mve.go
@@ -57,6 +57,9 @@ type BuyMVERequest struct {
 	DiversityZone string
 	PromoCode     string
 	CostCentre    string
+	// MarketplaceVisibility is sent only when non-nil. Leaving it nil omits the
+	// field so the API applies its own default, rather than forcing false.
+	MarketplaceVisibility *bool
 
 	ResourceTags map[string]string `json:"resourceTags,omitempty"`
 
@@ -192,6 +195,7 @@ func createMVEOrder(req *BuyMVERequest) []*MVEOrderConfig {
 		Config: MVEConfig{
 			DiversityZone: req.DiversityZone,
 		},
+		MarketplaceVisibility: req.MarketplaceVisibility,
 	}
 
 	if len(req.Vnics) == 0 {

--- a/mve_test.go
+++ b/mve_test.go
@@ -43,10 +43,11 @@ func (suite *MVEClientTestSuite) TestBuyMVE() {
 	mveSvc := suite.client.MVEService
 	productUid := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	req := &BuyMVERequest{
-		Name:          "test-mve",
-		Term:          12,
-		LocationID:    1,
-		DiversityZone: "blue",
+		Name:                  "test-mve",
+		Term:                  12,
+		LocationID:            1,
+		DiversityZone:         "blue",
+		MarketplaceVisibility: PtrTo(false),
 	}
 	jblob := `{
     "message": "MVE [36b3f68e-2f54-4331-bf94-f8984449365f] created.",
@@ -134,6 +135,7 @@ func (suite *MVEClientTestSuite) TestBuyMVE() {
 		Config: MVEConfig{
 			DiversityZone: req.DiversityZone,
 		},
+		MarketplaceVisibility: PtrTo(false),
 	}}
 	want := &BuyMVEResponse{TechnicalServiceUID: productUid}
 
@@ -158,11 +160,34 @@ func (suite *MVEClientTestSuite) TestBuyMVE() {
 		suite.Equal(wantOrder.LocationID, gotOrder.LocationID)
 		suite.Equal(wantOrder.NetworkInterfaces, gotOrder.NetworkInterfaces)
 		suite.Equal(wantOrder.Config, gotOrder.Config)
+		suite.Equal(wantOrder.MarketplaceVisibility, gotOrder.MarketplaceVisibility)
 		suite.Equal([]string{}, wrapper.DiscountCodes)
 	})
 	got, err := mveSvc.BuyMVE(ctx, req)
 	suite.NoError(err)
 	suite.Equal(want, got)
+}
+
+// TestCreateMVEOrderMarketplaceVisibility asserts the marshaled MVEOrderConfig
+// carries marketplaceVisibility when set, and omits it (preserving the API
+// default) when the request leaves it nil.
+func (suite *MVEClientTestSuite) TestCreateMVEOrderMarketplaceVisibility() {
+	visible := suite.marshalMVEOrder(&BuyMVERequest{MarketplaceVisibility: PtrTo(true)})
+	suite.Contains(visible, `"marketplaceVisibility":true`)
+
+	hidden := suite.marshalMVEOrder(&BuyMVERequest{MarketplaceVisibility: PtrTo(false)})
+	suite.Contains(hidden, `"marketplaceVisibility":false`)
+
+	unset := suite.marshalMVEOrder(&BuyMVERequest{})
+	suite.NotContains(unset, "marketplaceVisibility")
+}
+
+func (suite *MVEClientTestSuite) marshalMVEOrder(req *BuyMVERequest) string {
+	orders := createMVEOrder(req)
+	suite.Require().Len(orders, 1)
+	b, err := json.Marshal(orders[0])
+	suite.Require().NoError(err)
+	return string(b)
 }
 
 // TestListMVEs tests the ListMVEs method which lists provisioned MVE products

--- a/mve_types.go
+++ b/mve_types.go
@@ -2,15 +2,16 @@ package megaport
 
 // MVEOrderConfig represents a request to buy an MVE from the Megaport Products API.
 type MVEOrderConfig struct {
-	LocationID        int                   `json:"locationId"`
-	Name              string                `json:"productName"`
-	Term              int                   `json:"term"`
-	ProductType       string                `json:"productType"`
-	PromoCode         string                `json:"promoCode,omitempty"`
-	CostCentre        string                `json:"costCentre,omitempty"`
-	NetworkInterfaces []MVENetworkInterface `json:"vnics"`
-	VendorConfig      VendorConfig          `json:"vendorConfig"`
-	Config            MVEConfig             `json:"config"`
+	LocationID            int                   `json:"locationId"`
+	Name                  string                `json:"productName"`
+	Term                  int                   `json:"term"`
+	ProductType           string                `json:"productType"`
+	PromoCode             string                `json:"promoCode,omitempty"`
+	CostCentre            string                `json:"costCentre,omitempty"`
+	NetworkInterfaces     []MVENetworkInterface `json:"vnics"`
+	VendorConfig          VendorConfig          `json:"vendorConfig"`
+	Config                MVEConfig             `json:"config"`
+	MarketplaceVisibility *bool                 `json:"marketplaceVisibility,omitempty"`
 
 	ResourceTags []ResourceTag `json:"resourceTags,omitempty"`
 }


### PR DESCRIPTION
The SDK couldn't set marketplace visibility when ordering an MVE. `BuyMVERequest` had no field for it and `createMVEOrder` never sent one, so the buy payload omitted `marketplaceVisibility` even though the order API accepts it. This is the MVE mirror of the MCR fix in #169.

The buy endpoint takes an array of `MegaportServiceRequest` whose DESIGN variant merges `DesignServiceBaseRequest` (which defines `marketplaceVisibility`) via `allOf` over every product type, so the field is accepted for MVE just like Port and MCR. Confirmed against the OpenAPI spec.

- Add `MarketplaceVisibility *bool` to `BuyMVERequest` and the `MVEOrderConfig` wire struct (`marketplaceVisibility,omitempty`).
- Wire it through `createMVEOrder`, which `ValidateMVEOrder` also uses, so validate carries it too.
- Tests assert the marshaled order includes the key when set (true/false) and omits it when unset.

`*bool` + `omitempty`, not plain `bool`: a nil pointer omits the key so existing callers keep the API default instead of being silently flipped to `false`, matching #169 and the `Modify*Request` convention.