### PR TITLE
ESD-1703: Fix MCR prefix filter list ge/le encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Changes
 - Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).
-- Fix `ge`/`le` on MCR and NAT gateway prefix lists: MCR sent them as JSON numbers where the API declares strings, and both dropped a deliberate 0. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int` (`PtrTo(24)` to set, `nil` for unset). Map unset to `nil`, **not** `PtrTo(0)`: a 0 now reaches the API, where `le: 0` matches nothing, so a `deny` entry can quietly stop denying.
+- Fix `ge`/`le` on MCR and NAT gateway prefix lists: MCR sent them as JSON numbers where the API declares strings, and both dropped a deliberate 0. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int`. Map unset to `nil`, **not** `PtrTo(0)`: any set value now reaches the API verbatim instead of being dropped, so a stray 0 changes which routes a filter matches.
 
 # 1.0.0 Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Changes
 - Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).
-- Fix `ge`/`le` encoding on MCR and NAT gateway prefix lists: they now go out as the strings the API declares, and a prefix length of 0 is sent rather than dropped. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int`. Set one with `PtrTo(24)`; an absent value reads back as `nil` instead of `0`. When migrating, map "unset" to `nil`, **not** `PtrTo(0)`: a 0 used to be silently dropped and is now honored, which changes which prefixes the filter matches. Negative values are likewise no longer dropped.
+- Fix `ge`/`le` on MCR and NAT gateway prefix lists: MCR sent them as JSON numbers where the API declares strings, and both dropped a deliberate 0. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int` (`PtrTo(24)` to set, `nil` for unset). Map unset to `nil`, **not** `PtrTo(0)`: a 0 now reaches the API, where `le: 0` matches nothing, so a `deny` entry can quietly stop denying.
 
 # 1.0.0 Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Changes
 - Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).
-- Fix `ge`/`le` on MCR and NAT gateway prefix lists: MCR sent them as JSON numbers where the API declares strings, and both dropped a deliberate 0. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int`. Map unset to `nil`, **not** `PtrTo(0)`: any set value now reaches the API verbatim instead of being dropped, so a stray 0 changes which routes a filter matches.
+- Fix `ge`/`le` on MCR and NAT gateway prefix lists: MCR sent numbers where the API declares strings, and both dropped a deliberate 0. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int`; map unset to `nil`, not `PtrTo(0)`. A stray 0 is now rejected by the API rather than ignored.
 
 # 1.0.0 Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Changes
 - Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).
-- Fix `ge`/`le` encoding on MCR and NAT gateway prefix lists. Create and modify now send them as the strings the API declares, and a prefix length of 0 reaches the wire instead of being dropped. **Breaking:** `MCRPrefixListEntry.Ge`/`.Le` and `NATGatewayPrefixListEntry.Ge`/`.Le` are now `*int`, so an unset value is distinguishable from a deliberate 0. Use `PtrTo(24)` to set one; reading an absent `ge`/`le` now yields `nil` rather than `0`.
+- Fix `ge`/`le` encoding on MCR and NAT gateway prefix lists: they now go out as the strings the API declares, and a prefix length of 0 is sent rather than dropped. **Breaking:** `Ge`/`Le` on `MCRPrefixListEntry` and `NATGatewayPrefixListEntry` are now `*int`. Set one with `PtrTo(24)`; an absent value reads back as `nil` instead of `0`. When migrating, map "unset" to `nil`, **not** `PtrTo(0)`: a 0 used to be silently dropped and is now honored, which changes which prefixes the filter matches. Negative values are likewise no longer dropped.
 
 # 1.0.0 Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Changes
 - Bump Go toolchain to 1.26.5 to pick up a `crypto/tls` fix for an Encrypted Client Hello privacy leak ([GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)).
+- Fix `ge`/`le` encoding on MCR and NAT gateway prefix lists. Create and modify now send them as the strings the API declares, and a prefix length of 0 reaches the wire instead of being dropped. **Breaking:** `MCRPrefixListEntry.Ge`/`.Le` and `NATGatewayPrefixListEntry.Ge`/`.Le` are now `*int`, so an unset value is distinguishable from a deliberate 0. Use `PtrTo(24)` to set one; reading an absent `ge`/`le` now yields `nil` rather than `0`.
 
 # 1.0.0 Release
 

--- a/errors.go
+++ b/errors.go
@@ -152,6 +152,12 @@ var ErrBuyMCRRequestNil = errors.New("buy MCR request cannot be nil")
 // ErrCreateMCRPrefixFilterListRequestNil is returned when CreatePrefixFilterList is called with a nil request.
 var ErrCreateMCRPrefixFilterListRequestNil = errors.New("create MCR prefix filter list request cannot be nil")
 
+// ErrMCRPrefixFilterListNil is returned when a prefix filter list itself is nil.
+var ErrMCRPrefixFilterListNil = errors.New("MCR prefix filter list cannot be nil")
+
+// ErrMCRPrefixFilterListEntriesNil is returned when a prefix filter list's Entries is nil.
+var ErrMCRPrefixFilterListEntriesNil = errors.New("MCR prefix filter list entries cannot be nil")
+
 // ErrModifyMCRRequestNil is returned when ModifyMCR is called with a nil request.
 var ErrModifyMCRRequestNil = errors.New("modify MCR request cannot be nil")
 

--- a/mcr.go
+++ b/mcr.go
@@ -397,7 +397,12 @@ func (svc *MCRServiceOp) CreatePrefixFilterList(ctx context.Context, req *Create
 	}
 	url := "/v2/product/mcr2/" + req.MCRID + "/prefixList"
 
-	clientReq, err := svc.Client.NewRequest(ctx, "POST", url, req.PrefixFilterList.toAPI())
+	reqBody, err := req.PrefixFilterList.toAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	clientReq, err := svc.Client.NewRequest(ctx, "POST", url, reqBody)
 
 	if err != nil {
 		return nil, err
@@ -582,7 +587,11 @@ func (svc *MCRServiceOp) DeleteMCRPrefixFilterList(ctx context.Context, mcrID st
 // ModifyMCRPrefixFilterList modifies a prefix filter list on an MCR in the Megaport MCR API.
 func (svc *MCRServiceOp) ModifyMCRPrefixFilterList(ctx context.Context, mcrID string, prefixFilterListID int, prefixFilterList *MCRPrefixFilterList) (*ModifyMCRPrefixFilterListResponse, error) {
 	url := fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrID, prefixFilterListID)
-	clientReq, err := svc.Client.NewRequest(ctx, "PUT", url, prefixFilterList.toAPI())
+	reqBody, err := prefixFilterList.toAPI()
+	if err != nil {
+		return nil, err
+	}
+	clientReq, err := svc.Client.NewRequest(ctx, "PUT", url, reqBody)
 	if err != nil {
 		return nil, err
 	}

--- a/mcr.go
+++ b/mcr.go
@@ -397,7 +397,7 @@ func (svc *MCRServiceOp) CreatePrefixFilterList(ctx context.Context, req *Create
 	}
 	url := "/v2/product/mcr2/" + req.MCRID + "/prefixList"
 
-	clientReq, err := svc.Client.NewRequest(ctx, "POST", url, req.PrefixFilterList)
+	clientReq, err := svc.Client.NewRequest(ctx, "POST", url, req.PrefixFilterList.toAPI())
 
 	if err != nil {
 		return nil, err
@@ -582,7 +582,7 @@ func (svc *MCRServiceOp) DeleteMCRPrefixFilterList(ctx context.Context, mcrID st
 // ModifyMCRPrefixFilterList modifies a prefix filter list on an MCR in the Megaport MCR API.
 func (svc *MCRServiceOp) ModifyMCRPrefixFilterList(ctx context.Context, mcrID string, prefixFilterListID int, prefixFilterList *MCRPrefixFilterList) (*ModifyMCRPrefixFilterListResponse, error) {
 	url := fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrID, prefixFilterListID)
-	clientReq, err := svc.Client.NewRequest(ctx, "PUT", url, prefixFilterList)
+	clientReq, err := svc.Client.NewRequest(ctx, "PUT", url, prefixFilterList.toAPI())
 	if err != nil {
 		return nil, err
 	}

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -349,7 +349,7 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     nil, // staging omitted ge when it matched the prefix length; undocumented
+				Ge:     nil, // undocumented: the API strips ge/le that equal the prefix length
 				Le:     PtrTo(25),
 			},
 		},
@@ -461,7 +461,7 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     nil, // staging omitted ge when it matched the prefix length; undocumented
+				Ge:     nil, // undocumented: the API strips ge/le that equal the prefix length
 				Le:     PtrTo(26),
 			},
 		},

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -349,7 +349,7 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     nil, // API omits ge in the response when it equals the prefix length
+				Ge:     nil, // staging omitted ge when it matched the prefix length; undocumented
 				Le:     PtrTo(25),
 			},
 		},
@@ -461,7 +461,7 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     nil, // API omits ge in the response when it equals the prefix length
+				Ge:     nil, // staging omitted ge when it matched the prefix length; undocumented
 				Le:     PtrTo(26),
 			},
 		},

--- a/mcr_integration_test.go
+++ b/mcr_integration_test.go
@@ -199,14 +199,14 @@ func (suite *MCRIntegrationTestSuite) TestCreatePrefixFilterList() {
 		{
 			Action: "permit",
 			Prefix: "10.0.1.0/24",
-			Ge:     24,
-			Le:     24,
+			Ge:     PtrTo(24),
+			Le:     PtrTo(24),
 		},
 		{
 			Action: "deny",
 			Prefix: "10.0.2.0/24",
-			Ge:     24,
-			Le:     24,
+			Ge:     PtrTo(24),
+			Le:     PtrTo(24),
 		},
 	}
 
@@ -298,14 +298,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 		{
 			Action: "permit",
 			Prefix: "10.0.1.0/24",
-			Ge:     25,
-			Le:     32,
+			Ge:     PtrTo(25),
+			Le:     PtrTo(32),
 		},
 		{
 			Action: "deny",
 			Prefix: "10.0.2.0/24",
-			Ge:     24,
-			Le:     25,
+			Ge:     PtrTo(24),
+			Le:     PtrTo(25),
 		},
 	}
 
@@ -313,14 +313,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 		{
 			Action: "permit",
 			Prefix: "10.0.1.0/24",
-			Ge:     26,
-			Le:     32,
+			Ge:     PtrTo(26),
+			Le:     PtrTo(32),
 		},
 		{
 			Action: "deny",
 			Prefix: "10.0.2.0/24",
-			Ge:     25,
-			Le:     27,
+			Ge:     PtrTo(25),
+			Le:     PtrTo(27),
 		},
 	}
 
@@ -343,14 +343,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "permit",
 				Prefix: "10.0.1.0/24",
