### PR TITLE
ESD-1670: Add AsOverride to the BGP connection config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 - Add `WithCallContext` client option that sets the `X-Call-Context` header so API calls act on behalf of a managed account (identified by company UID).
+- Add `AsOverride` (`*bool`) to `BgpConnectionConfig` so consumers can enable AS Override for eBGP peering. Unset leaves the API default in place.
 
 ## Changes
 - Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).

--- a/vxc_test.go
+++ b/vxc_test.go
@@ -1535,6 +1535,52 @@ func (suite *VXCClientTestSuite) TestMCRVXCWithIPsecTunnel() {
 	suite.Equal("192.0.2.4", multiGot.Interfaces[1].IpSecTunnelOptions["sourceIpAddress"])
 }
 
+// TestBgpConnectionAsOverride verifies that AsOverride on a BGP connection
+// serialises only when set, so an unset field leaves the API default in place.
+func (suite *VXCClientTestSuite) TestBgpConnectionAsOverride() {
+	marshalAsOverride := func(cfg VXCOrderVrouterPartnerConfig) (any, bool) {
+		raw, err := json.Marshal(cfg)
+		suite.NoError(err)
+		var got struct {
+			Interfaces []struct {
+				BgpConnections []map[string]any `json:"bgpConnections"`
+			} `json:"interfaces"`
+		}
+		suite.NoError(json.Unmarshal(raw, &got))
+		suite.Require().Len(got.Interfaces, 1)
+		suite.Require().Len(got.Interfaces[0].BgpConnections, 1)
+		v, ok := got.Interfaces[0].BgpConnections[0]["asOverride"]
+		return v, ok
+	}
+	newCfg := func(asOverride *bool) VXCOrderVrouterPartnerConfig {
+		return VXCOrderVrouterPartnerConfig{
+			Interfaces: []PartnerConfigInterface{{
+				BgpConnections: []BgpConnectionConfig{{
+					PeerAsn:        65000,
+					LocalIpAddress: "192.0.2.1",
+					PeerIpAddress:  "192.0.2.2",
+					AsOverride:     asOverride,
+				}},
+			}},
+		}
+	}
+
+	enabled := true
+	v, present := marshalAsOverride(newCfg(&enabled))
+	suite.True(present, "asOverride must be sent when set true")
+	suite.Equal(true, v)
+
+	// Explicit false is preserved (a plain bool with omitempty could not do this).
+	disabled := false
+	v, present = marshalAsOverride(newCfg(&disabled))
+	suite.True(present, "asOverride must be sent when set false")
+	suite.Equal(false, v)
+
+	// Unset (nil) omits the key so the API applies its own default.
+	_, present = marshalAsOverride(newCfg(nil))
+	suite.False(present, "unset asOverride must be omitted")
+}
+
 // TestListVXCs tests the ListVXCs method with various filters
 func (suite *VXCClientTestSuite) TestListVXCs() {
 	// Define mock responses for products list API

--- a/vxc_types.go
+++ b/vxc_types.go
@@ -396,7 +396,8 @@ type BgpConnectionConfig struct {
 	ExportWhitelist    int      `json:"exportWhitelist,omitempty"`
 	ExportBlacklist    int      `json:"exportBlacklist,omitempty"`
 	AsPathPrependCount int      `json:"asPathPrependCount,omitempty"`
-	PeerType           string   `json:"peerType,omitempty"` // can be NON_CLOUD, PRIV_CLOUD, or PUB_CLOUD
+	PeerType           string   `json:"peerType,omitempty"`   // can be NON_CLOUD, PRIV_CLOUD, or PUB_CLOUD
+	AsOverride         *bool    `json:"asOverride,omitempty"` // nil applies the API default; only valid for eBGP
 }
 
 // AWS STUFF


### PR DESCRIPTION
The Megaport API's `BgpConnectionRequest` carries an `asOverride` boolean (enables AS Override for eBGP peering) that the SDK didn't expose, so no consumer could set it. This adds it, unblocking the Terraform provider work in ESD-1671 (raised from customer enquiry 00075754).

- Add `AsOverride *bool` to `BgpConnectionConfig` with `json:"asOverride,omitempty"`. Using `*bool` (not plain `bool`) matches the neighbouring optional fields (`Passive`, `LocalAsn`) so nil omits the key and the API keeps applying its default, and it lets a consumer send an explicit `false`.
- Add a marshal unit test covering set-true, set-false, and unset.
- CHANGELOG entry under Unreleased.

Verified against the OpenAPI spec that `asOverride` is a boolean on `BgpConnectionRequest`, and end to end on staging: an MCR vRouter VXC ordered with `asOverride: true` is accepted, and `GET /v2/product/{uid}` echoes the value back under `resources...interfaces[].bgpConnections[].asOverride`.

`BgpConnectionConfig` is the same struct the SDK decodes GET responses into (`CSPConnectionVirtualRouterInterface.BGPConnections`), so this one addition covers both the write and read paths: reading a VXC back now populates `AsOverride` (it was previously discarded). That gives the provider ticket a direct read for its drift handling, no separate response type needed.