### PR TITLE
chore: bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.26.4'  # Keep in sync with the toolchain directive in go.mod
+          go-version: '1.26.5'  # Keep in sync with the toolchain directive in go.mod
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0  # Pin to avoid CI drift
       - name: Run govulncheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.26.4'  # Keep in sync with the toolchain directive in go.mod
+          go-version: '1.26.5'  # Keep in sync with the toolchain directive in go.mod
           cache: false
       - name: Run linters
         # Pinned to a SHA whitelisted for the org — any new SHA must be

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.26.4'  # Keep in sync with the toolchain directive in go.mod
+          go-version: '1.26.5'  # Keep in sync with the toolchain directive in go.mod
       - name: Run Tests
         run: go test -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## New Features
 - Add `WithCallContext` client option that sets the `X-Call-Context` header so API calls act on behalf of a managed account (identified by company UID).
 
+## Changes
+- Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).
+
 # 1.0.0 Release
 
 ## New Features

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/megaport/megaportgo
 
 go 1.21
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/lithammer/fuzzysearch v1.1.8


### PR DESCRIPTION
## Summary
govulncheck flags GO-2026-5856 (Encrypted Client Hello privacy leak in `crypto/tls`) against the pinned `go1.26.4` toolchain. The finding traces through real TLS usage (`Client.Do` / `DoRequestWithClient` making outbound HTTPS calls), so it's a real toolchain issue, not a dead-code false positive. Fixed upstream in `go1.26.5`.

- Bump `toolchain` directive in `go.mod` to `go1.26.5`
- Bump `go-version` in `test.yml`, `lint.yml`, `govulncheck.yml` to match
- CHANGELOG entry

## Test plan
- [x] `go build ./...` and `go test ./...` pass on go1.26.5
- [x] `golangci-lint run` clean
- [x] `govulncheck ./...` no longer reports GO-2026-5856