-				Ge:     25,
-				Le:     32,
+				Ge:     PtrTo(25),
+				Le:     PtrTo(32),
 			},
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     0,
-				Le:     25,
+				Ge:     nil, // API omits ge in the response when it equals the prefix length
+				Le:     PtrTo(25),
 			},
 		},
 	}
@@ -361,14 +361,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "permit",
 				Prefix: "10.0.1.0/24",
-				Ge:     26,
-				Le:     32,
+				Ge:     PtrTo(26),
+				Le:     PtrTo(32),
 			},
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     25,
-				Le:     27,
+				Ge:     PtrTo(25),
+				Le:     PtrTo(27),
 			},
 		},
 	}
@@ -418,14 +418,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "permit",
 				Prefix: "10.0.1.0/24",
-				Ge:     26,
-				Le:     32,
+				Ge:     PtrTo(26),
+				Le:     PtrTo(32),
 			},
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     24,
-				Le:     26,
+				Ge:     PtrTo(24),
+				Le:     PtrTo(26),
 			},
 		},
 	}
@@ -436,14 +436,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "permit",
 				Prefix: "10.0.1.0/24",
-				Ge:     27,
-				Le:     32,
+				Ge:     PtrTo(27),
+				Le:     PtrTo(32),
 			},
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     25,
-				Le:     27,
+				Ge:     PtrTo(25),
+				Le:     PtrTo(27),
 			},
 		},
 	}
@@ -455,14 +455,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "permit",
 				Prefix: "10.0.1.0/24",
-				Ge:     26,
-				Le:     32,
+				Ge:     PtrTo(26),
+				Le:     PtrTo(32),
 			},
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     0,
-				Le:     26,
+				Ge:     nil, // API omits ge in the response when it equals the prefix length
+				Le:     PtrTo(26),
 			},
 		},
 	}
@@ -474,14 +474,14 @@ func (suite *MCRIntegrationTestSuite) TestMegaportPrefixFilterList() {
 			{
 				Action: "permit",
 				Prefix: "10.0.1.0/24",
-				Ge:     27,
-				Le:     32,
+				Ge:     PtrTo(27),
+				Le:     PtrTo(32),
 			},
 			{
 				Action: "deny",
 				Prefix: "10.0.2.0/24",
-				Ge:     25,
-				Le:     27,
+				Ge:     PtrTo(25),
+				Le:     PtrTo(27),
 			},
 		},
 	}

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -271,14 +271,15 @@ func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 }
 
 // mcrPrefixListGeLeFixture covers every ge/le cell: both set, both a deliberate
-// 0, neither set, and one set without the other.
+// 0, neither set, and one set without the other. The 0 sits on a default route
+// because the API requires ge to be at least the prefix length.
 func mcrPrefixListGeLeFixture() MCRPrefixFilterList {
 	return MCRPrefixFilterList{
 		Description:   "ge-le-list",
 		AddressFamily: "IPv4",
 		Entries: []*MCRPrefixListEntry{
 			{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(25), Le: PtrTo(32)},
-			{Action: "deny", Prefix: "10.0.2.0/24", Ge: PtrTo(0), Le: PtrTo(0)},
+			{Action: "deny", Prefix: "0.0.0.0/0", Ge: PtrTo(0), Le: PtrTo(0)},
 			{Action: "permit", Prefix: "10.0.3.0/24"},
 			{Action: "permit", Prefix: "10.0.4.0/24", Le: PtrTo(30)},
 		},
@@ -294,7 +295,7 @@ const wantMCRPrefixListGeLeBody = `{
 	"addressFamily": "IPv4",
 	"entries": [
 		{"action": "permit", "prefix": "10.0.1.0/24", "ge": "25", "le": "32"},
-		{"action": "deny", "prefix": "10.0.2.0/24", "ge": "0", "le": "0"},
+		{"action": "deny", "prefix": "0.0.0.0/0", "ge": "0", "le": "0"},
 		{"action": "permit", "prefix": "10.0.3.0/24"},
 		{"action": "permit", "prefix": "10.0.4.0/24", "le": "30"}
 	]
@@ -343,9 +344,10 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListGeLeEncoding() {
 	suite.True(got.IsUpdated)
 }
 
-// TestModifyMCRPrefixFilterListBodyEdgeCases pins a nil list and a nil Entries as
-// byte-identical to the old direct marshal, not as bodies the API accepts.
-func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
+// TestModifyMCRPrefixFilterListNullBodies covers the two bodies the API answers
+// with a 400: a bare null and a null entries array. Both are refused locally, so
+// no request goes out.
+func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListNullBodies() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	mcrSvc := suite.client.MCRService
 
@@ -353,43 +355,59 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 		name string
 		id   int
 		list *MCRPrefixFilterList
-		want string
+		want error
 	}{
 		{
 			name: "nil list",
 			id:   1,
 			list: nil,
-			want: `null`,
+			want: ErrMCRPrefixFilterListNil,
 		},
 		{
 			name: "nil entries",
 			id:   2,
 			list: &MCRPrefixFilterList{ID: 7, Description: "d", AddressFamily: "IPv4"},
-			want: `{"id":7,"description":"d","addressFamily":"IPv4","entries":null}`,
+			want: ErrMCRPrefixFilterListEntriesNil,
 		},
 	}
 
 	for _, tc := range cases {
 		tc := tc
 		suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, tc.id), func(w http.ResponseWriter, r *http.Request) {
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				suite.FailNowf("could not read body", "%v", err)
-			}
-			suite.JSONEq(tc.want, string(body))
-			fmt.Fprint(w, `{"message":"ok","terms":""}`)
+			suite.Failf("request should not have been sent", "case %q reached the API", tc.name)
 		})
 
 		suite.Run(tc.name, func() {
 			_, err := mcrSvc.ModifyMCRPrefixFilterList(ctx, mcrId, tc.id, tc.list)
-			suite.NoError(err)
+			suite.ErrorIs(err, tc.want)
 		})
 	}
 }
 
-// A nil entry is refused before the request goes out. The API's own validation
-// accepts a null element and faults on it further in, and the read path rejects
-// it, so emitting one is never right.
+// TestModifyMCRPrefixFilterListEmptyEntries pins an empty Entries as still
+// reaching the wire, unlike a nil one.
+func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListEmptyEntries() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, 9), func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			suite.FailNowf("could not read body", "%v", err)
+		}
+		suite.JSONEq(`{"id":0,"description":"d","addressFamily":"IPv4","entries":[]}`, string(body))
+		fmt.Fprint(w, `{"message":"ok","terms":""}`)
+	})
+
+	_, err := suite.client.MCRService.ModifyMCRPrefixFilterList(ctx, mcrId, 9, &MCRPrefixFilterList{
+		Description:   "d",
+		AddressFamily: "IPv4",
+		Entries:       []*MCRPrefixListEntry{},
+	})
+	suite.NoError(err)
+}
+
+// TestModifyMCRPrefixFilterListNilEntry checks a nil entry is refused before the
+// request goes out, and that the error names which entry.
 func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListNilEntry() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 
@@ -397,11 +415,55 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListNilEntry() {
 		Description:   "d",
 		AddressFamily: "IPv4",
 		Entries: []*MCRPrefixListEntry{
+			{Action: "permit", Prefix: "10.0.1.0/24", Le: PtrTo(25)},
 			nil,
-			{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(0)},
 		},
 	})
-	suite.ErrorContains(err, "prefix list entry 0: nil entry")
+	suite.ErrorContains(err, "prefix list entry 1: nil entry")
+}
+
+// TestCreatePrefixFilterListConversionError pins the create path's own error
+// return, which is a separate call site from the modify path's.
+func (suite *MCRClientTestSuite) TestCreatePrefixFilterListConversionError() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+
+	suite.mux.HandleFunc("/v2/product/mcr2/"+mcrId+"/prefixList", func(w http.ResponseWriter, r *http.Request) {
+		suite.Fail("request should not have been sent")
+	})
+
+	cases := []struct {
+		name string
+		list MCRPrefixFilterList
+		want string
+	}{
+		{
+			name: "nil entries",
+			list: MCRPrefixFilterList{Description: "d", AddressFamily: "IPv4"},
+			want: ErrMCRPrefixFilterListEntriesNil.Error(),
+		},
+		{
+			name: "nil entry",
+			list: MCRPrefixFilterList{
+				Description:   "d",
+				AddressFamily: "IPv4",
+				Entries: []*MCRPrefixListEntry{
+					{Action: "permit", Prefix: "10.0.1.0/24"},
+					nil,
+				},
+			},
+			want: "prefix list entry 1: nil entry",
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			_, err := suite.client.MCRService.CreatePrefixFilterList(ctx, &CreateMCRPrefixFilterListRequest{
+				MCRID:            mcrId,
+				PrefixFilterList: tc.list,
+			})
+			suite.ErrorContains(err, tc.want)
+		})
+	}
 }
 
 // TestPrefixFilterListGeLeDecoding covers the read direction: an absent ge/le
@@ -421,17 +483,24 @@ func (suite *MCRClientTestSuite) TestPrefixFilterListGeLeDecoding() {
 
 	got, err := mcrSvc.GetMCRPrefixFilterList(ctx, mcrId, 7)
 	suite.NoError(err)
+	suite.Equal(7, got.ID)
+	suite.Equal("d", got.Description)
+	suite.Equal("IPv4", got.AddressFamily)
 	suite.Require().Len(got.Entries, 3)
+	suite.Equal("permit", got.Entries[0].Action)
+	suite.Equal("10.0.1.0/24", got.Entries[0].Prefix)
 	suite.Equal(PtrTo(0), got.Entries[0].Ge)
 	suite.Equal(PtrTo(25), got.Entries[0].Le)
+	suite.Equal("deny", got.Entries[1].Action)
+	suite.Equal("10.0.2.0/24", got.Entries[1].Prefix)
 	suite.Nil(got.Entries[1].Ge)
 	suite.Nil(got.Entries[1].Le)
 	suite.Nil(got.Entries[2].Ge)
 	suite.Equal(PtrTo(0), got.Entries[2].Le)
 }
 
-// A null entries array has to stay nil through the decode, or handing the result
-// straight back to Modify sends "entries":[], which deletes every entry.
+// TestPrefixFilterListNullEntriesStaysNil pins the read path's nil Entries, which
+// the list endpoint returns on every call.
 func (suite *MCRClientTestSuite) TestPrefixFilterListNullEntriesStaysNil() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -222,14 +223,14 @@ func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 		{
 			Action: "permit",
 			Prefix: "10.0.1.0/24",
-			Ge:     24,
-			Le:     24,
+			Ge:     PtrTo(24),
+			Le:     PtrTo(24),
 		},
 		{
 			Action: "deny",
 			Prefix: "10.0.2.0/24",
-			Ge:     24,
-			Le:     24,
+			Ge:     PtrTo(24),
+			Le:     PtrTo(24),
 		},
 	}
 
@@ -267,6 +268,101 @@ func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 		PrefixFilterList: validatedPrefixFilterList,
 	})
 	suite.NoError(prefixErr)
+}
+
+// geLeEncodingList is the fixture for the ge/le wire-encoding tests: one entry
+// with both set, one with a deliberate 0, one with neither.
+func geLeEncodingList() MCRPrefixFilterList {
+	return MCRPrefixFilterList{
+		Description:   "ge-le-list",
+		AddressFamily: "IPv4",
+		Entries: []*MCRPrefixListEntry{
+			{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(25), Le: PtrTo(32)},
+			{Action: "deny", Prefix: "10.0.2.0/24", Ge: PtrTo(0), Le: PtrTo(25)},
+			{Action: "permit", Prefix: "10.0.3.0/24"},
+		},
+	}
+}
+
+// wantGeLeBody is the payload the API expects: ge/le are strings per
+// PrefixEntryDto, a deliberate 0 is present as "0", and an unset ge/le is
+// absent rather than sent as 0.
+const wantGeLeBody = `{
+	"id": 0,
+	"description": "ge-le-list",
+	"addressFamily": "IPv4",
+	"entries": [
+		{"action": "permit", "prefix": "10.0.1.0/24", "ge": "25", "le": "32"},
+		{"action": "deny", "prefix": "10.0.2.0/24", "ge": "0", "le": "25"},
+		{"action": "permit", "prefix": "10.0.3.0/24"}
+	]
+}`
+
+// TestCreatePrefixFilterListGeLeEncoding asserts the marshaled POST body, not
+// just that a stubbed response decodes.
+func (suite *MCRClientTestSuite) TestCreatePrefixFilterListGeLeEncoding() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	mcrSvc := suite.client.MCRService
+
+	suite.mux.HandleFunc("/v2/product/mcr2/"+mcrId+"/prefixList", func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPost)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			suite.FailNowf("could not read body", "%v", err)
+		}
+		suite.JSONEq(wantGeLeBody, string(body))
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":2819,"description":"ge-le-list","addressFamily":"IPv4","entries":[]}}`)
+	})
+
+	_, err := mcrSvc.CreatePrefixFilterList(ctx, &CreateMCRPrefixFilterListRequest{
+		MCRID:            mcrId,
+		PrefixFilterList: geLeEncodingList(),
+	})
+	suite.NoError(err)
+}
+
+// TestModifyMCRPrefixFilterListGeLeEncoding is the PUT counterpart.
+func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListGeLeEncoding() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	mcrSvc := suite.client.MCRService
+	list := geLeEncodingList()
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, 2819), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodPut)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			suite.FailNowf("could not read body", "%v", err)
+		}
+		suite.JSONEq(wantGeLeBody, string(body))
+		fmt.Fprint(w, `{"message":"ok","terms":""}`)
+	})
+
+	got, err := mcrSvc.ModifyMCRPrefixFilterList(ctx, mcrId, 2819, &list)
+	suite.NoError(err)
+	suite.True(got.IsUpdated)
+}
+
+// TestPrefixFilterListGeLeDecoding covers the read direction: an absent ge/le
+// decodes to nil, so callers can tell it apart from a deliberate 0.
+func (suite *MCRClientTestSuite) TestPrefixFilterListGeLeDecoding() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	mcrSvc := suite.client.MCRService
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, 7), func(w http.ResponseWriter, r *http.Request) {
+		suite.testMethod(r, http.MethodGet)
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":7,"description":"d","addressFamily":"IPv4","entries":[
+			{"action":"permit","prefix":"10.0.1.0/24","ge":"0","le":"25"},
+			{"action":"deny","prefix":"10.0.2.0/24"}
+		]}}`)
+	})
+
+	got, err := mcrSvc.GetMCRPrefixFilterList(ctx, mcrId, 7)
+	suite.NoError(err)
+	suite.Require().Len(got.Entries, 2)
+	suite.Equal(PtrTo(0), got.Entries[0].Ge)
+	suite.Equal(PtrTo(25), got.Entries[0].Le)
+	suite.Nil(got.Entries[1].Ge)
+	suite.Nil(got.Entries[1].Le)
 }
 
 // TestListMCRs tests the ListMCRs method

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -343,8 +343,9 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListGeLeEncoding() {
 }
 
 // TestModifyMCRPrefixFilterListBodyEdgeCases pins the shapes the converter has
-// to leave alone: a nil list, a nil Entries, and a nil entry all reach the wire
-// as they did when this type was marshaled directly.
+// to leave alone: a nil list, a nil Entries, and a nil entry reach the wire
+// byte-identical to the old direct marshal. Whether the API accepts those
+// bodies is a separate question.
 func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	mcrSvc := suite.client.MCRService
@@ -383,7 +384,7 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 	}
 
 	for _, tc := range cases {
-		tc := tc // go 1.21: the loop variable is shared with the handler closure
+		tc := tc
 		suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, tc.id), func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
@@ -393,8 +394,10 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 			fmt.Fprint(w, `{"message":"ok","terms":""}`)
 		})
 
-		_, err := mcrSvc.ModifyMCRPrefixFilterList(ctx, mcrId, tc.id, tc.list)
-		suite.NoErrorf(err, "case %s", tc.name)
+		suite.Run(tc.name, func() {
+			_, err := mcrSvc.ModifyMCRPrefixFilterList(ctx, mcrId, tc.id, tc.list)
+			suite.NoError(err)
+		})
 	}
 }
 
@@ -409,22 +412,66 @@ func (suite *MCRClientTestSuite) TestPrefixFilterListGeLeDecoding() {
 		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":7,"description":"d","addressFamily":"IPv4","entries":[
 			{"action":"permit","prefix":"10.0.1.0/24","ge":"0","le":"25"},
 			{"action":"deny","prefix":"10.0.2.0/24"},
-			{"action":"permit","prefix":"10.0.3.0/24","le":"0"},
-			null
+			{"action":"permit","prefix":"10.0.3.0/24","le":"0"}
 		]}}`)
 	})
 
 	got, err := mcrSvc.GetMCRPrefixFilterList(ctx, mcrId, 7)
 	suite.NoError(err)
