### PR TITLE
ESD-1610: Add call-context client option for managed accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## New Features
+- Add `WithCallContext` client option that sets the `X-Call-Context` header so API calls act on behalf of a managed account (identified by company UID).
+
 # 1.0.0 Release
 
 ## New Features

--- a/client.go
+++ b/client.go
@@ -36,6 +36,10 @@ const (
 	userAgent      = "Go-Megaport-Library/" + libraryVersion
 	mediaType      = "application/json"
 	headerTraceId  = "Trace-Id"
+
+	// headerCallContext lets an authenticated user act on behalf of a company
+	// they can manage; the value is that company's UID.
+	headerCallContext = "X-Call-Context"
 )
 
 // TokenProvider is an interface for providing access tokens.
@@ -262,6 +266,18 @@ func WithCustomHeaders(headers map[string]string) ClientOpt {
 	return func(c *Client) error {
 		for k, v := range headers {
 			c.headers[k] = v
+		}
+		return nil
+	}
+}
+
+// WithCallContext sets the X-Call-Context header so requests act on behalf of
+// the given managed account; companyUID is that company's UID. An empty UID
+// sets no header.
+func WithCallContext(companyUID string) ClientOpt {
+	return func(c *Client) error {
+		if companyUID != "" {
+			c.headers[headerCallContext] = companyUID
 		}
 		return nil
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -201,6 +201,42 @@ func (suite *ClientTestSuite) TestNewRequest_withCustomHeaders() {
 	}
 }
 
+// TestNewRequest_withCallContext tests that WithCallContext sets the
+// X-Call-Context header only when a non-empty company UID is provided.
+func (suite *ClientTestSuite) TestNewRequest_withCallContext() {
+	expectedUID := "fdf6a5fd-8fac-4957-bfcd-f1c77c2abf83"
+
+	// With the option and a UID: the header is present and equal to the UID.
+	withOpt, err := New(nil, WithCallContext(expectedUID))
+	if err != nil {
+		suite.FailNowf("unexpected error", "New() unexpected error: %v", err.Error())
+	}
+	req, _ := withOpt.NewRequest(ctx, http.MethodGet, "/foo", nil)
+	if got := req.Header.Get("X-Call-Context"); got != expectedUID {
+		suite.FailNowf("call context header mismatch", "X-Call-Context = %q; expected %q", got, expectedUID)
+	}
+
+	// Without the option: the header is absent.
+	without, err := New(nil)
+	if err != nil {
+		suite.FailNowf("unexpected error", "New() unexpected error: %v", err.Error())
+	}
+	req, _ = without.NewRequest(ctx, http.MethodGet, "/foo", nil)
+	if vals := req.Header.Values("X-Call-Context"); len(vals) != 0 {
+		suite.FailNowf("call context header should be absent", "X-Call-Context present: %v; expected absent", vals)
+	}
+
+	// With an empty UID: the header is absent.
+	empty, err := New(nil, WithCallContext(""))
+	if err != nil {
+		suite.FailNowf("unexpected error", "New() unexpected error: %v", err.Error())
+	}
+	req, _ = empty.NewRequest(ctx, http.MethodGet, "/foo", nil)
+	if vals := req.Header.Values("X-Call-Context"); len(vals) != 0 {
+		suite.FailNowf("call context header should be absent", "X-Call-Context present: %v; expected absent", vals)
+	}
+}
+
 // TestDo_get tests if the Do function returns a GET request with the default base URL and user agent.
 func (suite *ClientTestSuite) TestDo() {
 


### PR DESCRIPTION
Adds a first-class client option so callers can act on behalf of a managed account, instead of hand-setting a magic header string in each consumer. This is the SDK piece of EIP-7108; the Terraform provider and CLI will consume it in follow-up tickets.

- `WithCallContext(companyUID)` sets the `X-Call-Context` header (a company UID) on every request, reusing the existing per-request header map.
- Empty UID sets no header; without the option, behavior is unchanged.
- Unit test covers header presence, absence without the option, and absence with an empty string. It asserts the literal header name so a rename of the internal constant is caught.

Header name and company-UUID value verified against the megalith v3 OpenAPI spec.