-	suite.Require().Len(got.Entries, 4)
+	suite.Require().Len(got.Entries, 3)
 	suite.Equal(PtrTo(0), got.Entries[0].Ge)
 	suite.Equal(PtrTo(25), got.Entries[0].Le)
 	suite.Nil(got.Entries[1].Ge)
 	suite.Nil(got.Entries[1].Le)
 	suite.Nil(got.Entries[2].Ge)
 	suite.Equal(PtrTo(0), got.Entries[2].Le)
-	// A null entry decodes to nil instead of panicking.
-	suite.Nil(got.Entries[3])
+}
+
+// TestPrefixFilterListDecodeErrors covers the failure mode the string encoding
+// introduces: a ge/le the API sends that is not a number, and a null entry the
+// caller would otherwise have to nil-check.
+func (suite *MCRClientTestSuite) TestPrefixFilterListDecodeErrors() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	mcrSvc := suite.client.MCRService
+
+	cases := []struct {
+		name    string
+		id      int
+		entries string
+		wantErr string
+	}{
+		{
+			name:    "non-numeric ge",
+			id:      11,
+			entries: `{"action":"permit","prefix":"10.0.1.0/24","ge":"x"}`,
+			wantErr: `prefix list entry 0: invalid ge "x"`,
+		},
+		{
+			name:    "non-numeric le",
+			id:      12,
+			entries: `{"action":"permit","prefix":"10.0.1.0/24","le":"y"}`,
+			wantErr: `prefix list entry 0: invalid le "y"`,
+		},
+		{
+			name:    "null entry",
+			id:      13,
+			entries: `{"action":"permit","prefix":"10.0.1.0/24"},null`,
+			wantErr: `prefix list entry 1: null entry in response`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, tc.id), func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"message":"ok","terms":"","data":{"id":%d,"description":"d","addressFamily":"IPv4","entries":[%s]}}`, tc.id, tc.entries)
+		})
+
+		suite.Run(tc.name, func() {
+			got, err := mcrSvc.GetMCRPrefixFilterList(ctx, mcrId, tc.id)
+			suite.Nil(got)
+			suite.ErrorContains(err, tc.wantErr)
+		})
+	}
 }
 
 // TestListMCRs tests the ListMCRs method

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -285,8 +285,9 @@ func mcrPrefixListGeLeFixture() MCRPrefixFilterList {
 	}
 }
 
-// wantMCRPrefixListGeLeBody is the payload the API expects: ge/le as strings per
-// PrefixEntryDto, a deliberate 0 present as "0", an unset one absent.
+// wantMCRPrefixListGeLeBody pins ge/le as strings per PrefixEntryDto, a
+// deliberate 0 present as "0", an unset one absent. The leading id is not part
+// of PrefixListRequest; it is pre-existing and out of scope here.
 const wantMCRPrefixListGeLeBody = `{
 	"id": 0,
 	"description": "ge-le-list",
@@ -342,10 +343,8 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListGeLeEncoding() {
 	suite.True(got.IsUpdated)
 }
 
-// TestModifyMCRPrefixFilterListBodyEdgeCases pins the shapes the converter has
-// to leave alone: a nil list, a nil Entries, and a nil entry reach the wire
-// byte-identical to the old direct marshal. Whether the API accepts those
-// bodies is a separate question.
+// TestModifyMCRPrefixFilterListBodyEdgeCases pins a nil list and a nil Entries as
+// byte-identical to the old direct marshal, not as bodies the API accepts.
 func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	mcrSvc := suite.client.MCRService
@@ -365,21 +364,8 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 		{
 			name: "nil entries",
 			id:   2,
-			list: &MCRPrefixFilterList{Description: "d", AddressFamily: "IPv4"},
-			want: `{"id":0,"description":"d","addressFamily":"IPv4","entries":null}`,
-		},
-		{
-			name: "nil entry keeps its position",
-			id:   3,
-			list: &MCRPrefixFilterList{
-				Description:   "d",
-				AddressFamily: "IPv4",
-				Entries: []*MCRPrefixListEntry{
-					nil,
-					{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(0)},
-				},
-			},
-			want: `{"id":0,"description":"d","addressFamily":"IPv4","entries":[null,{"action":"permit","prefix":"10.0.1.0/24","ge":"0"}]}`,
+			list: &MCRPrefixFilterList{ID: 7, Description: "d", AddressFamily: "IPv4"},
+			want: `{"id":7,"description":"d","addressFamily":"IPv4","entries":null}`,
 		},
 	}
 
@@ -399,6 +385,23 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
 			suite.NoError(err)
 		})
 	}
+}
+
+// A nil entry is refused before the request goes out. The API's own validation
+// accepts a null element and faults on it further in, and the read path rejects
+// it, so emitting one is never right.
+func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListNilEntry() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+
+	_, err := suite.client.MCRService.ModifyMCRPrefixFilterList(ctx, mcrId, 4, &MCRPrefixFilterList{
+		Description:   "d",
+		AddressFamily: "IPv4",
+		Entries: []*MCRPrefixListEntry{
+			nil,
+			{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(0)},
+		},
+	})
+	suite.ErrorContains(err, "prefix list entry 0: nil entry")
 }
 
 // TestPrefixFilterListGeLeDecoding covers the read direction: an absent ge/le
@@ -427,9 +430,22 @@ func (suite *MCRClientTestSuite) TestPrefixFilterListGeLeDecoding() {
 	suite.Equal(PtrTo(0), got.Entries[2].Le)
 }
 
-// TestPrefixFilterListDecodeErrors covers the failure mode the string encoding
-// introduces: a ge/le the API sends that is not a number, and a null entry the
-// caller would otherwise have to nil-check.
+// A null entries array has to stay nil through the decode, or handing the result
+// straight back to Modify sends "entries":[], which deletes every entry.
+func (suite *MCRClientTestSuite) TestPrefixFilterListNullEntriesStaysNil() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+
+	suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, 21), func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":21,"description":"d","addressFamily":"IPv4","entries":null}}`)
+	})
+
+	got, err := suite.client.MCRService.GetMCRPrefixFilterList(ctx, mcrId, 21)
+	suite.NoError(err)
+	suite.Nil(got.Entries)
+}
+
+// TestPrefixFilterListDecodeErrors asserts a non-numeric ge/le or a null entry
+// fails the whole read, naming the entry, rather than being smoothed over.
 func (suite *MCRClientTestSuite) TestPrefixFilterListDecodeErrors() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	mcrSvc := suite.client.MCRService
@@ -447,10 +463,10 @@ func (suite *MCRClientTestSuite) TestPrefixFilterListDecodeErrors() {
 			wantErr: `prefix list entry 0: invalid ge "x"`,
 		},
 		{
-			name:    "non-numeric le",
+			name:    "non-numeric le on a later entry",
 			id:      12,
-			entries: `{"action":"permit","prefix":"10.0.1.0/24","le":"y"}`,
-			wantErr: `prefix list entry 0: invalid le "y"`,
+			entries: `{"action":"permit","prefix":"10.0.1.0/24"},{"action":"permit","prefix":"10.0.2.0/24","le":"y"}`,
+			wantErr: `prefix list entry 1: invalid le "y"`,
 		},
 		{
 			name:    "null entry",

--- a/mcr_test.go
+++ b/mcr_test.go
@@ -270,36 +270,36 @@ func (suite *MCRClientTestSuite) TestCreatePrefixFilterList() {
 	suite.NoError(prefixErr)
 }
 
-// geLeEncodingList is the fixture for the ge/le wire-encoding tests: one entry
-// with both set, one with a deliberate 0, one with neither.
-func geLeEncodingList() MCRPrefixFilterList {
+// mcrPrefixListGeLeFixture covers every ge/le cell: both set, both a deliberate
+// 0, neither set, and one set without the other.
+func mcrPrefixListGeLeFixture() MCRPrefixFilterList {
 	return MCRPrefixFilterList{
 		Description:   "ge-le-list",
 		AddressFamily: "IPv4",
 		Entries: []*MCRPrefixListEntry{
 			{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(25), Le: PtrTo(32)},
-			{Action: "deny", Prefix: "10.0.2.0/24", Ge: PtrTo(0), Le: PtrTo(25)},
+			{Action: "deny", Prefix: "10.0.2.0/24", Ge: PtrTo(0), Le: PtrTo(0)},
 			{Action: "permit", Prefix: "10.0.3.0/24"},
+			{Action: "permit", Prefix: "10.0.4.0/24", Le: PtrTo(30)},
 		},
 	}
 }
 
-// wantGeLeBody is the payload the API expects: ge/le are strings per
-// PrefixEntryDto, a deliberate 0 is present as "0", and an unset ge/le is
-// absent rather than sent as 0.
-const wantGeLeBody = `{
+// wantMCRPrefixListGeLeBody is the payload the API expects: ge/le as strings per
+// PrefixEntryDto, a deliberate 0 present as "0", an unset one absent.
+const wantMCRPrefixListGeLeBody = `{
 	"id": 0,
 	"description": "ge-le-list",
 	"addressFamily": "IPv4",
 	"entries": [
 		{"action": "permit", "prefix": "10.0.1.0/24", "ge": "25", "le": "32"},
-		{"action": "deny", "prefix": "10.0.2.0/24", "ge": "0", "le": "25"},
-		{"action": "permit", "prefix": "10.0.3.0/24"}
+		{"action": "deny", "prefix": "10.0.2.0/24", "ge": "0", "le": "0"},
+		{"action": "permit", "prefix": "10.0.3.0/24"},
+		{"action": "permit", "prefix": "10.0.4.0/24", "le": "30"}
 	]
 }`
 
-// TestCreatePrefixFilterListGeLeEncoding asserts the marshaled POST body, not
-// just that a stubbed response decodes.
+// TestCreatePrefixFilterListGeLeEncoding asserts the marshaled POST body.
 func (suite *MCRClientTestSuite) TestCreatePrefixFilterListGeLeEncoding() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	mcrSvc := suite.client.MCRService
@@ -310,13 +310,13 @@ func (suite *MCRClientTestSuite) TestCreatePrefixFilterListGeLeEncoding() {
 		if err != nil {
 			suite.FailNowf("could not read body", "%v", err)
 		}
-		suite.JSONEq(wantGeLeBody, string(body))
+		suite.JSONEq(wantMCRPrefixListGeLeBody, string(body))
 		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":2819,"description":"ge-le-list","addressFamily":"IPv4","entries":[]}}`)
 	})
 
 	_, err := mcrSvc.CreatePrefixFilterList(ctx, &CreateMCRPrefixFilterListRequest{
 		MCRID:            mcrId,
-		PrefixFilterList: geLeEncodingList(),
+		PrefixFilterList: mcrPrefixListGeLeFixture(),
 	})
 	suite.NoError(err)
 }
@@ -325,7 +325,7 @@ func (suite *MCRClientTestSuite) TestCreatePrefixFilterListGeLeEncoding() {
 func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListGeLeEncoding() {
 	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
 	mcrSvc := suite.client.MCRService
-	list := geLeEncodingList()
+	list := mcrPrefixListGeLeFixture()
 
 	suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, 2819), func(w http.ResponseWriter, r *http.Request) {
 		suite.testMethod(r, http.MethodPut)
@@ -333,13 +333,69 @@ func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListGeLeEncoding() {
 		if err != nil {
 			suite.FailNowf("could not read body", "%v", err)
 		}
-		suite.JSONEq(wantGeLeBody, string(body))
+		suite.JSONEq(wantMCRPrefixListGeLeBody, string(body))
 		fmt.Fprint(w, `{"message":"ok","terms":""}`)
 	})
 
 	got, err := mcrSvc.ModifyMCRPrefixFilterList(ctx, mcrId, 2819, &list)
 	suite.NoError(err)
 	suite.True(got.IsUpdated)
+}
+
+// TestModifyMCRPrefixFilterListBodyEdgeCases pins the shapes the converter has
+// to leave alone: a nil list, a nil Entries, and a nil entry all reach the wire
+// as they did when this type was marshaled directly.
+func (suite *MCRClientTestSuite) TestModifyMCRPrefixFilterListBodyEdgeCases() {
+	mcrId := "36b3f68e-2f54-4331-bf94-f8984449365f"
+	mcrSvc := suite.client.MCRService
+
+	cases := []struct {
+		name string
+		id   int
+		list *MCRPrefixFilterList
+		want string
+	}{
+		{
+			name: "nil list",
+			id:   1,
+			list: nil,
+			want: `null`,
+		},
+		{
+			name: "nil entries",
+			id:   2,
+			list: &MCRPrefixFilterList{Description: "d", AddressFamily: "IPv4"},
+			want: `{"id":0,"description":"d","addressFamily":"IPv4","entries":null}`,
+		},
+		{
+			name: "nil entry keeps its position",
+			id:   3,
+			list: &MCRPrefixFilterList{
+				Description:   "d",
+				AddressFamily: "IPv4",
+				Entries: []*MCRPrefixListEntry{
+					nil,
+					{Action: "permit", Prefix: "10.0.1.0/24", Ge: PtrTo(0)},
+				},
+			},
+			want: `{"id":0,"description":"d","addressFamily":"IPv4","entries":[null,{"action":"permit","prefix":"10.0.1.0/24","ge":"0"}]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // go 1.21: the loop variable is shared with the handler closure
+		suite.mux.HandleFunc(fmt.Sprintf("/v2/product/mcr2/%s/prefixList/%d", mcrId, tc.id), func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				suite.FailNowf("could not read body", "%v", err)
+			}
+			suite.JSONEq(tc.want, string(body))
+			fmt.Fprint(w, `{"message":"ok","terms":""}`)
+		})
+
+		_, err := mcrSvc.ModifyMCRPrefixFilterList(ctx, mcrId, tc.id, tc.list)
+		suite.NoErrorf(err, "case %s", tc.name)
+	}
 }
 
 // TestPrefixFilterListGeLeDecoding covers the read direction: an absent ge/le
@@ -352,17 +408,23 @@ func (suite *MCRClientTestSuite) TestPrefixFilterListGeLeDecoding() {
 		suite.testMethod(r, http.MethodGet)
 		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":7,"description":"d","addressFamily":"IPv4","entries":[
 			{"action":"permit","prefix":"10.0.1.0/24","ge":"0","le":"25"},
-			{"action":"deny","prefix":"10.0.2.0/24"}
+			{"action":"deny","prefix":"10.0.2.0/24"},
+			{"action":"permit","prefix":"10.0.3.0/24","le":"0"},
+			null
 		]}}`)
 	})
 
 	got, err := mcrSvc.GetMCRPrefixFilterList(ctx, mcrId, 7)
 	suite.NoError(err)
-	suite.Require().Len(got.Entries, 2)
+	suite.Require().Len(got.Entries, 4)
 	suite.Equal(PtrTo(0), got.Entries[0].Ge)
 	suite.Equal(PtrTo(25), got.Entries[0].Le)
 	suite.Nil(got.Entries[1].Ge)
 	suite.Nil(got.Entries[1].Le)
+	suite.Nil(got.Entries[2].Ge)
+	suite.Equal(PtrTo(0), got.Entries[2].Le)
+	// A null entry decodes to nil instead of panicking.
+	suite.Nil(got.Entries[3])
 }
 
 // TestListMCRs tests the ListMCRs method

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -208,10 +208,14 @@ type APIMCRPrefixFilterList struct {
 }
 
 func (e *APIMCRPrefixFilterList) ToMCRPrefixFilterList() (*MCRPrefixFilterList, error) {
-	entries := make([]*MCRPrefixListEntry, len(e.Entries))
+	// Allocate only for a non-nil slice, so a null entries array does not come
+	// back as [] and turn a read-modify-write into "delete every entry".
+	var entries []*MCRPrefixListEntry
+	if e.Entries != nil {
+		entries = make([]*MCRPrefixListEntry, len(e.Entries))
+	}
 	for i, entry := range e.Entries {
-		// Rejecting a null entry beats returning a nil element for the caller to
-		// dereference. The API declares entries non-nullable, so this is malformed.
+		// The API declares entries non-nullable, so a null is malformed.
 		if entry == nil {
 			return nil, fmt.Errorf("prefix list entry %d: null entry in response", i)
 		}
@@ -247,10 +251,11 @@ func (e *APIMCRPrefixFilterListEntry) ToMCRPrefixFilterListEntry() (*MCRPrefixLi
 }
 
 // toAPI converts the user-facing MCRPrefixFilterList to its wire-level
-// representation, where the API expects Ge/Le as strings.
-func (l *MCRPrefixFilterList) toAPI() *APIMCRPrefixFilterList {
+// representation, where the API expects Ge/Le as strings. A nil entry is an
+// error rather than a null on the wire.
+func (l *MCRPrefixFilterList) toAPI() (*APIMCRPrefixFilterList, error) {
 	if l == nil {
-		return nil
+		return nil, nil
 	}
 	// Allocate only for a non-nil slice, so a nil Entries still marshals as
 	// null rather than [].
@@ -259,9 +264,10 @@ func (l *MCRPrefixFilterList) toAPI() *APIMCRPrefixFilterList {
 		entries = make([]*APIMCRPrefixFilterListEntry, len(l.Entries))
 	}
 	for i, entry := range l.Entries {
-		// A nil entry stays nil so it marshals as null.
+		// Refuse to send what the read path refuses to accept. A null element
+		// passes the API's own validation and faults it further in.
 		if entry == nil {
-			continue
+			return nil, fmt.Errorf("prefix list entry %d: nil entry", i)
 		}
 		entries[i] = &APIMCRPrefixFilterListEntry{
 			Action: entry.Action,
@@ -275,5 +281,5 @@ func (l *MCRPrefixFilterList) toAPI() *APIMCRPrefixFilterList {
 		Description:   l.Description,
 		AddressFamily: l.AddressFamily,
 		Entries:       entries,
-	}
+	}, nil
 }

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -251,21 +251,18 @@ func (e *APIMCRPrefixFilterListEntry) ToMCRPrefixFilterListEntry() (*MCRPrefixLi
 }
 
 // toAPI converts the user-facing MCRPrefixFilterList to its wire-level
-// representation, where the API expects Ge/Le as strings. A nil entry is an
-// error rather than a null on the wire.
+// representation, where the API expects Ge/Le as strings. A nil list, a nil
+// Entries, or a nil entry is refused here rather than sent: the API 400s on all
+// three. An empty Entries is valid and clears the list.
 func (l *MCRPrefixFilterList) toAPI() (*APIMCRPrefixFilterList, error) {
 	if l == nil {
-		return nil, nil
+		return nil, ErrMCRPrefixFilterListNil
 	}
-	// Allocate only for a non-nil slice, so a nil Entries still marshals as
-	// null rather than [].
-	var entries []*APIMCRPrefixFilterListEntry
-	if l.Entries != nil {
-		entries = make([]*APIMCRPrefixFilterListEntry, len(l.Entries))
+	if l.Entries == nil {
+		return nil, ErrMCRPrefixFilterListEntriesNil
 	}
+	entries := make([]*APIMCRPrefixFilterListEntry, len(l.Entries))
 	for i, entry := range l.Entries {
-		// Refuse to send what the read path refuses to accept. A null element
-		// passes the API's own validation and faults it further in.
 		if entry == nil {
 			return nil, fmt.Errorf("prefix list entry %d: nil entry", i)
 		}

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -152,11 +152,13 @@ type APIMCRPrefixFilterListEntry struct {
 }
 
 // MCRPrefixListEntry represents an entry in a prefix filter list.
+// Ge/Le are pointers because 0 is a valid prefix length the API treats
+// differently from an absent value.
 type MCRPrefixListEntry struct {
 	Action string `json:"action"`
 	Prefix string `json:"prefix"`
-	Ge     int    `json:"ge,omitempty"` // Great than or equal to - (Optional) The minimum starting prefix length to be matched. Valid values are from 0 to 32 (IPv4), or 0 to 128 (IPv6). The minimum (ge) must be no greater than or equal to the maximum value (le).
-	Le     int    `json:"le,omitempty"` // Less than or equal to - (Optional) The maximum ending prefix length to be matched. The prefix length is greater than or equal to the minimum value (ge). Valid values are from 0 to 32 (IPv4), or 0 to 128 (IPv6), but the maximum must be no less than the minimum value (ge).
+	Ge     *int   `json:"ge,omitempty"` // Great than or equal to - (Optional) The minimum starting prefix length to be matched. Valid values are from 0 to 32 (IPv4), or 0 to 128 (IPv6). The minimum (ge) must be no greater than or equal to the maximum value (le).
+	Le     *int   `json:"le,omitempty"` // Less than or equal to - (Optional) The maximum ending prefix length to be matched. The prefix length is greater than or equal to the minimum value (ge). Valid values are from 0 to 32 (IPv4), or 0 to 128 (IPv6), but the maximum must be no less than the minimum value (ge).
 }
 
 // mcrOrderResponse represents a response from the Megaport Products API after ordering an MCR.
@@ -223,20 +225,20 @@ func (e *APIMCRPrefixFilterList) ToMCRPrefixFilterList() (*MCRPrefixFilterList, 
 }
 
 func (e *APIMCRPrefixFilterListEntry) ToMCRPrefixFilterListEntry() (*MCRPrefixListEntry, error) {
-	var ge, le int
+	var ge, le *int
 	if e.Ge != "" {
 		geVal, err := strconv.Atoi(e.Ge)
 		if err != nil {
 			return nil, err
 		}
-		ge = geVal
+		ge = &geVal
 	}
 	if e.Le != "" {
 		leVal, err := strconv.Atoi(e.Le)
 		if err != nil {
 			return nil, err
 		}
-		le = leVal
+		le = &leVal
 	}
 	return &MCRPrefixListEntry{
 		Action: e.Action,
@@ -244,4 +246,38 @@ func (e *APIMCRPrefixFilterListEntry) ToMCRPrefixFilterListEntry() (*MCRPrefixLi
 		Ge:     ge,
 		Le:     le,
 	}, nil
+}
+
+// toAPI converts the user-facing MCRPrefixFilterList to its wire-level
+// representation, where the API expects Ge/Le as strings. A set Ge/Le of 0
+// goes out as "0"; nil is omitted.
+func (l *MCRPrefixFilterList) toAPI() *APIMCRPrefixFilterList {
+	if l == nil {
+		return nil
+	}
+	entries := make([]*APIMCRPrefixFilterListEntry, len(l.Entries))
+	for i, entry := range l.Entries {
+		// A nil entry stays nil so it marshals as null, as it did when this
+		// type went on the wire directly.
+		if entry == nil {
+			continue
+		}
+		apiEntry := &APIMCRPrefixFilterListEntry{
+			Action: entry.Action,
+			Prefix: entry.Prefix,
+		}
+		if entry.Ge != nil {
+			apiEntry.Ge = strconv.Itoa(*entry.Ge)
+		}
+		if entry.Le != nil {
+			apiEntry.Le = strconv.Itoa(*entry.Le)
+		}
+		entries[i] = apiEntry
+	}
+	return &APIMCRPrefixFilterList{
+		ID:            l.ID,
+		Description:   l.Description,
+		AddressFamily: l.AddressFamily,
+		Entries:       entries,
+	}
 }

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -1,6 +1,6 @@
 package megaport
 
-import "strconv"
+import "fmt"
 
 // MCROrder represents a request to buy an MCR from the Megaport Products API.
 type MCROrder struct {
@@ -210,13 +210,14 @@ type APIMCRPrefixFilterList struct {
 func (e *APIMCRPrefixFilterList) ToMCRPrefixFilterList() (*MCRPrefixFilterList, error) {
 	entries := make([]*MCRPrefixListEntry, len(e.Entries))
 	for i, entry := range e.Entries {
-		// A null entry in the response stays nil rather than panicking.
+		// Rejecting a null entry beats returning a nil element for the caller to
+		// dereference. The API declares entries non-nullable, so this is malformed.
 		if entry == nil {
-			continue
+			return nil, fmt.Errorf("prefix list entry %d: null entry in response", i)
 		}
 		mcrEntry, err := entry.ToMCRPrefixFilterListEntry()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("prefix list entry %d: %w", i, err)
 		}
 		entries[i] = mcrEntry
 	}
@@ -229,20 +230,13 @@ func (e *APIMCRPrefixFilterList) ToMCRPrefixFilterList() (*MCRPrefixFilterList, 
 }
 
 func (e *APIMCRPrefixFilterListEntry) ToMCRPrefixFilterListEntry() (*MCRPrefixListEntry, error) {
-	var ge, le *int
-	if e.Ge != "" {
-		geVal, err := strconv.Atoi(e.Ge)
-		if err != nil {
-			return nil, err
-		}
-		ge = &geVal
+	ge, err := prefixLenFromAPI(e.Ge)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ge %q: %w", e.Ge, err)
 	}
-	if e.Le != "" {
-		leVal, err := strconv.Atoi(e.Le)
-		if err != nil {
-			return nil, err
-		}
-		le = &leVal
+	le, err := prefixLenFromAPI(e.Le)
+	if err != nil {
+		return nil, fmt.Errorf("invalid le %q: %w", e.Le, err)
 	}
 	return &MCRPrefixListEntry{
 		Action: e.Action,
@@ -269,17 +263,12 @@ func (l *MCRPrefixFilterList) toAPI() *APIMCRPrefixFilterList {
 		if entry == nil {
 			continue
 		}
-		apiEntry := &APIMCRPrefixFilterListEntry{
+		entries[i] = &APIMCRPrefixFilterListEntry{
 			Action: entry.Action,
 			Prefix: entry.Prefix,
+			Ge:     prefixLenToAPI(entry.Ge),
+			Le:     prefixLenToAPI(entry.Le),
 		}
-		if entry.Ge != nil {
-			apiEntry.Ge = strconv.Itoa(*entry.Ge)
-		}
-		if entry.Le != nil {
-			apiEntry.Le = strconv.Itoa(*entry.Le)
-		}
-		entries[i] = apiEntry
 	}
 	return &APIMCRPrefixFilterList{
 		ID:            l.ID,

--- a/mcr_types.go
+++ b/mcr_types.go
@@ -210,6 +210,10 @@ type APIMCRPrefixFilterList struct {
 func (e *APIMCRPrefixFilterList) ToMCRPrefixFilterList() (*MCRPrefixFilterList, error) {
 	entries := make([]*MCRPrefixListEntry, len(e.Entries))
 	for i, entry := range e.Entries {
+		// A null entry in the response stays nil rather than panicking.
+		if entry == nil {
+			continue
+		}
 		mcrEntry, err := entry.ToMCRPrefixFilterListEntry()
 		if err != nil {
 			return nil, err
@@ -249,16 +253,19 @@ func (e *APIMCRPrefixFilterListEntry) ToMCRPrefixFilterListEntry() (*MCRPrefixLi
 }
 
 // toAPI converts the user-facing MCRPrefixFilterList to its wire-level
-// representation, where the API expects Ge/Le as strings. A set Ge/Le of 0
-// goes out as "0"; nil is omitted.
+// representation, where the API expects Ge/Le as strings.
 func (l *MCRPrefixFilterList) toAPI() *APIMCRPrefixFilterList {
 	if l == nil {
 		return nil
 	}
-	entries := make([]*APIMCRPrefixFilterListEntry, len(l.Entries))
+	// Allocate only for a non-nil slice, so a nil Entries still marshals as
+	// null rather than [].
+	var entries []*APIMCRPrefixFilterListEntry
+	if l.Entries != nil {
+		entries = make([]*APIMCRPrefixFilterListEntry, len(l.Entries))
+	}
 	for i, entry := range l.Entries {
-		// A nil entry stays nil so it marshals as null, as it did when this
-		// type went on the wire directly.
+		// A nil entry stays nil so it marshals as null.
 		if entry == nil {
 			continue
 		}

--- a/nat_gateway_integration_test.go
+++ b/nat_gateway_integration_test.go
@@ -579,7 +579,7 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayPrefixListLifecycle()
 	cases := []struct {
 		name               string
 		create             *NATGatewayPrefixList
-		expectGe, expectLe int
+		expectGe, expectLe *int
 		// extraPrefix is appended on update — must differ from the create
 		// entries' prefix to avoid the API's duplicate-prefix rejection.
 		extraPrefix string
@@ -590,11 +590,11 @@ func (suite *NATGatewayIntegrationTestSuite) TestNATGatewayPrefixListLifecycle()
 				Description:   "integration-test-v4",
 				AddressFamily: AddressFamilyIPv4,
 				Entries: []NATGatewayPrefixListEntry{
-					{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+					{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: PtrTo(24), Le: PtrTo(32)},
 				},
 			},
-			expectGe:    24,
-			expectLe:    32,
+			expectGe:    PtrTo(24),
+			expectLe:    PtrTo(32),
 			extraPrefix: "172.16.0.0/12",
 		},
 		{

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -1044,6 +1044,20 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidGe() {
 	suite.Error(err)
 }
 
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidLe() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-bad-le"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/4", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8","le":"not-a-number"}]}}`)
+	})
+
+	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
+	suite.ErrorContains(err, `invalid le "not-a-number"`)
+}
+
 func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListValidation() {
 	_, err := suite.client.NATGatewayService.GetNATGatewayPrefixList(context.Background(), "", 1)
 	suite.ErrorIs(err, ErrNATGatewayProductUIDRequired)

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -1059,6 +1059,18 @@ func (suite *NATGatewayClientTestSuite) TestUpdateNATGatewayPrefixList() {
 
 	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/5", func(w http.ResponseWriter, r *http.Request) {
 		suite.Equal(http.MethodPut, r.Method)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			suite.FailNowf("could not read body", "%v", err)
+		}
+		suite.JSONEq(`{
+			"description": "updated",
+			"addressFamily": "IPv4",
+			"entries": [
+				{"action": "permit", "prefix": "172.16.0.0/12", "ge": "0", "le": "24"},
+				{"action": "deny", "prefix": "10.0.0.0/8"}
+			]
+		}`, string(body))
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":5,"description":"updated","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"172.16.0.0/12"}]}}`)
 	})
@@ -1066,7 +1078,10 @@ func (suite *NATGatewayClientTestSuite) TestUpdateNATGatewayPrefixList() {
 	pl, err := natSvc.UpdateNATGatewayPrefixList(ctx, productUID, 5, &NATGatewayPrefixList{
 		Description:   "updated",
 		AddressFamily: AddressFamilyIPv4,
-		Entries:       []NATGatewayPrefixListEntry{{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12"}},
+		Entries: []NATGatewayPrefixListEntry{
+			{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12", Ge: PtrTo(0), Le: PtrTo(24)},
+			{Action: PrefixListActionDeny, Prefix: "10.0.0.0/8"},
+		},
 	})
 	suite.NoError(err)
 	suite.Equal("updated", pl.Description)
@@ -1291,7 +1306,7 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 		Entries: []NATGatewayPrefixListEntry{
 			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: PtrTo(24), Le: PtrTo(32)},
 			{Action: PrefixListActionDeny, Prefix: "0.0.0.0/0"}, // ge/le omitted
-			{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12", Ge: PtrTo(0), Le: PtrTo(24)},
+			{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12", Ge: PtrTo(0), Le: PtrTo(0)},
 		},
 	}
 
@@ -1301,6 +1316,7 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 	suite.Equal("", api.Entries[1].Ge)
 	suite.Equal("", api.Entries[1].Le)
 	suite.Equal("0", api.Entries[2].Ge)
+	suite.Equal("0", api.Entries[2].Le)
 
 	// A deliberate 0 has to survive the wire type's omitempty, and an unset
 	// ge/le has to stay absent.
@@ -1312,7 +1328,7 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 		"entries": [
 			{"action": "permit", "prefix": "10.0.0.0/8", "ge": "24", "le": "32"},
 			{"action": "deny", "prefix": "0.0.0.0/0"},
-			{"action": "permit", "prefix": "172.16.0.0/12", "ge": "0", "le": "24"}
+			{"action": "permit", "prefix": "172.16.0.0/12", "ge": "0", "le": "0"}
 		]
 	}`, string(body))
 
@@ -1323,4 +1339,5 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 	suite.Nil(back.Entries[1].Ge)
 	suite.Nil(back.Entries[1].Le)
 	suite.Equal(PtrTo(0), back.Entries[2].Ge)
+	suite.Equal(PtrTo(0), back.Entries[2].Le)
 }

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -1037,11 +1037,11 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidGe() {
 
 	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/4", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8","ge":"not-a-number"}]}}`)
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8"},{"action":"permit","prefix":"10.0.1.0/24","ge":"not-a-number"}]}}`)
 	})
 
 	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
-	suite.ErrorContains(err, `prefix list entry 0: invalid ge "not-a-number"`)
+	suite.ErrorContains(err, `prefix list entry 1: invalid ge "not-a-number"`)
 }
 
 func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidLe() {
@@ -1058,8 +1058,8 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidLe() {
 	suite.ErrorContains(err, `prefix list entry 1: invalid le "not-a-number"`)
 }
 
-// A null entry is rejected on the NAT read path too. Both products share one
-// schema, and a value-typed wire slice would smooth it into a blank entry.
+// TestGetNATGatewayPrefixListNullEntry covers the NAT read path's null entry,
+// which a value-typed wire slice would smooth into a blank entry.
 func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListNullEntry() {
 	ctx := context.Background()
 	natSvc := suite.client.NATGatewayService
@@ -1072,6 +1072,41 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListNullEntry() {
 
 	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
 	suite.ErrorContains(err, "prefix list entry 1: null entry in response")
+}
+
+// TestNATGatewayPrefixListNullEntryOnWrite covers the create and update
+// read-backs, which decode the same envelope through their own call sites.
+func (suite *NATGatewayClientTestSuite) TestNATGatewayPrefixListNullEntryOnWrite() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-null-write"
+	const nullEntryBody = `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8"},null]}}`
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, nullEntryBody)
+	})
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/4", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, nullEntryBody)
+	})
+
+	req := &NATGatewayPrefixList{
+		Description:   "x",
+		AddressFamily: AddressFamilyIPv4,
+		Entries: []NATGatewayPrefixListEntry{
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8"},
+		},
+	}
+
+	suite.Run("create", func() {
+		_, err := natSvc.CreateNATGatewayPrefixList(ctx, productUID, req)
+		suite.ErrorContains(err, "prefix list entry 1: null entry in response")
+	})
+	suite.Run("update", func() {
+		_, err := natSvc.UpdateNATGatewayPrefixList(ctx, productUID, 4, req)
+		suite.ErrorContains(err, "prefix list entry 1: null entry in response")
+	})
 }
 
 func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListValidation() {
@@ -1335,8 +1370,10 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 		AddressFamily: AddressFamilyIPv4,
 		Entries: []NATGatewayPrefixListEntry{
 			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: PtrTo(24), Le: PtrTo(32)},
-			{Action: PrefixListActionDeny, Prefix: "0.0.0.0/0"}, // ge/le omitted
-			{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12", Ge: PtrTo(0), Le: PtrTo(0)},
+			{Action: PrefixListActionDeny, Prefix: "172.16.0.0/12"}, // ge/le omitted
+			// A 0 is only valid on a default route: the API requires ge to be
+			// at least the prefix length.
+			{Action: PrefixListActionPermit, Prefix: "0.0.0.0/0", Ge: PtrTo(0), Le: PtrTo(0)},
 		},
 	}
 
@@ -1357,17 +1394,24 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 		"addressFamily": "IPv4",
 		"entries": [
 			{"action": "permit", "prefix": "10.0.0.0/8", "ge": "24", "le": "32"},
-			{"action": "deny", "prefix": "0.0.0.0/0"},
-			{"action": "permit", "prefix": "172.16.0.0/12", "ge": "0", "le": "0"}
+			{"action": "deny", "prefix": "172.16.0.0/12"},
+			{"action": "permit", "prefix": "0.0.0.0/0", "ge": "0", "le": "0"}
 		]
 	}`, string(body))
 
 	back, err := api.toPrefixList()
 	suite.Require().NoError(err)
+	suite.Equal("rt", back.Description)
+	suite.Equal(AddressFamilyIPv4, back.AddressFamily)
+	suite.Equal(PrefixListActionPermit, back.Entries[0].Action)
+	suite.Equal("10.0.0.0/8", back.Entries[0].Prefix)
 	suite.Equal(PtrTo(24), back.Entries[0].Ge)
 	suite.Equal(PtrTo(32), back.Entries[0].Le)
+	suite.Equal(PrefixListActionDeny, back.Entries[1].Action)
+	suite.Equal("172.16.0.0/12", back.Entries[1].Prefix)
 	suite.Nil(back.Entries[1].Ge)
 	suite.Nil(back.Entries[1].Le)
+	suite.Equal("0.0.0.0/0", back.Entries[2].Prefix)
 	suite.Equal(PtrTo(0), back.Entries[2].Ge)
 	suite.Equal(PtrTo(0), back.Entries[2].Le)
 }

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -1041,7 +1041,7 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidGe() {
 	})
 
 	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
-	suite.Error(err)
+	suite.ErrorContains(err, `prefix list entry 0: invalid ge "not-a-number"`)
 }
 
 func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidLe() {
@@ -1051,11 +1051,27 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListInvalidLe() {
 
 	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/4", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8","le":"not-a-number"}]}}`)
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8"},{"action":"permit","prefix":"10.0.1.0/24","le":"not-a-number"}]}}`)
 	})
 
 	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
-	suite.ErrorContains(err, `invalid le "not-a-number"`)
+	suite.ErrorContains(err, `prefix list entry 1: invalid le "not-a-number"`)
+}
+
+// A null entry is rejected on the NAT read path too. Both products share one
+// schema, and a value-typed wire slice would smooth it into a blank entry.
+func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListNullEntry() {
+	ctx := context.Background()
+	natSvc := suite.client.NATGatewayService
+	productUID := "uid-pl-null-entry"
+
+	suite.mux.HandleFunc("/v3/products/nat_gateways/"+productUID+"/prefix_lists/4", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"ok","terms":"","data":{"id":4,"description":"x","addressFamily":"IPv4","entries":[{"action":"permit","prefix":"10.0.0.0/8"},null]}}`)
+	})
+
+	_, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 4)
+	suite.ErrorContains(err, "prefix list entry 1: null entry in response")
 }
 
 func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixListValidation() {

--- a/nat_gateway_test.go
+++ b/nat_gateway_test.go
@@ -981,13 +981,13 @@ func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayPrefixList() {
 		Description:   "private",
 		AddressFamily: AddressFamilyIPv4,
 		Entries: []NATGatewayPrefixListEntry{
-			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: PtrTo(24), Le: PtrTo(32)},
 		},
 	})
 	suite.NoError(err)
 	suite.Equal(11, pl.ID)
-	suite.Equal(24, pl.Entries[0].Ge)
-	suite.Equal(32, pl.Entries[0].Le)
+	suite.Equal(PtrTo(24), pl.Entries[0].Ge)
+	suite.Equal(PtrTo(32), pl.Entries[0].Le)
 }
 
 func (suite *NATGatewayClientTestSuite) TestCreateNATGatewayPrefixListValidation() {
@@ -1025,8 +1025,8 @@ func (suite *NATGatewayClientTestSuite) TestGetNATGatewayPrefixList() {
 	pl, err := natSvc.GetNATGatewayPrefixList(ctx, productUID, 3)
 	suite.NoError(err)
 	suite.Equal(AddressFamilyIPv6, pl.AddressFamily)
-	suite.Equal(0, pl.Entries[0].Ge)
-	suite.Equal(0, pl.Entries[0].Le)
+	suite.Nil(pl.Entries[0].Ge)
+	suite.Nil(pl.Entries[0].Le)
 	suite.Equal(PrefixListActionDeny, pl.Entries[0].Action)
 }
 
@@ -1289,8 +1289,9 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 		Description:   "rt",
 		AddressFamily: AddressFamilyIPv4,
 		Entries: []NATGatewayPrefixListEntry{
-			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: PtrTo(24), Le: PtrTo(32)},
 			{Action: PrefixListActionDeny, Prefix: "0.0.0.0/0"}, // ge/le omitted
+			{Action: PrefixListActionPermit, Prefix: "172.16.0.0/12", Ge: PtrTo(0), Le: PtrTo(24)},
 		},
 	}
 
@@ -1299,11 +1300,27 @@ func (suite *NATGatewayClientTestSuite) TestPrefixListGeLeRoundTrip() {
 	suite.Equal("32", api.Entries[0].Le)
 	suite.Equal("", api.Entries[1].Ge)
 	suite.Equal("", api.Entries[1].Le)
+	suite.Equal("0", api.Entries[2].Ge)
+
+	// A deliberate 0 has to survive the wire type's omitempty, and an unset
+	// ge/le has to stay absent.
+	body, err := json.Marshal(api)
+	suite.Require().NoError(err)
+	suite.JSONEq(`{
+		"description": "rt",
+		"addressFamily": "IPv4",
+		"entries": [
+			{"action": "permit", "prefix": "10.0.0.0/8", "ge": "24", "le": "32"},
+			{"action": "deny", "prefix": "0.0.0.0/0"},
+			{"action": "permit", "prefix": "172.16.0.0/12", "ge": "0", "le": "24"}
+		]
+	}`, string(body))
 
 	back, err := api.toPrefixList()
 	suite.Require().NoError(err)
-	suite.Equal(24, back.Entries[0].Ge)
-	suite.Equal(32, back.Entries[0].Le)
-	suite.Equal(0, back.Entries[1].Ge)
-	suite.Equal(0, back.Entries[1].Le)
+	suite.Equal(PtrTo(24), back.Entries[0].Ge)
+	suite.Equal(PtrTo(32), back.Entries[0].Le)
+	suite.Nil(back.Entries[1].Ge)
+	suite.Nil(back.Entries[1].Le)
+	suite.Equal(PtrTo(0), back.Entries[2].Ge)
 }

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -290,14 +290,15 @@ type NATGatewayPrefixList struct {
 	Entries       []NATGatewayPrefixListEntry `json:"entries"`
 }
 
-// NATGatewayPrefixListEntry is a single entry in a prefix list. Ge/Le are
-// exposed as ints for ergonomics; the SDK converts to/from the API's string
-// representation transparently.
+// NATGatewayPrefixListEntry is a single entry in a prefix list. The SDK
+// converts Ge/Le to and from the API's string representation transparently.
+// They are pointers because 0 is a valid prefix length the API treats
+// differently from an absent value.
 type NATGatewayPrefixListEntry struct {
 	Action string `json:"action"` // PrefixListActionPermit or PrefixListActionDeny.
 	Prefix string `json:"prefix"`
-	Ge     int    `json:"ge,omitempty"`
-	Le     int    `json:"le,omitempty"`
+	Ge     *int   `json:"ge,omitempty"`
+	Le     *int   `json:"le,omitempty"`
 }
 
 // NATGatewayPrefixListSummary is the compact entry returned by the
@@ -326,7 +327,8 @@ type apiNATGatewayPrefixListEntry struct {
 }
 
 // toAPI converts the user-facing NATGatewayPrefixList to its wire-level
-// representation (Ge/Le as strings, zero values omitted).
+// representation (Ge/Le as strings). A set Ge/Le of 0 goes out as "0"; nil is
+// omitted.
 func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
 	out := &apiNATGatewayPrefixList{
 		ID:            p.ID,
@@ -339,11 +341,11 @@ func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
 			Action: e.Action,
 			Prefix: e.Prefix,
 		}
-		if e.Ge > 0 {
-			apiEntry.Ge = strconv.Itoa(e.Ge)
+		if e.Ge != nil {
+			apiEntry.Ge = strconv.Itoa(*e.Ge)
 		}
-		if e.Le > 0 {
-			apiEntry.Le = strconv.Itoa(e.Le)
+		if e.Le != nil {
+			apiEntry.Le = strconv.Itoa(*e.Le)
 		}
 		out.Entries[i] = apiEntry
 	}
@@ -366,14 +368,14 @@ func (a *apiNATGatewayPrefixList) toPrefixList() (*NATGatewayPrefixList, error) 
 			if err != nil {
 				return nil, fmt.Errorf("prefix list entry %d: invalid ge %q: %w", i, e.Ge, err)
 			}
-			entry.Ge = ge
+			entry.Ge = &ge
 		}
 		if e.Le != "" {
 			le, err := strconv.Atoi(e.Le)
 			if err != nil {
 				return nil, fmt.Errorf("prefix list entry %d: invalid le %q: %w", i, e.Le, err)
 			}
-			entry.Le = le
+			entry.Le = &le
 		}
 		out.Entries[i] = entry
 	}

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -3,7 +3,6 @@ package megaport
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 )
 
 // NATGatewaySession represents a speed/session-count availability entry for NAT Gateways.
@@ -335,17 +334,12 @@ func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
 		Entries:       make([]apiNATGatewayPrefixListEntry, len(p.Entries)),
 	}
 	for i, e := range p.Entries {
-		apiEntry := apiNATGatewayPrefixListEntry{
+		out.Entries[i] = apiNATGatewayPrefixListEntry{
 			Action: e.Action,
 			Prefix: e.Prefix,
+			Ge:     prefixLenToAPI(e.Ge),
+			Le:     prefixLenToAPI(e.Le),
 		}
-		if e.Ge != nil {
-			apiEntry.Ge = strconv.Itoa(*e.Ge)
-		}
-		if e.Le != nil {
-			apiEntry.Le = strconv.Itoa(*e.Le)
-		}
-		out.Entries[i] = apiEntry
 	}
 	return out
 }
@@ -360,22 +354,20 @@ func (a *apiNATGatewayPrefixList) toPrefixList() (*NATGatewayPrefixList, error) 
 		Entries:       make([]NATGatewayPrefixListEntry, len(a.Entries)),
 	}
 	for i, e := range a.Entries {
-		entry := NATGatewayPrefixListEntry{Action: e.Action, Prefix: e.Prefix}
-		if e.Ge != "" {
-			ge, err := strconv.Atoi(e.Ge)
-			if err != nil {
-				return nil, fmt.Errorf("prefix list entry %d: invalid ge %q: %w", i, e.Ge, err)
-			}
-			entry.Ge = &ge
+		ge, err := prefixLenFromAPI(e.Ge)
+		if err != nil {
+			return nil, fmt.Errorf("prefix list entry %d: invalid ge %q: %w", i, e.Ge, err)
 		}
-		if e.Le != "" {
-			le, err := strconv.Atoi(e.Le)
-			if err != nil {
-				return nil, fmt.Errorf("prefix list entry %d: invalid le %q: %w", i, e.Le, err)
-			}
-			entry.Le = &le
+		le, err := prefixLenFromAPI(e.Le)
+		if err != nil {
+			return nil, fmt.Errorf("prefix list entry %d: invalid le %q: %w", i, e.Le, err)
 		}
-		out.Entries[i] = entry
+		out.Entries[i] = NATGatewayPrefixListEntry{
+			Action: e.Action,
+			Prefix: e.Prefix,
+			Ge:     ge,
+			Le:     le,
+		}
 	}
 	return out, nil
 }

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -308,13 +308,14 @@ type NATGatewayPrefixListSummary struct {
 }
 
 // apiNATGatewayPrefixList is the wire-level representation — the API sends
-// Ge/Le as strings. See (NATGatewayPrefixList).toAPI / fromAPI for
-// conversion.
+// Ge/Le as strings. See (NATGatewayPrefixList).toAPI / toPrefixList for
+// conversion. Entries are pointers so a null element is distinguishable from
+// an empty one on decode.
 type apiNATGatewayPrefixList struct {
-	ID            int                            `json:"id,omitempty"`
-	Description   string                         `json:"description"`
-	AddressFamily string                         `json:"addressFamily"`
-	Entries       []apiNATGatewayPrefixListEntry `json:"entries"`
+	ID            int                             `json:"id,omitempty"`
+	Description   string                          `json:"description"`
+	AddressFamily string                          `json:"addressFamily"`
+	Entries       []*apiNATGatewayPrefixListEntry `json:"entries"`
 }
 
 type apiNATGatewayPrefixListEntry struct {
@@ -331,10 +332,10 @@ func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
 		ID:            p.ID,
 		Description:   p.Description,
 		AddressFamily: p.AddressFamily,
-		Entries:       make([]apiNATGatewayPrefixListEntry, len(p.Entries)),
+		Entries:       make([]*apiNATGatewayPrefixListEntry, len(p.Entries)),
 	}
 	for i, e := range p.Entries {
-		out.Entries[i] = apiNATGatewayPrefixListEntry{
+		out.Entries[i] = &apiNATGatewayPrefixListEntry{
 			Action: e.Action,
 			Prefix: e.Prefix,
 			Ge:     prefixLenToAPI(e.Ge),
@@ -344,8 +345,9 @@ func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
 	return out
 }
 
-// fromAPI converts a wire-level apiNATGatewayPrefixList into the user-facing
-// NATGatewayPrefixList. Non-numeric Ge/Le strings produce an error.
+// toPrefixList converts a wire-level apiNATGatewayPrefixList into the
+// user-facing NATGatewayPrefixList. A null entry or a non-numeric Ge/Le
+// produces an error.
 func (a *apiNATGatewayPrefixList) toPrefixList() (*NATGatewayPrefixList, error) {
 	out := &NATGatewayPrefixList{
 		ID:            a.ID,
@@ -354,6 +356,10 @@ func (a *apiNATGatewayPrefixList) toPrefixList() (*NATGatewayPrefixList, error) 
 		Entries:       make([]NATGatewayPrefixListEntry, len(a.Entries)),
 	}
 	for i, e := range a.Entries {
+		// The API declares entries non-nullable, so a null is malformed.
+		if e == nil {
+			return nil, fmt.Errorf("prefix list entry %d: null entry in response", i)
+		}
 		ge, err := prefixLenFromAPI(e.Ge)
 		if err != nil {
 			return nil, fmt.Errorf("prefix list entry %d: invalid ge %q: %w", i, e.Ge, err)

--- a/nat_gateway_types.go
+++ b/nat_gateway_types.go
@@ -290,10 +290,9 @@ type NATGatewayPrefixList struct {
 	Entries       []NATGatewayPrefixListEntry `json:"entries"`
 }
 
-// NATGatewayPrefixListEntry is a single entry in a prefix list. The SDK
-// converts Ge/Le to and from the API's string representation transparently.
-// They are pointers because 0 is a valid prefix length the API treats
-// differently from an absent value.
+// NATGatewayPrefixListEntry is a single entry in a prefix list. Ge/Le are
+// pointers because 0 is a valid prefix length, distinct from absent; the SDK
+// converts them to and from the API's strings.
 type NATGatewayPrefixListEntry struct {
 	Action string `json:"action"` // PrefixListActionPermit or PrefixListActionDeny.
 	Prefix string `json:"prefix"`
@@ -327,8 +326,7 @@ type apiNATGatewayPrefixListEntry struct {
 }
 
 // toAPI converts the user-facing NATGatewayPrefixList to its wire-level
-// representation (Ge/Le as strings). A set Ge/Le of 0 goes out as "0"; nil is
-// omitted.
+// representation (Ge/Le as strings).
 func (p *NATGatewayPrefixList) toAPI() *apiNATGatewayPrefixList {
 	out := &apiNATGatewayPrefixList{
 		ID:            p.ID,

--- a/nat_gateway_vxc_integration_test.go
+++ b/nat_gateway_vxc_integration_test.go
@@ -101,7 +101,7 @@ func (suite *NATGatewayVXCIntegrationTestSuite) TestVXCAttachedToNATGateway() {
 		Description:   "vxc-integration-private",
 		AddressFamily: AddressFamilyIPv4,
 		Entries: []NATGatewayPrefixListEntry{
-			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: 24, Le: 32},
+			{Action: PrefixListActionPermit, Prefix: "10.0.0.0/8", Ge: PtrTo(24), Le: PtrTo(32)},
 		},
 	})
 	if err != nil {

--- a/shared_types.go
+++ b/shared_types.go
@@ -2,6 +2,7 @@ package megaport
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 )
 
@@ -66,4 +67,26 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	}
 	t.Time = time.Unix(timestamp/1000, 0) // Divide by 1000 to convert from milliseconds to seconds
 	return nil
+}
+
+// prefixLenToAPI renders an optional prefix-list ge/le as the string the API
+// declares. Unset is "", which the wire types omit.
+func prefixLenToAPI(v *int) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.Itoa(*v)
+}
+
+// prefixLenFromAPI parses an optional prefix-list ge/le. An absent value is
+// nil, distinct from a deliberate 0.
+func prefixLenFromAPI(s string) (*int, error) {
+	if s == "" {
+		return nil, nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
 }


### PR DESCRIPTION
The SDK marshals `ge`/`le` with the wrong type on MCR prefix filter list create and modify. `MCRPrefixFilterList` goes straight on the wire, and its entries hold `Ge int` / `Le int` with `omitempty`, so values go out as JSON numbers where the API declares strings, and a prefix length of 0 produces no key at all. NAT gateway prefix lists get the string conversion right but drop the zero with an explicit `if e.Ge > 0`.

megalith does not default an absent `ge`: it forwards the field verbatim into netauto under `NON_NULL`. Absent and `"0"` are genuinely different requests downstream, so dropping a deliberate 0 is a behavior bug, not only a contract mismatch.

- Add `MCRPrefixFilterList.toAPI()`, mirroring the existing inbound converter, and call it from `CreatePrefixFilterList` and `ModifyMCRPrefixFilterList`.
- `MCRPrefixListEntry.Ge`/`.Le` and `NATGatewayPrefixListEntry.Ge`/`.Le` become `*int` so unset is distinguishable from a deliberate 0. **Breaking** for both consumers.
- NAT's `toAPI` emits `"0"` for a set zero instead of dropping it.
- Both directions share two helpers (`prefixLenToAPI` / `prefixLenFromAPI`) rather than repeating the same rule in four places.
- Decoding errors on a `ge`/`le` that is not a number and on a `null` entry, naming the index. Previously a bad value zeroed the field and a `null` entry panicked.
- `toAPI` refuses to send a `null` entry, so the SDK cannot write a list its own read path then rejects. megalith validates the entries list but not its elements, so a `null` faults it rather than earning a 400.
- Tests now assert the marshaled request body. The old create test stubbed a response and never looked at what it sent.

## Migrating a consumer

Wrapping the existing `int` fields in `PtrTo(...)` is **not** a safe migration. Both consumers encode "unset" as `0`, and on the provider side that is documented behavior, not an accident.

- `terraform-provider-megaport`'s NAT prefix list schema declares `ge`/`le` as `Optional + Computed` with `Default: int64default.StaticInt64(0)`, described to users as "Omit or set to 0 to match the prefix's own length". The SDK's `if e.Ge > 0` was that sentinel's only implementation. With it gone, every entry the user left unbounded sends a real `le: "0"` instead of nothing, which is a different request.
- "Map unset to `nil`" is not reachable from that schema as written: an attribute with a static default never reports `IsNull()`, and returning a null on read where the plan holds 0 fails the apply with "Provider produced inconsistent result after apply". A correct migration has to drop the defaults as well, which is a second breaking change for provider users.
- `megaport-cli` (`mcr_inputs.go`) flattens its own pointer to a `0` default, and the provider's `mcr_prefix_filter_list_utils.go` tests `if entry.Ge == 0 || entry.Le == 0`.

Those updates land in their own tickets. Treat the provider one as a gate on bumping the SDK there, not a follow-up.

## What I could not verify

- Integration tests were not run. They need staging credentials and create real MCRs.
- Two integration-test expectations changed from `Ge: 0` to `Ge: nil`. The API looks like it omits `ge` from the response when it equals the prefix length: the pre-existing test sends `Ge: 24` on a `/24` and expected `0` back. Under the old `int` type, `0` meant "absent or zero", so the expectation was ambiguous. Two risks here, both needing a credentialed run: now that a correctly typed `"24"` goes out, the API may start echoing `ge` back and these assertions would fail; and if the API ever returns `"ge": "0"`, `nil` is the wrong expectation.
- Nothing enforces `ge`/`le` anywhere in the declared contract: the spec types them as plain `string` with no pattern or bounds (its description names 0 to 32 and 0 to 128, but nothing checks it), and megalith holds them as opaque nullable strings. So a negative value is more likely forwarded to netauto than rejected, and `ge > le` has never been checked. Range validation is deliberately out of scope here.
- What `ge`/`le` of 0 actually does. The spec's description puts 0 inside the valid range and says nothing about its meaning, megalith forwards the string untouched, and netauto declares a bare `int32`. This is the highest-consequence unknown and the reason the provider migration is a gate: a consumer that migrates a stray `0` sends a `deny` nobody has characterized.
- `PrefixListRequest` declares no `id` property, but the SDK sends `"id": 0` on create and the body's own id on modify (which can disagree with the path). Pre-existing and left alone per the ticket's scope; the spec sets no `additionalProperties: false` and megalith ignores unknown properties, so it is harmless today. Worth its own ticket.

